### PR TITLE
fix: map us-east-2 SSO region to us-east-1 API region

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -40,6 +40,7 @@ export function resolveKiroModel(modelId: string): string {
  * internally via the AWS SDK partition resolver.
  */
 const API_REGION_MAP: Record<string, string> = {
+  "us-east-2": "us-east-1",
   "eu-west-1": "eu-central-1",
   "eu-west-2": "eu-central-1",
   "eu-west-3": "eu-central-1",

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { filterModelsByRegion, KIRO_MODEL_IDS, kiroModels, resolveKiroModel } from "../src/models.js";
+import { filterModelsByRegion, KIRO_MODEL_IDS, kiroModels, resolveApiRegion, resolveKiroModel } from "../src/models.js";
 
 describe("Feature 2: Model Definitions", () => {
   describe("resolveKiroModel", () => {
@@ -35,6 +35,24 @@ describe("Feature 2: Model Definitions", () => {
   describe("KIRO_MODEL_IDS", () => {
     it("contains 17 model IDs", () => {
       expect(KIRO_MODEL_IDS.size).toBe(17);
+    });
+  });
+
+  describe("resolveApiRegion", () => {
+    it("maps us-east-2 to us-east-1", () => {
+      expect(resolveApiRegion("us-east-2")).toBe("us-east-1");
+    });
+
+    it("maps eu-west-1 to eu-central-1", () => {
+      expect(resolveApiRegion("eu-west-1")).toBe("eu-central-1");
+    });
+
+    it("passes through us-east-1 unchanged", () => {
+      expect(resolveApiRegion("us-east-1")).toBe("us-east-1");
+    });
+
+    it("defaults to us-east-1 when undefined", () => {
+      expect(resolveApiRegion(undefined)).toBe("us-east-1");
     });
   });
 


### PR DESCRIPTION
## Root Cause

Region mismatch between the user's Kiro OAuth credentials and the provider's region resolution.

- User authenticated via `kiro-cli`, which issued credentials for **`us-east-2`** (the SSO/OIDC region stored in `~/.pi/agent/auth.json`)
- `API_REGION_MAP` only mapped EU SSO regions to their API counterparts — US regions outside `us-east-1` were not mapped
- `resolveApiRegion("us-east-2")` passed through as-is, and `filterModelsByRegion()` returned an **empty array** (no `us-east-2` entry in `MODELS_BY_REGION`)
- With zero models, pi treated the provider as having no valid configuration, surfacing the generic `"No model selected"` error

## Fix

Added `"us-east-2": "us-east-1"` to `API_REGION_MAP` in `src/models.ts`, consistent with how EU SSO regions already map to `eu-central-1`. This ensures `resolveApiRegion()` routes `us-east-2` credentials to the `us-east-1` API endpoint, where all models are available.

## Tests

Added 4 test cases for `resolveApiRegion` in `test/models.test.ts`:

- maps us-east-2 to us-east-1
- maps eu-west-1 to eu-central-1
- passes through us-east-1 unchanged
- defaults to us-east-1 when undefined

All 249 tests pass (14 test files).