### PR TITLE
fix: map us-west-1 and us-west-2 to us-east-1 API region

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -41,6 +41,8 @@ export function resolveKiroModel(modelId: string): string {
  * internally via the AWS SDK partition resolver.
  */
 const API_REGION_MAP: Record<string, string> = {
+  "us-west-1": "us-east-1",
+  "us-west-2": "us-east-1",
   "us-east-2": "us-east-1",
   "eu-west-1": "eu-central-1",
   "eu-west-2": "eu-central-1",


### PR DESCRIPTION
## Problem

SSO instances in `us-west-1` / `us-west-2` are not in `API_REGION_MAP`, so `resolveApiRegion()` passes them through as-is. `filterModelsByRegion()` then fails with:

```
Unknown API region "us-west-2" — no models available.
```

## Fix

Add `us-west-1` and `us-west-2` to `API_REGION_MAP`, routing them to `us-east-1` (same as `us-east-2` already is).

## Testing

Existing tests pass. The change is a two-line addition to the region map.