### PR TITLE
fix(stream): prevent agent loop stall on empty/malformed tool calls

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -423,6 +423,7 @@ export function streamKiro(
             content: (output.content[textBlockIndex] as TextContent).text,
             partial: output,
           });
+        let emittedToolCalls = 0;
         for (const tc of toolCalls) {
           if (!tc.input.trim()) {
             console.warn(
@@ -445,6 +446,7 @@ export function streamKiro(
           stream.push({ type: "toolcall_start", contentIndex: idx, partial: output });
           stream.push({ type: "toolcall_delta", contentIndex: idx, delta: tc.input, partial: output });
           stream.push({ type: "toolcall_end", contentIndex: idx, toolCall, partial: output });
+          emittedToolCalls++;
         }
         // Prefer usage event values when available, fall back to tiktoken
         if (usageEvent) {
@@ -460,10 +462,40 @@ export function streamKiro(
           // Model might not have cost info, use zeros
           output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
         }
-        if (!receivedContextUsage && toolCalls.length === 0) {
+        // Detect degenerate responses: the API returned 200 but produced no
+        // usable content at all — no text and no tool calls (not even broken
+        // ones). This happens when the stream is truncated early or the API
+        // returns only a contextUsage event. Retry with backoff.
+        //
+        // When tool calls *were* present but all got dropped (empty/unparseable
+        // input), don't retry — the API did respond, it just sent malformed
+        // tool calls. Retrying would likely produce the same result. The
+        // stopReason fix below prevents the agent loop stall.
+        const hasText = textBlockIndex !== null && (output.content[textBlockIndex] as TextContent).text.length > 0;
+        if (!hasText && toolCalls.length === 0) {
+          if (retryCount < maxRetries) {
+            retryCount++;
+            const delayMs = Math.min(1000 * 2 ** (retryCount - 1), MAX_RETRY_DELAY);
+            console.warn(
+              `[pi-provider-kiro] Empty response (no text, no tool calls) — retrying (${retryCount}/${maxRetries})`,
+            );
+            // Reset output content for the retry
+            output.content = [];
+            await abortableDelay(delayMs, options?.signal);
+            continue;
+          }
+          console.warn(
+            `[pi-provider-kiro] Empty response after ${maxRetries} retries — returning stopReason:"stop" to avoid agent loop stall`,
+          );
+        }
+        // Use emittedToolCalls (not toolCalls.length) to avoid stopReason:"toolUse"
+        // when all tool calls were skipped due to empty/unparseable input — that
+        // combination (empty content + toolUse stop) causes pi's agent loop to
+        // stall waiting for tool results that will never arrive.
+        if (!receivedContextUsage && emittedToolCalls === 0) {
           output.stopReason = "length";
         } else {
-          output.stopReason = toolCalls.length > 0 ? "toolUse" : "stop";
+          output.stopReason = emittedToolCalls > 0 ? "toolUse" : "stop";
         }
         stream.push({ type: "done", reason: output.stopReason as "stop" | "toolUse", message: output });
         stream.end();

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1380,6 +1380,140 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  // =========================================================================
+  // Empty response / ghost tool call recovery (stopReason stall fix)
+  // =========================================================================
+
+  it("does not set stopReason to toolUse when all tool calls have empty input", async () => {
+    // Reproduces the bug: API returns a tool call with empty input + contextUsage.
+    // Before the fix, stopReason was "toolUse" with empty content → agent loop stall.
+    const toolPayload = '{"name":"bash","toolUseId":"tc1","input":"","stop":true}';
+    const mockFetch = mockFetchOk(`${toolPayload}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    // No retry — tool calls were present (just malformed), so only 1 fetch call
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    // Must NOT be "toolUse" — that would stall the agent loop
+    expect(done?.type === "done" && done.reason).not.toBe("toolUse");
+    expect(done?.type === "done" && done.message.content.filter((b) => b.type === "toolCall")).toHaveLength(0);
+
+    warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not set stopReason to toolUse when all tool calls have unparseable input", async () => {
+    const toolPayload = '{"name":"bash","toolUseId":"tc1","input":"not-json","stop":true}';
+    const mockFetch = mockFetchOk(`${toolPayload}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    expect(done?.type === "done" && done.reason).not.toBe("toolUse");
+
+    warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("retries on completely empty response (no text, no tool calls)", async () => {
+    // Simulates the degenerate API response: only contextUsage, no content or tools.
+    // Should retry up to maxRetries, then return without stalling.
+    const emptyResponse = '{"contextUsagePercentage":50}';
+    const goodResponse = '{"content":"recovered"}{"contextUsagePercentage":10}';
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(emptyResponse) })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+          }),
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(goodResponse) })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+          }),
+        },
+      });
+    vi.stubGlobal("fetch", mockFetch);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    // Should have retried: 2 fetch calls
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    expect(done?.type === "done" && done.message.stopReason).toBe("stop");
+    expect(
+      done?.type === "done" &&
+        done.message.content.some((b) => b.type === "text" && (b as TextContent).text === "recovered"),
+    ).toBe(true);
+
+    warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns stop (not toolUse) after max retries on persistent empty responses", async () => {
+    const emptyResponse = '{"contextUsagePercentage":50}';
+
+    // All 4 attempts return empty — need a fresh reader for each call
+    const makeEmptyResponse = () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(emptyResponse) })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+        }),
+      },
+    });
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeEmptyResponse())
+      .mockResolvedValueOnce(makeEmptyResponse())
+      .mockResolvedValueOnce(makeEmptyResponse())
+      .mockResolvedValueOnce(makeEmptyResponse());
+    vi.stubGlobal("fetch", mockFetch);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    // 1 initial + 3 retries = 4 calls
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    // Must be "stop", not "toolUse" — toolUse with empty content stalls the agent
+    expect(done?.type === "done" && done.reason).toBe("stop");
+    expect(done?.type === "done" && done.message.content).toHaveLength(0);
+
+    warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  }, 30000);
+
   it("keeps non-consecutive duplicate content events", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"A"}',


### PR DESCRIPTION
## Problem

When the Kiro API returns tool calls with empty or unparseable input, pi's agent loop stalls indefinitely — the UI stops spinning and the session becomes unresponsive. The user has to manually interrupt with a message like "status?" to recover.

This was observed in a real session where the API returned degenerate responses (empty content, zero tokens) with `stopReason: toolUse` twice during a long research task (~54K and ~67K input tokens).

## Root Cause

The tool call emission loop in `stream.ts` has two guards that skip broken tool calls:
- Empty input: `if (!tc.input.trim()) { continue; }`
- Unparseable JSON: `catch (e) { ... continue; }`

But the `stopReason` logic checked `toolCalls.length > 0` — the raw array, not what actually made it into `output.content`. So you'd end up with:
- `output.content = []` (nothing emitted)
- `output.stopReason = "toolUse"` (raw array had entries)

Pi's agent loop sees `toolUse` and waits for tool results that will never arrive.

## Fix

1. **stopReason fix**: Track `emittedToolCalls` (tool calls that actually made it into `output.content`) and use that instead of `toolCalls.length` for the `stopReason` decision.

2. **Empty response retry**: When the API returns a truly empty response (no text, no tool calls at all), retry with exponential backoff up to 3 times. After max retries, return `stopReason: "stop"` to avoid stalling.

## Tests

4 new tests covering:
- `stopReason` is not `toolUse` when all tool calls have empty input
- `stopReason` is not `toolUse` when all tool calls have unparseable input
- Empty responses trigger retry and recover on success
- Persistent empty responses exhaust retries and return `stop` (not `toolUse`)

All 242 existing tests continue to pass.