### PR TITLE
feat(login): interactive login with all sign-in methods and native TUI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 import type { Api, Model, OAuthCredentials } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getKiroCliCredentials } from "./kiro-cli.js";
+import { setExtensionContext } from "./login-ui.js";
 import { filterModelsByRegion, kiroModels, resolveApiRegion } from "./models.js";
 import type { KiroCredentials } from "./oauth.js";
 import { loginKiro, refreshKiroToken } from "./oauth.js";
@@ -12,6 +13,10 @@ import { streamKiro } from "./stream.js";
 import { fetchKiroUsage } from "./usage.js";
 
 export default function (pi: ExtensionAPI) {
+  // Capture ctx for the custom TUI login component
+  pi.on("session_start", async (_event, ctx) => {
+    setExtensionContext(ctx);
+  });
   pi.registerProvider("kiro", {
     baseUrl: "https://q.us-east-1.amazonaws.com/generateAssistantResponse",
     api: "kiro-api",

--- a/src/login-ui.ts
+++ b/src/login-ui.ts
@@ -1,0 +1,125 @@
+// Feature 10b: Custom TUI login component
+//
+// Replaces multiple onPrompt calls with a single ctx.ui.custom() overlay
+// to work around pi's stacked-input bug (mirrored cursors on sequential prompts).
+//
+// Phase 1: SelectList — pick login method (Builder ID / IdC / Google / GitHub)
+// Phase 2: Input — enter IAM Identity Center start URL (only for option 2)
+
+import { DynamicBorder, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Container, Input, type SelectItem, SelectList, Text } from "@mariozechner/pi-tui";
+
+export type LoginChoice =
+  | { method: "builder-id" }
+  | { method: "idc"; startUrl: string }
+  | { method: "google" }
+  | { method: "github" }
+  | null; // cancelled
+
+let _ctx: ExtensionContext | undefined;
+
+export function setExtensionContext(ctx: ExtensionContext) {
+  _ctx = ctx;
+}
+
+/**
+ * Show the login method selection UI using pi's native TUI components.
+ * Returns the user's choice or null if cancelled.
+ */
+export async function showLoginUI(): Promise<LoginChoice> {
+  if (!_ctx) return null;
+  const ctx = _ctx;
+
+  return ctx.ui.custom<LoginChoice>((tui, theme, _kb, done) => {
+    const items: SelectItem[] = [
+      { value: "builder-id", label: "Builder ID", description: "AWS Builder ID (default)" },
+      { value: "idc", label: "Your organization", description: "IAM Identity Center (SSO)" },
+      { value: "google", label: "Google", description: "Social login via kiro-cli" },
+      { value: "github", label: "GitHub", description: "Social login via kiro-cli" },
+    ];
+
+    let phase: "select" | "url" = "select";
+    const container = new Container();
+    const border = new DynamicBorder((s: string) => theme.fg("accent", s));
+    const title = new Text(theme.fg("accent", theme.bold("Kiro Login")), 1, 0);
+    const hint = new Text(theme.fg("dim", "↑↓ navigate • enter select • esc cancel"), 1, 0);
+    const borderBottom = new DynamicBorder((s: string) => theme.fg("accent", s));
+
+    // Phase 1: SelectList
+    const selectList = new SelectList(items, items.length, {
+      selectedPrefix: (t: string) => theme.fg("accent", t),
+      selectedText: (t: string) => theme.fg("accent", t),
+      description: (t: string) => theme.fg("muted", t),
+      scrollInfo: (t: string) => theme.fg("dim", t),
+      noMatch: (t: string) => theme.fg("warning", t),
+    });
+
+    selectList.onSelect = (item) => {
+      if (item.value === "idc") {
+        switchToUrlInput();
+      } else {
+        done({ method: item.value as "builder-id" | "google" | "github" });
+      }
+    };
+    selectList.onCancel = () => done(null);
+
+    // Phase 2: URL Input
+    const urlLabel = new Text("Start URL (e.g. https://mycompany.awsapps.com/start)", 1, 0);
+    const urlInput = new Input();
+    const urlHint = new Text(theme.fg("dim", "enter submit • esc back"), 1, 0);
+
+    urlInput.onSubmit = (value) => {
+      const trimmed = value.trim();
+      if (trimmed?.startsWith("http")) {
+        done({ method: "idc", startUrl: trimmed });
+      }
+    };
+    urlInput.onEscape = () => {
+      switchToSelect();
+    };
+
+    function switchToUrlInput() {
+      phase = "url";
+      container.clear();
+      container.addChild(border);
+      container.addChild(new Text(theme.fg("accent", theme.bold("IAM Identity Center")), 1, 0));
+      container.addChild(urlLabel);
+      container.addChild(urlInput);
+      container.addChild(urlHint);
+      container.addChild(borderBottom);
+      tui.requestRender();
+    }
+
+    function switchToSelect() {
+      phase = "select";
+      urlInput.setValue("");
+      container.clear();
+      container.addChild(border);
+      container.addChild(title);
+      container.addChild(selectList);
+      container.addChild(hint);
+      container.addChild(borderBottom);
+      tui.requestRender();
+    }
+
+    // Initial state
+    switchToSelect();
+
+    return {
+      render(width: number) {
+        return container.render(width);
+      },
+      invalidate() {
+        container.invalidate();
+      },
+      handleInput(data: string) {
+        if (phase === "select") {
+          selectList.handleInput(data);
+        } else {
+          urlInput.handleInput(data);
+        }
+        tui.requestRender();
+      },
+    };
+  });
+}

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,0 +1,274 @@
+// Feature 10: Interactive Login — device code flow fallback
+//
+// Reached when no existing credentials are found (no Kiro IDE, no kiro-cli).
+// Matches the four options shown on app.kiro.dev/signin:
+//   Builder ID, Your organization (IAM IdC), Google, GitHub
+//
+// Primary path: native TUI component (login-ui.ts) via ctx.ui.custom().
+//   Uses zero onPrompt calls — SelectList for method, Input for IdC URL.
+// Fallback path: single onPrompt call when ctx is not yet available
+//   (e.g. first run before session_start fires).
+//
+// For IAM Identity Center, the SSO region is auto-detected by probing
+// common AWS OIDC endpoints. Inference/API region is derived from SSO
+// region automatically via resolveApiRegion() in models.ts.
+
+import { execFileSync } from "node:child_process";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
+import { showLoginUI } from "./login-ui.js";
+import { BUILDER_ID_START_URL, type KiroAuthMethod, type KiroCredentials, SSO_SCOPES } from "./oauth.js";
+
+type PromptFn = (p: { message: string; placeholder?: string; allowEmpty?: boolean }) => Promise<string>;
+
+function getPrompt(callbacks: OAuthLoginCallbacks): PromptFn {
+  return (callbacks as unknown as { onPrompt: PromptFn }).onPrompt;
+}
+
+function getProgress(callbacks: OAuthLoginCallbacks): ((msg: string) => void) | undefined {
+  return (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress;
+}
+
+function getSignal(callbacks: OAuthLoginCallbacks): AbortSignal | undefined {
+  return (callbacks as unknown as { signal?: AbortSignal }).signal;
+}
+
+// Regions to probe when auto-detecting the IAM Identity Center OIDC region.
+// Must cover every SSO region that resolveApiRegion() maps to a Kiro API region,
+// plus the API regions themselves. Ordered by likelihood.
+const IDC_PROBE_REGIONS = [
+  "us-east-1", // Kiro API region + common SSO region
+  "eu-west-1", // SSO region → eu-central-1 API
+  "eu-central-1", // Kiro API region + SSO region
+  "us-east-2", // SSO region → us-east-1 API
+  "eu-west-2", // SSO region → eu-central-1 API
+  "eu-west-3", // SSO region → eu-central-1 API
+  "eu-north-1", // SSO region → eu-central-1 API
+  "ap-southeast-1",
+  "ap-northeast-1",
+  "us-west-2",
+];
+
+type DeviceAuth = {
+  verificationUri: string;
+  verificationUriComplete: string;
+  userCode: string;
+  deviceCode: string;
+  interval: number;
+  expiresIn: number;
+};
+
+/**
+ * Interactive login fallback — shown when no existing credentials are available.
+ *
+ * Uses pi's native TUI components (SelectList + Input) via ctx.ui.custom()
+ * when available, falling back to a single onPrompt call otherwise.
+ * This avoids pi's stacked-input bug where sequential onPrompt calls
+ * render simultaneously with mirrored cursors.
+ */
+export async function interactiveLogin(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+  // Try native TUI component first (requires ctx from session_start)
+  const choice = await showLoginUI();
+
+  if (choice) {
+    switch (choice.method) {
+      case "builder-id":
+        return runDeviceCodeFlow(callbacks, BUILDER_ID_START_URL, "us-east-1");
+      case "idc":
+        return runDeviceCodeFlowWithRegionDetection(callbacks, choice.startUrl);
+      case "google":
+        return loginViaKiroCli(callbacks, "google");
+      case "github":
+        return loginViaKiroCli(callbacks, "github");
+    }
+  }
+
+  // Fallback: single onPrompt (ctx not available, e.g. first run before session_start)
+  const input =
+    (
+      await getPrompt(callbacks)({
+        message: "Paste IAM Identity Center URL, or blank for Builder ID",
+        placeholder: "https://mycompany.awsapps.com/start",
+        allowEmpty: true,
+      })
+    )?.trim() || "";
+
+  if (getSignal(callbacks)?.aborted) throw new Error("Login cancelled");
+
+  if (!input) return runDeviceCodeFlow(callbacks, BUILDER_ID_START_URL, "us-east-1");
+  if (!input.startsWith("http"))
+    throw new Error(`Invalid input "${input}". Paste your start URL or leave blank for Builder ID.`);
+  return runDeviceCodeFlowWithRegionDetection(callbacks, input);
+}
+
+/**
+ * Register an OIDC client and start device authorization in a given region.
+ * Returns null if the region rejects the startUrl.
+ */
+async function tryRegisterAndAuthorize(
+  startUrl: string,
+  region: string,
+): Promise<{ clientId: string; clientSecret: string; oidcEndpoint: string; devAuth: DeviceAuth } | null> {
+  const oidcEndpoint = `https://oidc.${region}.amazonaws.com`;
+
+  const regResp = await fetch(`${oidcEndpoint}/client/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+    body: JSON.stringify({
+      clientName: "pi-cli",
+      clientType: "public",
+      scopes: SSO_SCOPES,
+      grantTypes: ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
+    }),
+  });
+  if (!regResp.ok) return null;
+  const { clientId, clientSecret } = (await regResp.json()) as { clientId: string; clientSecret: string };
+
+  const devResp = await fetch(`${oidcEndpoint}/device_authorization`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+    body: JSON.stringify({ clientId, clientSecret, startUrl }),
+  });
+  if (!devResp.ok) return null;
+
+  return { clientId, clientSecret, oidcEndpoint, devAuth: (await devResp.json()) as DeviceAuth };
+}
+
+/**
+ * Run device code flow for a known region (e.g. Builder ID -> us-east-1).
+ */
+async function runDeviceCodeFlow(
+  callbacks: OAuthLoginCallbacks,
+  startUrl: string,
+  region: string,
+): Promise<OAuthCredentials> {
+  const result = await tryRegisterAndAuthorize(startUrl, region);
+  if (!result) throw new Error(`Device authorization failed in ${region}`);
+  return pollDeviceCode(callbacks, result.clientId, result.clientSecret, region, result.oidcEndpoint, result.devAuth);
+}
+
+/**
+ * Probe common AWS regions to find which OIDC endpoint accepts the given start URL,
+ * then run the device code flow in that region.
+ */
+async function runDeviceCodeFlowWithRegionDetection(
+  callbacks: OAuthLoginCallbacks,
+  startUrl: string,
+): Promise<OAuthCredentials> {
+  getProgress(callbacks)?.("Detecting your Identity Center region...");
+
+  for (const region of IDC_PROBE_REGIONS) {
+    const result = await tryRegisterAndAuthorize(startUrl, region);
+    if (result) {
+      getProgress(callbacks)?.(`Region detected: ${region}`);
+      return pollDeviceCode(
+        callbacks,
+        result.clientId,
+        result.clientSecret,
+        region,
+        result.oidcEndpoint,
+        result.devAuth,
+      );
+    }
+  }
+
+  throw new Error(
+    `Could not find an AWS region that accepts ${startUrl}. ` +
+      `Tried: ${IDC_PROBE_REGIONS.join(", ")}. Check your start URL and try again.`,
+  );
+}
+
+/**
+ * Poll the OIDC token endpoint until the user completes browser auth or timeout.
+ */
+async function pollDeviceCode(
+  callbacks: OAuthLoginCallbacks,
+  clientId: string,
+  clientSecret: string,
+  region: string,
+  oidcEndpoint: string,
+  devAuth: DeviceAuth,
+): Promise<OAuthCredentials> {
+  (callbacks as unknown as { onAuth: (info: { url: string; instructions: string }) => void }).onAuth({
+    url: devAuth.verificationUriComplete,
+    instructions: `Your code: ${devAuth.userCode}`,
+  });
+
+  const deadline = Date.now() + (devAuth.expiresIn || 600) * 1000;
+  const baseInterval = (devAuth.interval || 5) * 1000;
+  let interval = baseInterval;
+
+  while (Date.now() < deadline) {
+    if (getSignal(callbacks)?.aborted) throw new Error("Login cancelled");
+    await new Promise((r) => setTimeout(r, interval));
+
+    const tokResp = await fetch(`${oidcEndpoint}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+      body: JSON.stringify({
+        clientId,
+        clientSecret,
+        deviceCode: devAuth.deviceCode,
+        grantType: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+    });
+    const tokData = (await tokResp.json()) as {
+      error?: string;
+      accessToken?: string;
+      refreshToken?: string;
+      expiresIn?: number;
+    };
+
+    switch (tokData.error) {
+      case undefined:
+        if (tokData.accessToken && tokData.refreshToken) {
+          return {
+            refresh: `${tokData.refreshToken}|${clientId}|${clientSecret}|idc`,
+            access: tokData.accessToken,
+            expires: Date.now() + (tokData.expiresIn || 3600) * 1000 - 5 * 60 * 1000,
+            clientId,
+            clientSecret,
+            region,
+            authMethod: "idc" as KiroAuthMethod,
+          } satisfies KiroCredentials;
+        }
+        break;
+      case "authorization_pending":
+        break;
+      case "slow_down":
+        interval += baseInterval;
+        break;
+      default:
+        throw new Error(`Authorization failed: ${tokData.error}`);
+    }
+  }
+  throw new Error("Authorization timed out");
+}
+
+/**
+ * Delegate Google/GitHub social login to kiro-cli.
+ * Requires kiro-cli to be installed and in PATH.
+ */
+export async function loginViaKiroCli(
+  callbacks: OAuthLoginCallbacks,
+  provider: "google" | "github",
+): Promise<OAuthCredentials> {
+  const { getKiroCliCredentials, getKiroCliSocialToken } = await import("./kiro-cli.js");
+
+  getProgress(callbacks)?.(`Initiating ${provider} login via kiro-cli...`);
+
+  try {
+    execFileSync("kiro-cli", ["login", "--license", "free"], {
+      timeout: 120000,
+      stdio: "inherit",
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`kiro-cli login failed: ${msg}. Ensure kiro-cli is installed and in PATH.`);
+  }
+
+  const creds = getKiroCliSocialToken() || getKiroCliCredentials();
+  if (!creds) throw new Error("kiro-cli login completed but no credentials found in its database");
+
+  getProgress(callbacks)?.(creds.authMethod === "desktop" ? "Google/GitHub login successful" : "Login successful");
+  return creds;
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -4,13 +4,12 @@
 //   - "idc": AWS Builder ID or IAM Identity Center (SSO) via device code flow
 //   - "desktop": Google/GitHub social login via Kiro auth service (delegates to kiro-cli)
 //
-// Social login (Google/GitHub) uses PKCE with localhost callback, which requires
-// either a local browser or SSH port forwarding. We delegate to kiro-cli for this
-// flow since it already handles the complexity.
+// When no existing credentials are found (no Kiro IDE, no kiro-cli), falls back
+// to the interactive login flow in login.ts (Feature 10).
 
-import { execFileSync } from "node:child_process";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
 import { getKiroIdeCredentials, getKiroIdeCredentialsAllowExpired } from "./kiro-ide.js";
+import { interactiveLogin, loginViaKiroCli } from "./login.js";
 
 export const SSO_OIDC_ENDPOINT = "https://oidc.us-east-1.amazonaws.com";
 export const BUILDER_ID_START_URL = "https://view.awsapps.com/start";
@@ -106,120 +105,8 @@ export async function loginKiro(
     }
   }
 
-  // Fall back to device code flow
-  const regResp = await fetch(`${SSO_OIDC_ENDPOINT}/client/register`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
-    body: JSON.stringify({
-      clientName: "pi-cli",
-      clientType: "public",
-      scopes: SSO_SCOPES,
-      grantTypes: ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
-    }),
-  });
-  if (!regResp.ok) throw new Error(`Client registration failed: ${regResp.status}`);
-  const { clientId, clientSecret } = (await regResp.json()) as { clientId: string; clientSecret: string };
-
-  const devResp = await fetch(`${SSO_OIDC_ENDPOINT}/device_authorization`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
-    body: JSON.stringify({ clientId, clientSecret, startUrl: BUILDER_ID_START_URL }),
-  });
-  if (!devResp.ok) throw new Error(`Device authorization failed: ${devResp.status}`);
-  const devAuth = (await devResp.json()) as {
-    verificationUri: string;
-    verificationUriComplete: string;
-    userCode: string;
-    deviceCode: string;
-    interval: number;
-    expiresIn: number;
-  };
-
-  (callbacks as unknown as { onAuth: (info: { url: string; instructions: string }) => void }).onAuth({
-    url: devAuth.verificationUriComplete,
-    instructions: `Your code: ${devAuth.userCode}`,
-  });
-
-  const interval = (devAuth.interval || 5) * 1000;
-  const maxAttempts = Math.floor((devAuth.expiresIn || 600) / (devAuth.interval || 5));
-  let currentInterval = interval;
-
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if ((callbacks as unknown as { signal?: AbortSignal }).signal?.aborted) throw new Error("Login cancelled");
-    await new Promise((r) => setTimeout(r, currentInterval));
-    const tokResp = await fetch(`${SSO_OIDC_ENDPOINT}/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
-      body: JSON.stringify({
-        clientId,
-        clientSecret,
-        deviceCode: devAuth.deviceCode,
-        grantType: "urn:ietf:params:oauth:grant-type:device_code",
-      }),
-    });
-    const tokData = (await tokResp.json()) as {
-      error?: string;
-      accessToken?: string;
-      refreshToken?: string;
-      expiresIn?: number;
-    };
-    if (tokData.error === "authorization_pending") continue;
-    if (tokData.error === "slow_down") {
-      currentInterval += interval;
-      continue;
-    }
-    if (tokData.error) throw new Error(`Authorization failed: ${tokData.error}`);
-    if (tokData.accessToken && tokData.refreshToken) {
-      return {
-        refresh: `${tokData.refreshToken}|${clientId}|${clientSecret}|idc`,
-        access: tokData.accessToken,
-        expires: Date.now() + (tokData.expiresIn || 3600) * 1000 - 5 * 60 * 1000,
-        clientId,
-        clientSecret,
-        region: "us-east-1",
-        authMethod: "idc" as KiroAuthMethod,
-      };
-    }
-  }
-  throw new Error("Authorization timed out");
-}
-
-/**
- * Delegate social login to kiro-cli.
- * Requires kiro-cli to be installed and in PATH.
- */
-async function loginViaKiroCli(
-  callbacks: OAuthLoginCallbacks,
-  provider: "google" | "github",
-): Promise<OAuthCredentials> {
-  const { getKiroCliCredentials, getKiroCliSocialToken } = await import("./kiro-cli.js");
-
-  (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
-    `Initiating ${provider} login via kiro-cli...`,
-  );
-
-  // Run kiro-cli login
-  try {
-    execFileSync("kiro-cli", ["login", "--license", "free"], {
-      timeout: 120000, // 2 minutes should be enough
-      stdio: "inherit", // Let kiro-cli handle the browser/auth UX
-    });
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    throw new Error(`kiro-cli login failed: ${msg}. Ensure kiro-cli is installed and in PATH.`);
-  }
-
-  // Read the new credentials from kiro-cli's DB (prefer social token)
-  const creds = getKiroCliSocialToken() || getKiroCliCredentials();
-  if (!creds) {
-    throw new Error("kiro-cli login completed but no credentials found in its database");
-  }
-
-  (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
-    creds.authMethod === "desktop" ? "Google/GitHub login successful" : "Login successful",
-  );
-
-  return creds;
+  // Fall back to interactive login (Feature 10)
+  return interactiveLogin(callbacks);
 }
 
 /**

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -1,0 +1,232 @@
+import type { OAuthLoginCallbacks } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { interactiveLogin } from "../src/login.js";
+import type { KiroCredentials } from "../src/oauth.js";
+import { BUILDER_ID_START_URL } from "../src/oauth.js";
+
+vi.mock("../src/kiro-cli.js", () => ({
+  getKiroCliCredentials: vi.fn(() => undefined),
+  getKiroCliCredentialsAllowExpired: vi.fn(() => undefined),
+  getKiroCliSocialToken: vi.fn(() => undefined),
+  getKiroCliSocialTokenAllowExpired: vi.fn(() => undefined),
+  saveKiroCliCredentials: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
+
+// Mock login-ui — no ctx available in tests, return null to exercise fallback
+vi.mock("../src/login-ui.js", () => ({
+  showLoginUI: vi.fn(() => Promise.resolve(null)),
+  setExtensionContext: vi.fn(),
+}));
+
+function makeCallbacks(...responses: string[]): OAuthLoginCallbacks & { onAuth: ReturnType<typeof vi.fn> } {
+  const onPrompt = vi.fn();
+  for (const r of responses) onPrompt.mockResolvedValueOnce(r);
+  onPrompt.mockResolvedValue("");
+  return {
+    onAuth: vi.fn(),
+    onDeviceCode: vi.fn(),
+    onPrompt,
+    onProgress: vi.fn(),
+    signal: new AbortController().signal,
+  } as OAuthLoginCallbacks & { onAuth: ReturnType<typeof vi.fn> };
+}
+
+function mockBuilderIdFetch() {
+  return vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "cid", clientSecret: "csec" }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          verificationUri: "https://device.sso.us-east-1.amazonaws.com",
+          verificationUriComplete: "https://device.sso.us-east-1.amazonaws.com?code=ABCD",
+          userCode: "ABCD-1234",
+          deviceCode: "dc",
+          interval: 1,
+          expiresIn: 10,
+        }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
+    });
+}
+
+// us-east-1 device_authorization fails (wrong region), eu-west-1 succeeds
+function mockIdcAutoDetectFetch() {
+  return vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "c1", clientSecret: "s1" }) }) // us-east-1 register
+    .mockResolvedValueOnce({ ok: false, status: 400 }) // us-east-1 device_auth → wrong region
+    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "c2", clientSecret: "s2" }) }) // eu-west-1 register
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          verificationUri: "u",
+          verificationUriComplete: "u?code=X",
+          userCode: "X",
+          deviceCode: "dc",
+          interval: 1,
+          expiresIn: 10,
+        }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
+    });
+}
+
+describe("Feature 10: Interactive Login", () => {
+  describe("method selection (prompt 1)", () => {
+    it("blank/1 → Builder ID", async () => {
+      const mockFetch = mockBuilderIdFetch();
+      vi.stubGlobal("fetch", mockFetch);
+      const creds = await interactiveLogin(makeCallbacks(""));
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body).startUrl).toBe(BUILDER_ID_START_URL);
+      expect((creds as KiroCredentials).region).toBe("us-east-1");
+      vi.unstubAllGlobals();
+    });
+
+    it("TUI: google → kiro-cli Google", async () => {
+      const { showLoginUI } = await import("../src/login-ui.js");
+      vi.mocked(showLoginUI).mockResolvedValueOnce({ method: "google" });
+      const { getKiroCliSocialToken, getKiroCliCredentials } = await import("../src/kiro-cli.js");
+      vi.mocked(getKiroCliSocialToken).mockReturnValueOnce(undefined);
+      vi.mocked(getKiroCliCredentials).mockReturnValueOnce({
+        refresh: "rt|desktop",
+        access: "at",
+        expires: Date.now() + 3600000,
+        clientId: "",
+        clientSecret: "",
+        region: "us-east-1",
+        authMethod: "desktop",
+      });
+      expect(((await interactiveLogin(makeCallbacks(""))) as KiroCredentials).authMethod).toBe("desktop");
+    });
+
+    it("TUI: github → kiro-cli GitHub", async () => {
+      const { showLoginUI } = await import("../src/login-ui.js");
+      vi.mocked(showLoginUI).mockResolvedValueOnce({ method: "github" });
+      const { getKiroCliSocialToken, getKiroCliCredentials } = await import("../src/kiro-cli.js");
+      vi.mocked(getKiroCliSocialToken).mockReturnValueOnce(undefined);
+      vi.mocked(getKiroCliCredentials).mockReturnValueOnce({
+        refresh: "rt|desktop",
+        access: "at",
+        expires: Date.now() + 3600000,
+        clientId: "",
+        clientSecret: "",
+        region: "us-east-1",
+        authMethod: "desktop",
+      });
+      expect(((await interactiveLogin(makeCallbacks(""))) as KiroCredentials).authMethod).toBe("desktop");
+    });
+
+    it("TUI: builder-id → Builder ID flow", async () => {
+      const { showLoginUI } = await import("../src/login-ui.js");
+      vi.mocked(showLoginUI).mockResolvedValueOnce({ method: "builder-id" });
+      vi.stubGlobal("fetch", mockBuilderIdFetch());
+      const creds = await interactiveLogin(makeCallbacks(""));
+      expect((creds as KiroCredentials).region).toBe("us-east-1");
+      vi.unstubAllGlobals();
+    });
+
+    it("TUI: idc → IdC flow with auto-detect", async () => {
+      const { showLoginUI } = await import("../src/login-ui.js");
+      vi.mocked(showLoginUI).mockResolvedValueOnce({ method: "idc", startUrl: "https://mycompany.awsapps.com/start" });
+      vi.stubGlobal("fetch", mockIdcAutoDetectFetch());
+      const creds = await interactiveLogin(makeCallbacks(""));
+      expect((creds as KiroCredentials).region).toBe("eu-west-1");
+      vi.unstubAllGlobals();
+    });
+
+    it("TUI: null (cancelled) → falls back to onPrompt", async () => {
+      // showLoginUI returns null (default mock), so fallback fires
+      vi.stubGlobal("fetch", mockBuilderIdFetch());
+      const creds = await interactiveLogin(makeCallbacks(""));
+      expect((creds as KiroCredentials).region).toBe("us-east-1");
+      vi.unstubAllGlobals();
+    });
+
+    it("fallback: invalid non-URL input → throws", async () => {
+      vi.stubGlobal("fetch", vi.fn());
+      await expect(interactiveLogin(makeCallbacks("notaurl"))).rejects.toThrow("Invalid input");
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("fallback — onPrompt path (no TUI ctx)", () => {
+    it("URL → auto-detects region", async () => {
+      vi.stubGlobal("fetch", mockIdcAutoDetectFetch());
+      const creds = await interactiveLogin(makeCallbacks("https://mycompany.awsapps.com/start"));
+      expect((creds as KiroCredentials).region).toBe("eu-west-1");
+      vi.unstubAllGlobals();
+    });
+
+    it("blank → Builder ID", async () => {
+      vi.stubGlobal("fetch", mockBuilderIdFetch());
+      const creds = await interactiveLogin(makeCallbacks(""));
+      expect((creds as KiroCredentials).region).toBe("us-east-1");
+      vi.unstubAllGlobals();
+    });
+
+    it("all regions fail → throws helpful error", async () => {
+      let call = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(() => {
+          call++;
+          if (call % 2 === 1)
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ clientId: "c", clientSecret: "s" }) });
+          return Promise.resolve({ ok: false, status: 400 });
+        }),
+      );
+      await expect(interactiveLogin(makeCallbacks("https://unknown.awsapps.com/start"))).rejects.toThrow(
+        "Could not find",
+      );
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("device code polling", () => {
+    it("throws on cancelled signal", async () => {
+      const ac = new AbortController();
+      ac.abort();
+      const callbacks = { ...makeCallbacks(""), signal: ac.signal };
+      vi.stubGlobal("fetch", mockBuilderIdFetch());
+      await expect(interactiveLogin(callbacks)).rejects.toThrow("cancelled");
+      vi.unstubAllGlobals();
+    });
+
+    it("increases polling interval on slow_down", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "c", clientSecret: "s" }) })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                verificationUri: "u",
+                verificationUriComplete: "u",
+                userCode: "X",
+                deviceCode: "d",
+                interval: 1,
+                expiresIn: 30,
+              }),
+          })
+          .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ error: "slow_down" }) })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
+          }),
+      );
+      expect((await interactiveLogin(makeCallbacks(""))).access).toBe("at");
+      vi.unstubAllGlobals();
+    });
+  });
+});

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,7 +1,6 @@
-import type { OAuthLoginCallbacks } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { KiroCredentials } from "../src/oauth.js";
-import { loginKiroBuilderID, refreshKiroToken } from "../src/oauth.js";
+import { refreshKiroToken } from "../src/oauth.js";
 
 // Mock kiro-cli to prevent fallback to real credentials
 vi.mock("../src/kiro-cli.js", () => ({
@@ -12,110 +11,8 @@ vi.mock("../src/kiro-cli.js", () => ({
   saveKiroCliCredentials: vi.fn(),
 }));
 
-function makeCallbacks(overrides?: Partial<OAuthLoginCallbacks>): OAuthLoginCallbacks & {
-  onAuth: ReturnType<typeof vi.fn>;
-  signal: AbortSignal;
-} {
-  return {
-    onAuth: vi.fn(),
-    onDeviceCode: vi.fn(),
-    onPrompt: vi.fn().mockResolvedValue("code"),
-    onProgress: vi.fn(),
-    signal: new AbortController().signal,
-    ...overrides,
-  } as OAuthLoginCallbacks & { onAuth: ReturnType<typeof vi.fn>; signal: AbortSignal };
-}
-
-describe("Feature 3: OAuth — AWS Builder ID", () => {
-  describe("loginKiroBuilderID", () => {
-    it("calls onAuth with verification URL", async () => {
-      const callbacks = makeCallbacks();
-      const mockFetch = vi
-        .fn()
-        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "cid", clientSecret: "csec" }) })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              verificationUri: "https://device.sso.us-east-1.amazonaws.com",
-              verificationUriComplete: "https://device.sso.us-east-1.amazonaws.com?code=ABCD",
-              userCode: "ABCD-1234",
-              deviceCode: "dc",
-              interval: 1,
-              expiresIn: 10,
-            }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
-        });
-      vi.stubGlobal("fetch", mockFetch);
-
-      const creds = await loginKiroBuilderID(callbacks);
-      expect(callbacks.onAuth).toHaveBeenCalled();
-      const authCall = callbacks.onAuth.mock.calls[0][0];
-      expect(authCall.url).toContain("device.sso");
-      expect(creds.access).toBe("at");
-      expect(creds.refresh).toContain("rt|cid|csec|idc");
-      expect((creds as KiroCredentials).authMethod).toBe("idc");
-
-      vi.unstubAllGlobals();
-    });
-
-    it("throws on cancelled signal", async () => {
-      const ac = new AbortController();
-      ac.abort();
-      const callbacks = makeCallbacks({ signal: ac.signal });
-      const mockFetch = vi
-        .fn()
-        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "c", clientSecret: "s" }) })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              verificationUri: "u",
-              verificationUriComplete: "u",
-              userCode: "X",
-              deviceCode: "d",
-              interval: 1,
-              expiresIn: 10,
-            }),
-        });
-      vi.stubGlobal("fetch", mockFetch);
-
-      await expect(loginKiroBuilderID(callbacks)).rejects.toThrow("cancelled");
-      vi.unstubAllGlobals();
-    });
-
-    it("increases interval on slow_down response", async () => {
-      const callbacks = makeCallbacks();
-      const mockFetch = vi
-        .fn()
-        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "c", clientSecret: "s" }) })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              verificationUri: "u",
-              verificationUriComplete: "u",
-              userCode: "X",
-              deviceCode: "d",
-              interval: 1,
-              expiresIn: 30,
-            }),
-        })
-        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ error: "slow_down" }) })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
-        });
-      vi.stubGlobal("fetch", mockFetch);
-
-      const creds = await loginKiroBuilderID(callbacks);
-      expect(creds.access).toBe("at");
-      vi.unstubAllGlobals();
-    });
-  });
+describe("Feature 3: OAuth — Token Refresh", () => {
+  // Interactive login / device code flow tests live in test/login.test.ts (Feature 10)
 
   describe("refreshKiroToken", () => {
     it("refreshes token using encoded refresh field", async () => {
@@ -171,12 +68,7 @@ describe("Feature 3: OAuth — AWS Builder ID", () => {
     });
 
     it("throws on desktop token refresh failure", async () => {
-      const mockFetch = vi.fn().mockResolvedValueOnce({
-        ok: false,
-        status: 401,
-      });
-      vi.stubGlobal("fetch", mockFetch);
-
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({ ok: false, status: 401 }));
       await expect(
         refreshKiroToken({
           refresh: "desk_rt|desktop",
@@ -189,12 +81,10 @@ describe("Feature 3: OAuth — AWS Builder ID", () => {
     });
 
     it("throws on desktop token refresh with missing accessToken", async () => {
-      const mockFetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ expiresIn: 3600 }),
-      });
-      vi.stubGlobal("fetch", mockFetch);
-
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ expiresIn: 3600 }) }),
+      );
       await expect(
         refreshKiroToken({
           refresh: "desk_rt|desktop",
@@ -220,8 +110,7 @@ describe("Feature 3: OAuth — AWS Builder ID", () => {
         region: "us-west-2",
       } as KiroCredentials);
 
-      const url = mockFetch.mock.calls[0][0];
-      expect(url).toContain("oidc.us-west-2.amazonaws.com");
+      expect(mockFetch.mock.calls[0][0]).toContain("oidc.us-west-2.amazonaws.com");
       vi.unstubAllGlobals();
     });
 
@@ -230,7 +119,7 @@ describe("Feature 3: OAuth — AWS Builder ID", () => {
       vi.mocked(getKiroCliCredentialsAllowExpired).mockReturnValueOnce({
         refresh: "cli_rt|cli_cid|cli_csec|idc",
         access: "cli_at",
-        expires: Date.now() - 1000, // expired
+        expires: Date.now() - 1000,
         clientId: "cli_cid",
         clientSecret: "cli_csec",
         region: "us-east-1",
@@ -239,19 +128,14 @@ describe("Feature 3: OAuth — AWS Builder ID", () => {
 
       const mockFetch = vi
         .fn()
-        .mockResolvedValueOnce({ ok: false, status: 401 }) // direct refresh fails
+        .mockResolvedValueOnce({ ok: false, status: 401 })
         .mockResolvedValueOnce({
-          // expired creds refresh succeeds
           ok: true,
           json: () => Promise.resolve({ accessToken: "new_at", refreshToken: "new_rt", expiresIn: 3600 }),
         });
       vi.stubGlobal("fetch", mockFetch);
 
-      const creds = await refreshKiroToken({
-        refresh: "stale_rt|cid|csec|idc",
-        access: "stale_at",
-        expires: 0,
-      });
+      const creds = await refreshKiroToken({ refresh: "stale_rt|cid|csec|idc", access: "stale_at", expires: 0 });
       expect(creds.access).toBe("new_at");
       vi.unstubAllGlobals();
     });
@@ -270,16 +154,15 @@ describe("Feature 3: OAuth — AWS Builder ID", () => {
 
       const mockFetch = vi
         .fn()
-        .mockResolvedValueOnce({ ok: false, status: 401 }) // direct refresh fails
-        .mockResolvedValueOnce({ ok: false, status: 401 }); // expired creds refresh also fails
+        .mockResolvedValueOnce({ ok: false, status: 401 })
+        .mockResolvedValueOnce({ ok: false, status: 401 });
       vi.stubGlobal("fetch", mockFetch);
 
       const creds = await refreshKiroToken({
         refresh: "old_rt|cid|csec|idc",
         access: "old_at",
-        expires: Date.now() - 60_000, // within 5-min buffer window
+        expires: Date.now() - 60_000,
       });
-      // Falls through to Layer 5: returns credentials with buffer added
       expect(creds.access).toBe("old_at");
       expect(creds.expires).toBeGreaterThan(Date.now());
       vi.unstubAllGlobals();

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -4,7 +4,7 @@ import { kiroModels } from "../src/models.js";
 
 const mockPi = () => {
   const registerProvider = vi.fn();
-  return { pi: { registerProvider } as unknown as ExtensionAPI, registerProvider };
+  return { pi: { registerProvider, on: vi.fn() } as unknown as ExtensionAPI, registerProvider };
 };
 
 describe("Feature 1: Extension Registration", () => {


### PR DESCRIPTION
Add support for all four login methods from app.kiro.dev/signin as a device code flow fallback when no Kiro IDE or kiro-cli credentials are found:

  1. Builder ID        — AWS Builder ID (default, us-east-1)
  2. Your organization — IAM Identity Center (SSO region auto-detected)
  3. Google            — social login delegated to kiro-cli
  4. GitHub            — social login delegated to kiro-cli

Implementation:
- src/login.ts (new): interactiveLogin() orchestrator, device code flow with region auto-detection by probing AWS OIDC endpoints, kiro-cli delegation for social login
- src/login-ui.ts (new): native TUI login component using pi's SelectList + Input via ctx.ui.custom(). Works around pi's stacked- input bug where sequential onPrompt calls mirror keyboard input across all visible fields. Falls back to single onPrompt if ctx is not yet available.
- src/oauth.ts: loginKiro() cascade now delegates to interactiveLogin() as its last-resort fallback; device code flow and loginViaKiroCli extracted to login.ts
- src/index.ts: captures ExtensionContext on session_start for the TUI login component

SSO region is auto-detected by probing common AWS OIDC endpoints in order until one accepts the start URL. Inference/API region is derived automatically from SSO region via resolveApiRegion().

Fixes https://github.com/mikeyobrien/pi-provider-kiro/issues/34