### PR TITLE
fix: pass images from tool results to Kiro API

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -160,6 +160,7 @@ export function streamKiro(
         const firstMsg = currentMessages[0];
         let currentContent = "";
         const currentToolResults: KiroToolResult[] = [];
+        let currentImages: KiroImage[] | undefined;
         if (firstMsg?.role === "assistant") {
           const am = firstMsg as AssistantMessage;
           let armContent = "";
@@ -191,24 +192,42 @@ export function streamKiro(
               },
             });
           }
+          const toolResultImages: ImageContent[] = [];
           for (let i = 1; i < currentMessages.length; i++) {
             const m = currentMessages[i];
-            if (m.role === "toolResult")
+            if (m.role === "toolResult") {
+              const trm = m as ToolResultMessage;
               currentToolResults.push({
                 content: [{ text: truncate(getContentText(m), toolResultLimit) }],
-                status: (m as ToolResultMessage).isError ? "error" : "success",
-                toolUseId: (m as ToolResultMessage).toolCallId,
+                status: trm.isError ? "error" : "success",
+                toolUseId: trm.toolCallId,
               });
+              if (Array.isArray(trm.content))
+                for (const c of trm.content) if (c.type === "image") toolResultImages.push(c as ImageContent);
+            }
+          }
+          if (toolResultImages.length > 0) {
+            const converted = convertImagesToKiro(toolResultImages);
+            currentImages = currentImages ? [...currentImages, ...converted] : converted;
           }
           currentContent = currentToolResults.length > 0 ? "Tool results provided." : "Continue";
         } else if (firstMsg?.role === "toolResult") {
+          const toolResultImages2: ImageContent[] = [];
           for (const m of currentMessages)
-            if (m.role === "toolResult")
+            if (m.role === "toolResult") {
+              const trm = m as ToolResultMessage;
               currentToolResults.push({
                 content: [{ text: truncate(getContentText(m), toolResultLimit) }],
-                status: (m as ToolResultMessage).isError ? "error" : "success",
-                toolUseId: (m as ToolResultMessage).toolCallId,
+                status: trm.isError ? "error" : "success",
+                toolUseId: trm.toolCallId,
               });
+              if (Array.isArray(trm.content))
+                for (const c of trm.content) if (c.type === "image") toolResultImages2.push(c as ImageContent);
+            }
+          if (toolResultImages2.length > 0) {
+            const converted = convertImagesToKiro(toolResultImages2);
+            currentImages = currentImages ? [...currentImages, ...converted] : converted;
+          }
           currentContent = "Tool results provided.";
         } else if (firstMsg?.role === "user") {
           currentContent = typeof firstMsg.content === "string" ? firstMsg.content : getContentText(firstMsg);
@@ -229,7 +248,6 @@ export function streamKiro(
             uimc.tools = kt;
           }
         }
-        let currentImages: KiroImage[] | undefined;
         if (firstMsg?.role === "user") {
           const imgs = extractImages(firstMsg);
           if (imgs.length > 0) currentImages = convertImagesToKiro(imgs as ImageContent[]);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -158,13 +158,17 @@ export function buildHistory(
         assistantResponseMessage: { content: armContent, ...(armToolUses.length > 0 ? { toolUses: armToolUses } : {}) },
       });
     } else if (msg.role === "toolResult") {
+      const trMsg = msg as ToolResultMessage;
       const toolResults: KiroToolResult[] = [
         {
           content: [{ text: truncate(getContentText(msg), toolResultLimit) }],
-          status: (msg as ToolResultMessage).isError ? "error" : "success",
-          toolUseId: (msg as ToolResultMessage).toolCallId,
+          status: trMsg.isError ? "error" : "success",
+          toolUseId: trMsg.toolCallId,
         },
       ];
+      const trImages: ImageContent[] = [];
+      if (Array.isArray(trMsg.content))
+        for (const c of trMsg.content) if (c.type === "image") trImages.push(c as ImageContent);
       let j = i + 1;
       while (j < historyMessages.length && historyMessages[j].role === "toolResult") {
         const next = historyMessages[j] as ToolResultMessage;
@@ -173,6 +177,8 @@ export function buildHistory(
           status: next.isError ? "error" : "success",
           toolUseId: next.toolCallId,
         });
+        if (Array.isArray(next.content))
+          for (const c of next.content) if (c.type === "image") trImages.push(c as ImageContent);
         j++;
       }
       i = j - 1;
@@ -183,6 +189,7 @@ export function buildHistory(
           content: "Tool results provided.",
           modelId,
           origin: "AI_EDITOR",
+          ...(trImages.length > 0 ? { images: convertImagesToKiro(trImages) } : {}),
           userInputMessageContext: { toolResults },
         },
       });


### PR DESCRIPTION
## Problem

When pi's `read` tool reads an image file, it returns a `ToolResultMessage` with `ImageContent` in its `content` array. However, `pi-provider-kiro` silently drops these images during message transformation:

1. `extractImages()` explicitly returns `[]` for `toolResult` messages
2. `getContentText()` maps image content to empty strings
3. The toolResult-to-`KiroUserInputMessage` conversion only includes `text`, never `images`

As a result, the model never sees the actual image data — only the text metadata like `"Read image file [image/jpeg]..."`.

## Fix

Collect `ImageContent` from `ToolResultMessage.content` in three places and attach them to `userInputMessage.images` (which the Kiro API already supports):

- `buildHistory()` in `transform.ts` — history toolResult branch
- `stream.ts` — assistant + toolResult branch (current message)
- `stream.ts` — pure toolResult branch (current message)

## Testing

All 242 existing tests pass. Type check clean.
