### PR TITLE
fix: increase idle timeout from 30s to 120s

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -262,7 +262,7 @@ export function streamKiro(
         let textBlockIndex: number | null = null;
         const toolCalls: KiroToolCallState[] = [];
         let currentToolCall: KiroToolCallState | null = null;
-        const IDLE_TIMEOUT = 30_000;
+        const IDLE_TIMEOUT = 120_000;
         let idleTimer: ReturnType<typeof setTimeout> | null = null;
         const resetIdle = () => {
           if (idleTimer) clearTimeout(idleTimer);


### PR DESCRIPTION
The 30s IDLE_TIMEOUT was too aggressive for responses containing large tool call inputs (e.g. write() with substantial file content). The API streams these inputs slowly and the idle timer would fire mid-stream, causing 'idle timeout after max retries' errors.

120s gives the API enough headroom for large tool call payloads while still catching genuinely stalled connections.