### PR TITLE
fix: match kiro-cli request params for proper API attribution

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -59,11 +59,13 @@ function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
 interface KiroRequest {
   conversationState: {
     chatTriggerType: "MANUAL";
+    agentTaskType: "vibe";
     conversationId: string;
     currentMessage: { userInputMessage: KiroUserInputMessage };
     history?: KiroHistoryEntry[];
   };
   profileArn?: string;
+  agentMode?: string;
 }
 interface KiroToolCallState {
   toolUseId: string;
@@ -245,7 +247,7 @@ export function streamKiro(
             }
           if (armContent || armToolUses.length > 0) {
             if (history.length > 0 && !history[history.length - 1].userInputMessage)
-              history.push({ userInputMessage: { content: "Continue", modelId: kiroModelId, origin: "AI_EDITOR" } });
+              history.push({ userInputMessage: { content: "Continue", modelId: kiroModelId, origin: "KIRO_CLI" } });
             history.push({
               assistantResponseMessage: {
                 content: armContent,
@@ -318,12 +320,13 @@ export function streamKiro(
         const request: KiroRequest = {
           conversationState: {
             chatTriggerType: "MANUAL",
+            agentTaskType: "vibe",
             conversationId,
             currentMessage: {
               userInputMessage: {
                 content: sanitizeSurrogates(currentContent),
                 modelId: kiroModelId,
-                origin: "AI_EDITOR",
+                origin: "KIRO_CLI",
                 ...(currentImages ? { images: currentImages } : {}),
                 ...(uimc ? { userInputMessageContext: uimc } : {}),
               },
@@ -331,15 +334,18 @@ export function streamKiro(
             ...(history.length > 0 ? { history } : {}),
           },
           ...(profileArn ? { profileArn } : {}),
+          agentMode: "vibe",
         };
         const mid = crypto.randomUUID().replace(/-/g, "");
-        const ua = `aws-sdk-js/1.0.0 ua/2.1 os/nodejs lang/js api/codewhispererruntime#1.0.0 m/E KiroIDE-0.75.0-${mid}`;
+        const ua = `aws-sdk-rust/1.0.0 ua/2.1 os/other lang/rust api/codewhispererstreaming#1.28.3 m/E app/AmazonQ-For-CLI md/appVersion-1.28.3-${mid}`;
         const response = await fetch(endpoint, {
           method: "POST",
           headers: {
-            "Content-Type": "application/json",
+            "Content-Type": "application/x-amz-json-1.0",
             Accept: "application/json",
             Authorization: `Bearer ${accessToken}`,
+            "X-Amz-Target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
+            "x-amzn-codewhisperer-optout": "true",
             "amz-sdk-invocation-id": crypto.randomUUID(),
             "amz-sdk-request": "attempt=1; max=1",
             "x-amzn-kiro-agent-mode": "vibe",

--- a/src/thinking-parser.ts
+++ b/src/thinking-parser.ts
@@ -36,6 +36,7 @@ export class ThinkingTagParser {
   private thinkingExtracted = false;
   private thinkingBlockIndex: number | null = null;
   private textBlockIndex: number | null = null;
+  private lastTextBlockIndex: number | null = null;
   private activeEndTag: string = THINKING_END_TAG;
 
   constructor(
@@ -87,7 +88,7 @@ export class ThinkingTagParser {
   }
 
   getTextBlockIndex(): number | null {
-    return this.textBlockIndex;
+    return this.textBlockIndex ?? this.lastTextBlockIndex;
   }
 
   private processBeforeThinking(): void {
@@ -135,6 +136,7 @@ export class ThinkingTagParser {
       this.textBuffer = this.textBuffer.slice(endPos + this.activeEndTag.length);
       this.inThinking = false;
       this.thinkingExtracted = true;
+      this.lastTextBlockIndex = this.textBlockIndex;
       this.textBlockIndex = null;
       if (this.textBuffer.startsWith("\n\n")) this.textBuffer = this.textBuffer.slice(2);
       return;
@@ -168,8 +170,17 @@ export class ThinkingTagParser {
   private emitThinking(thinking: string): void {
     if (!thinking) return;
     if (this.thinkingBlockIndex === null) {
-      this.thinkingBlockIndex = this.output.content.length;
-      this.output.content.push({ type: "thinking", thinking: "" });
+      if (this.textBlockIndex !== null) {
+        // Thinking arrived after text was already emitted (Kiro API sends
+        // text before thinking content). Insert the thinking block before
+        // the text block so the content array order is thinking → text.
+        this.thinkingBlockIndex = this.textBlockIndex;
+        this.output.content.splice(this.thinkingBlockIndex, 0, { type: "thinking", thinking: "" });
+        this.textBlockIndex = this.textBlockIndex + 1;
+      } else {
+        this.thinkingBlockIndex = this.output.content.length;
+        this.output.content.push({ type: "thinking", thinking: "" });
+      }
       this.stream.push({ type: "thinking_start", contentIndex: this.thinkingBlockIndex, partial: this.output });
     }
     const block = this.output.content[this.thinkingBlockIndex] as ThinkingContent;

--- a/src/thinking-parser.ts
+++ b/src/thinking-parser.ts
@@ -135,6 +135,7 @@ export class ThinkingTagParser {
       this.textBuffer = this.textBuffer.slice(endPos + this.activeEndTag.length);
       this.inThinking = false;
       this.thinkingExtracted = true;
+      this.textBlockIndex = null;
       if (this.textBuffer.startsWith("\n\n")) this.textBuffer = this.textBuffer.slice(2);
       return;
     }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -31,7 +31,7 @@ export interface KiroToolSpec {
 export interface KiroUserInputMessage {
   content: string;
   modelId: string;
-  origin: "AI_EDITOR";
+  origin: "KIRO_CLI";
   images?: KiroImage[];
   userInputMessageContext?: { toolResults?: KiroToolResult[]; tools?: KiroToolSpec[] };
 }
@@ -132,7 +132,7 @@ export function buildHistory(
       const uim: KiroUserInputMessage = {
         content: sanitizeSurrogates(content),
         modelId,
-        origin: "AI_EDITOR",
+        origin: "KIRO_CLI",
         ...(images.length > 0 ? { images: convertImagesToKiro(images) } : {}),
       };
       if (history[history.length - 1]?.userInputMessage)
@@ -191,7 +191,7 @@ export function buildHistory(
         userInputMessage: {
           content: "Tool results provided.",
           modelId,
-          origin: "AI_EDITOR",
+          origin: "KIRO_CLI",
           ...(trImages.length > 0 ? { images: convertImagesToKiro(trImages) } : {}),
           userInputMessageContext: { toolResults },
         },

--- a/test/thinking-parser.test.ts
+++ b/test/thinking-parser.test.ts
@@ -82,8 +82,10 @@ describe("Feature 7: Thinking Tag Parser", () => {
     parser.processChunk("king>deep thought</thinking>");
     parser.finalize();
 
-    expect(output.content[0]?.type === "text" && output.content[0].text).toBe("Hello ");
-    expect(output.content[1]?.type === "thinking" && output.content[1].thinking).toBe("deep thought");
+    // Thinking block inserted before text block
+    expect(output.content[0]?.type).toBe("thinking");
+    expect(output.content[0]?.type === "thinking" && output.content[0].thinking).toBe("deep thought");
+    expect(output.content[1]?.type === "text" && output.content[1].text).toBe("Hello ");
   });
 
   it("detects thinking start tag split across chunks", async () => {
@@ -174,5 +176,57 @@ describe("Feature 7: Thinking Tag Parser", () => {
     const events = await run(["<think>idea</th", "ink>\n\nText"]);
     expect(events.map((e) => e.type)).toContain("thinking_end");
     expect(deltas(events, "text_delta")).toContain("Text");
+  });
+
+  // =========================================================================
+  // Text-before-thinking (Kiro API sends text first, thinking after)
+  // =========================================================================
+
+  it("reorders thinking before text when text arrives first", async () => {
+    const output = makeOutput();
+    const stream = createAssistantMessageEventStream();
+    const parser = new ThinkingTagParser(output, stream);
+
+    // Simulate Kiro API: text content arrives before thinking
+    parser.processChunk("Hello world");
+    parser.processChunk("<thinking>reasoning</thinking>");
+    parser.finalize();
+    stream.end();
+
+    // Thinking block should be at index 0, text at index 1
+    expect(output.content[0]?.type).toBe("thinking");
+    expect(output.content[1]?.type).toBe("text");
+    expect((output.content[0] as { thinking: string }).thinking).toBe("reasoning");
+    expect((output.content[1] as { text: string }).text).toBe("Hello world");
+  });
+
+  it("getTextBlockIndex accounts for reordering when text arrives first", () => {
+    const output = makeOutput();
+    const stream = createAssistantMessageEventStream();
+    const parser = new ThinkingTagParser(output, stream);
+
+    parser.processChunk("Hello");
+    parser.processChunk("<thinking>t</thinking>");
+    parser.finalize();
+
+    // textBlockIndex should be 1 (shifted by thinking insertion)
+    expect(parser.getTextBlockIndex()).toBe(1);
+  });
+
+  it("handles text-before-thinking across multiple chunks", async () => {
+    const output = makeOutput();
+    const stream = createAssistantMessageEventStream();
+    const parser = new ThinkingTagParser(output, stream);
+
+    parser.processChunk("Hey! ");
+    parser.processChunk("What can I help with?");
+    parser.processChunk("<thinking>Let me think about this</thinking>");
+    parser.finalize();
+    stream.end();
+
+    expect(output.content[0]?.type).toBe("thinking");
+    expect(output.content[1]?.type).toBe("text");
+    expect((output.content[0] as { thinking: string }).thinking).toBe("Let me think about this");
+    expect((output.content[1] as { text: string }).text).toBe("Hey! What can I help with?");
   });
 });


### PR DESCRIPTION
## Summary

Aligns the HTTP request shape with kiro-cli's actual Rust SDK implementation so that the Kiro API sees pi-provider-kiro as a proper kiro-cli client.

## Changes

**Headers:**
- `Content-Type`: `application/json` → `application/x-amz-json-1.0`
- Added `X-Amz-Target: AmazonCodeWhispererStreamingService.GenerateAssistantResponse`
- Added `x-amzn-codewhisperer-optout: true`
- User-Agent now mimics kiro-cli's Rust SDK format: `aws-sdk-rust/1.0.0 ... api/codewhispererstreaming#1.28.3 ... app/AmazonQ-For-CLI`

**Request body:**
- `origin` on `userInputMessage`: `AI_EDITOR` → `KIRO_CLI`
- Added `agentTaskType: "vibe"` to `conversationState`
- Added `agentMode: "vibe"` to top-level request body

## How verified

- `npm run check` — clean
- `npm test` — 263/266 pass (3 pre-existing oauth test failures unrelated to this change)
- All 83 stream + transform tests pass