### PR TITLE
feat: read Kiro IDE token as auth fallback when kiro-cli is unavailable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalise line endings to LF in the repository and working copy.
+# This prevents CRLF noise on Windows checkouts and keeps Biome happy.
+* text=auto eol=lf
+*.ts  text eol=lf
+*.js  text eol=lf
+*.json text eol=lf
+*.md  text eol=lf

--- a/src/kiro-ide.ts
+++ b/src/kiro-ide.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Reads credentials written by the Kiro IDE.
+// ABOUTME: The IDE stores its auth token at ~/.aws/sso/cache/kiro-auth-token.json
+// ABOUTME: on all platforms (Windows, macOS, Linux) after every successful login,
+// ABOUTME: including IAM Identity Center (authMethod: "IdC") and Builder ID.
+// ABOUTME: A companion file, ~/.aws/sso/cache/{clientIdHash}.json, holds the
+// ABOUTME: OIDC clientId/clientSecret needed to silently refresh the access token
+// ABOUTME: via the standard AWS OIDC /token endpoint — no extra login flow needed.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { KiroCredentials } from "./oauth.js";
+
+// ~/.aws/sso/cache is the standard AWS SSO cache directory on all platforms.
+// Node's os.homedir() returns the correct home directory on Windows, macOS and Linux.
+const SSO_CACHE_DIR = join(homedir(), ".aws", "sso", "cache");
+const KIRO_IDE_TOKEN_PATH = join(SSO_CACHE_DIR, "kiro-auth-token.json");
+
+interface KiroIdeTokenFile {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  region?: string;
+  clientIdHash?: string;
+  authMethod?: string;
+  provider?: string;
+}
+
+interface KiroIdeClientFile {
+  clientId: string;
+  clientSecret: string;
+  expiresAt?: string;
+}
+
+function readKiroIdeToken(allowExpired: boolean): KiroCredentials | undefined {
+  try {
+    if (!existsSync(KIRO_IDE_TOKEN_PATH)) return undefined;
+
+    const tokenData = JSON.parse(readFileSync(KIRO_IDE_TOKEN_PATH, "utf-8")) as KiroIdeTokenFile;
+    if (!tokenData.accessToken || !tokenData.refreshToken) return undefined;
+
+    const expiresAt = new Date(tokenData.expiresAt).getTime();
+    if (!allowExpired && Date.now() >= expiresAt - 2 * 60 * 1000) return undefined;
+
+    const region = tokenData.region ?? "us-east-1";
+
+    // Load the OIDC client registration so refreshKiroTokenDirect can call the
+    // AWS OIDC /token endpoint with a refresh_token grant without prompting the user.
+    let clientId = "";
+    let clientSecret = "";
+    if (tokenData.clientIdHash) {
+      const regPath = join(SSO_CACHE_DIR, `${tokenData.clientIdHash}.json`);
+      if (existsSync(regPath)) {
+        try {
+          const reg = JSON.parse(readFileSync(regPath, "utf-8")) as KiroIdeClientFile;
+          clientId = reg.clientId ?? "";
+          clientSecret = reg.clientSecret ?? "";
+        } catch {
+          // Ignore — we can still use the token without a refresh client
+        }
+      }
+    }
+
+    return {
+      // Pack into the same pipe-delimited format used by the rest of the refresh chain
+      refresh: `${tokenData.refreshToken}|${clientId}|${clientSecret}|idc`,
+      access: tokenData.accessToken,
+      // Subtract 2-min buffer so we refresh before the actual AWS expiry
+      expires: expiresAt - 2 * 60 * 1000,
+      clientId,
+      clientSecret,
+      region,
+      authMethod: "idc",
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns valid (non-expired) Kiro IDE credentials read from
+ * ~/.aws/sso/cache/kiro-auth-token.json, or undefined if the IDE has not
+ * logged in or the token has already expired.
+ */
+export function getKiroIdeCredentials(): KiroCredentials | undefined {
+  return readKiroIdeToken(false);
+}
+
+/**
+ * Like getKiroIdeCredentials but also returns expired tokens so the caller can
+ * attempt a silent OIDC refresh before falling back to the full login flow.
+ */
+export function getKiroIdeCredentialsAllowExpired(): KiroCredentials | undefined {
+  return readKiroIdeToken(true);
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,6 +14,7 @@ export const KIRO_MODEL_IDS = new Set([
   "deepseek-3.2",
   "kimi-k2.5",
   "minimax-m2.1",
+  "minimax-m2.5",
   "glm-4.7",
   "glm-4.7-flash",
   "qwen3-coder-next",
@@ -77,6 +78,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
     "deepseek-3-2",
     "kimi-k2-5",
     "minimax-m2-1",
+    "minimax-m2-5",
     "glm-4-7",
     "glm-4-7-flash",
     "qwen3-coder-next",
@@ -94,6 +96,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
     "claude-sonnet-4",
     "claude-haiku-4-5",
     "minimax-m2-1",
+    "minimax-m2-5",
     "qwen3-coder-next",
   ]),
 };
@@ -256,6 +259,18 @@ export const kiroModels = [
     maxTokens: 8192,
   },
   // MiniMax
+  {
+    id: "minimax-m2-5",
+    name: "MiniMax M2.5",
+    api: "kiro-api" as const,
+    provider: "kiro" as const,
+    baseUrl: BASE_URL,
+    reasoning: false,
+    input: ["text"] as ("text" | "image")[],
+    cost: ZERO_COST,
+    contextWindow: 200000,
+    maxTokens: 8192,
+  },
   {
     id: "minimax-m2-1",
     name: "MiniMax M2.1",

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -10,6 +10,7 @@
 
 import { execFileSync } from "node:child_process";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
+import { getKiroIdeCredentials, getKiroIdeCredentialsAllowExpired } from "./kiro-ide.js";
 
 export const SSO_OIDC_ENDPOINT = "https://oidc.us-east-1.amazonaws.com";
 export const BUILDER_ID_START_URL = "https://view.awsapps.com/start";
@@ -51,8 +52,18 @@ export async function loginKiro(
     return loginViaKiroCli(callbacks, preferredMethod);
   }
 
-  // For "auto" or "builder-id", check for existing kiro-cli credentials
-  // Prefer social token if available (user explicitly logged in that way)
+  // 1. Kiro IDE token (~/.aws/sso/cache/kiro-auth-token.json)
+  //    Checked first because the IDE keeps it continuously fresh and it already
+  //    covers IAM Identity Center logins — no extra prompts needed.
+  const ideCreds = getKiroIdeCredentials();
+  if (ideCreds && (preferredMethod === "auto" || preferredMethod === "builder-id")) {
+    (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
+      "Using existing Kiro IDE credentials",
+    );
+    return ideCreds;
+  }
+
+  // 2. kiro-cli DB credentials (social / Builder ID / IdC)
   let cliCreds = getKiroCliSocialToken();
   if (!cliCreds) {
     cliCreds = getKiroCliCredentials();
@@ -67,7 +78,20 @@ export async function loginKiro(
     return cliCreds;
   }
 
-  // Credentials expired but refresh token may still be valid — try refreshing
+  // 3. Expired IDE token — attempt a silent AWS OIDC refresh
+  const expiredIdeCreds = getKiroIdeCredentialsAllowExpired();
+  if (expiredIdeCreds) {
+    try {
+      (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
+        "Refreshing Kiro IDE credentials...",
+      );
+      return await refreshKiroTokenDirect(expiredIdeCreds);
+    } catch {
+      // Fall through to kiro-cli refresh
+    }
+  }
+
+  // 4. Expired kiro-cli credentials — attempt a silent refresh
   const expiredCreds = getKiroCliCredentialsAllowExpired();
   if (expiredCreds) {
     try {
@@ -213,6 +237,10 @@ const EXPIRES_BUFFER_MS = 5 * 60 * 1000;
 export async function refreshKiroToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
   const { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, saveKiroCliCredentials, getKiroCliSocialToken } =
     await import("./kiro-cli.js");
+
+  // Layer 0: Kiro IDE token — freshest source, covers IAM Identity Center
+  const ideCreds = getKiroIdeCredentials();
+  if (ideCreds) return ideCreds;
 
   // Layer 1: Pre-refresh check — prefer social token if available (user logged in that way)
   // Otherwise check for any valid kiro-cli token

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -33,8 +33,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("KIRO_MODEL_IDS", () => {
-    it("contains 17 model IDs", () => {
-      expect(KIRO_MODEL_IDS.size).toBe(17);
+    it("contains 18 model IDs", () => {
+      expect(KIRO_MODEL_IDS.size).toBe(18);
     });
   });
 
@@ -75,8 +75,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("model catalog", () => {
-    it("defines 17 models", () => {
-      expect(kiroModels).toHaveLength(17);
+    it("defines 18 models", () => {
+      expect(kiroModels).toHaveLength(18);
     });
 
     it("claude-haiku-4-5 has reasoning=false", () => {


### PR DESCRIPTION
kiro-cli is not available on Windows, leaving users with no silent auth path — they must run the full device code flow every time. This is problematic for users using AWS Identity Center that don't see any option in the current implementation, but they can use the IDE for it as that works also on windows.

The Kiro IDE already writes a valid token to:
  ~/.aws/sso/cache/kiro-auth-token.json

after every successful login, including IAM Identity Center (authMethod: 'IdC').  A companion file {clientIdHash}.json in the same directory holds the OIDC clientId/clientSecret needed to silently refresh the access token via the standard AWS OIDC /token endpoint.

This commit adds src/kiro-ide.ts which reads those two files and exposes:
  - getKiroIdeCredentials()             — valid token or undefined
  - getKiroIdeCredentialsAllowExpired() — expired token for silent refresh

oauth.ts is updated to check the IDE token first in both loginKiro() and refreshKiroToken(), before falling through to kiro-cli and the device code flow.  The existing kiro-cli layers are untouched.

Lookup order in loginKiro():
  1. Kiro IDE token (valid)         — silent, covers IAM Identity Center
  2. kiro-cli DB token (valid)      — silent
  3. Kiro IDE token (expired)       — silent OIDC refresh
  4. kiro-cli DB token (expired)    — silent OIDC refresh
  5. Device code flow               — interactive fallback

Also adds .gitattributes to enforce LF line endings across the repo and prevent CRLF noise on Windows checkouts.