### PR TITLE
fix(ci): bump node to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run check
       - run: npm test


### PR DESCRIPTION
Node 22's npm 10.9.7 cannot self-upgrade (npm/cli#9151), breaking the publish workflow. Bump to node 24 and remove the now-unnecessary `npm install -g npm@latest` step.

Closes #37.