### PR TITLE
ci: update GitHub Actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary
- update checkout and setup-node to the current v6 major in CI and publish workflows
- remove the GitHub Actions Node 20 deprecation warning path from repo workflows
- keep the repo on Node 24 for install/test/publish jobs

## Test Plan
- npm ci
- npm run check
- npm run lint
- npm test