### PR TITLE
Use pi sessionId for kiro conversationId

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -145,6 +145,7 @@ export function streamKiro(
       }
       let retryCount = 0;
       const maxRetries = 3;
+      const conversationId = options?.sessionId ?? crypto.randomUUID();
       while (retryCount <= maxRetries) {
         if (options?.signal?.aborted) throw options.signal.reason;
         const effectiveSystemPrompt = systemPrompt;
@@ -257,7 +258,7 @@ export function streamKiro(
         const request: KiroRequest = {
           conversationState: {
             chatTriggerType: "MANUAL",
-            conversationId: crypto.randomUUID(),
+            conversationId,
             currentMessage: {
               userInputMessage: {
                 content: sanitizeSurrogates(currentContent),

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1779,4 +1779,22 @@ describe("Feature 9: Streaming Integration", () => {
 
     vi.unstubAllGlobals();
   });
+
+  // =========================================================================
+  // conversationId uses sessionId when provided
+  // =========================================================================
+
+  it("uses options.sessionId as conversationId when provided", async () => {
+    const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":5}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const sessionId = "stable-session-id-1234";
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok", sessionId });
+    await collect(stream);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.conversationState.conversationId).toBe(sessionId);
+
+    vi.unstubAllGlobals();
+  });
 });


### PR DESCRIPTION

## What?
- use pi's sessionId for KiroRequest.conversationId

## Why?
Some org's track kiro usage conversation count stats. Using pi's sessionId for each request makes those stats more in line with what's expected.