### PR TITLE
fix: sanitizeSurrogates should only remove unpaired surrogates

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -47,7 +47,10 @@ export interface KiroHistoryEntry {
 export const TOOL_RESULT_LIMIT = 250000;
 
 export function sanitizeSurrogates(text: string): string {
-  return text.replace(/[\uD800-\uDFFF]/g, "\uFFFD");
+  // Replace unpaired high surrogates (0xD800-0xDBFF not followed by low surrogate)
+  // Replace unpaired low surrogates (0xDC00-0xDFFF not preceded by high surrogate)
+  // Properly paired surrogates (e.g. emoji like 🙈) are preserved.
+  return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
 }
 
 export function truncate(text: string, limit: number): string {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -44,8 +44,14 @@ const toolResult = (id: string, text: string, isError = false): ToolResultMessag
 
 describe("Feature 5: Message Transformation", () => {
   describe("sanitizeSurrogates", () => {
-    it("replaces lone surrogates", () => {
-      expect(sanitizeSurrogates("a\uD800b")).toBe("a\uFFFDb");
+    it("removes unpaired high surrogate", () => {
+      expect(sanitizeSurrogates("a\uD800b")).toBe("ab");
+    });
+    it("removes unpaired low surrogate", () => {
+      expect(sanitizeSurrogates("a\uDC00b")).toBe("ab");
+    });
+    it("preserves properly paired surrogates (emoji)", () => {
+      expect(sanitizeSurrogates("Hello 🙈 World")).toBe("Hello 🙈 World");
     });
     it("leaves normal text unchanged", () => {
       expect(sanitizeSurrogates("hello")).toBe("hello");


### PR DESCRIPTION
## Problem

The current `sanitizeSurrogates` in `src/transform.ts` uses `/[\uD800-\uDFFF]/g` which matches **all** surrogate characters, including properly paired ones. This means valid emoji like 🙈 (`\uD83D\uDE48`) get destroyed — both halves of the surrogate pair are replaced with `\uFFFD`, producing `\uFFFD\uFFFD`.

## Fix

Use lookahead/lookbehind to only target **unpaired** surrogates, matching the implementation in pi-mono (`packages/ai/src/utils/sanitize-unicode.ts`):

```ts
/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g
```

Also changed from replacing with `\uFFFD` to removing (empty string) for cleaner output.

## Tests

- Updated existing test to expect removal instead of replacement
- Added tests for unpaired low surrogate and properly paired emoji preservation
- All 244 tests pass