### PR TITLE
Fix: sanitizeHistory strips leading invalid entries instead of returning []

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-kiro",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.21"

--- a/src/history.ts
+++ b/src/history.ts
@@ -15,6 +15,9 @@ export function stripHistoryImages(history: KiroHistoryEntry[]): KiroHistoryEntr
 }
 
 export function sanitizeHistory(history: KiroHistoryEntry[]): KiroHistoryEntry[] {
+  // Strip leading entries that would make the history invalid
+  while (history.length > 0 && (!history[0]?.userInputMessage || history[0].userInputMessage.userInputMessageContext?.toolResults))
+    history = history.slice(1);
   const result: KiroHistoryEntry[] = [];
   for (let i = 0; i < history.length; i++) {
     const m = history[i];
@@ -32,10 +35,7 @@ export function sanitizeHistory(history: KiroHistoryEntry[]): KiroHistoryEntry[]
       result.push(m);
     }
   }
-  if (result.length > 0) {
-    const first = result[0];
-    if (!first?.userInputMessage || first.userInputMessage.userInputMessageContext?.toolResults) return [];
-  }
+  // Leading invalid entries already stripped above
   return result;
 }
 

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -58,6 +58,33 @@ describe("Feature 6: History Management", () => {
       expect(sanitizeHistory(h)).toHaveLength(0);
     });
 
+    it("strips leading toolResults entry and keeps subsequent valid entries (truncation bug)", () => {
+      // Reproduces the 25% context wipe bug: after truncation the first entry is a
+      // toolResults user message; the old code returned [] nuking all remaining history.
+      const h = [
+        userEntry("tool results", [{ toolUseId: "tc1", content: [{ text: "done" }], status: "success" }]),
+        userEntry("what time is it?"),
+        assistantEntry("It is noon."),
+      ];
+      const r = sanitizeHistory(h);
+      expect(r.length).toBeGreaterThan(0);
+      expect(r[0].userInputMessage).toBeDefined();
+      expect(r[0].userInputMessage?.userInputMessageContext?.toolResults).toBeUndefined();
+    });
+
+    it("strips leading assistant entry and keeps subsequent valid entries", () => {
+      // After truncation the first surviving entry may be an assistant message when
+      // the paired user message was shifted out.
+      const h = [
+        assistantEntry("stale assistant"),
+        userEntry("new user message"),
+        assistantEntry("response"),
+      ];
+      const r = sanitizeHistory(h);
+      expect(r.length).toBeGreaterThan(0);
+      expect(r[0].userInputMessage).toBeDefined();
+    });
+
     it("ensures first entry is a userInputMessage", () => {
       const h = [assistantEntry("stale"), userEntry("hi")];
       const r = sanitizeHistory(h);


### PR DESCRIPTION
Fixes #24.

`sanitizeHistory()` returned `[]` when the first post-loop entry was an assistant message or a `userInputMessage` with `toolResults`. In agent-heavy sessions, `truncateHistory()` shifting past a user→assistant pair could expose a `toolResults` entry at the front of the truncated history. The loop correctly skipped it, but left an `assistantResponseMessage` as `result[0]`, tripping the end-guard and wiping all remaining history (observed: ~25% context → 0.6%).

## Fix

Replace the end-guard `return []` with a pre-pass `while` loop that strips leading entries that are not a plain `userInputMessage` before the main loop runs.

## Tests

Two new test cases added; all 261 tests pass.