### PR TITLE
fix: restore launch readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Exclude `@mariozechner/pi-tui` from the release bundle so `npm ci` / CI builds stop trying to inline `koffi` native binaries during `prepare`
+
+### Changed
+
+- Refresh README and package metadata to match the current 19-model surface and login flow
+
 ## [0.5.1] - 2026-04-14
 
 ### Fixed
@@ -109,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: 17 models across 7 families, OAuth device code flow, kiro-cli SQLite credential fallback, streaming pipeline with thinking tag parser
 
+[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.1...HEAD
 [0.4.2]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.4.0...v0.4.1
 [0.5.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -1,27 +1,17 @@
 # pi-provider-kiro
 
-A [pi](https://shittycodingagent.ai/) provider extension that connects pi to the **Kiro API** (AWS CodeWhisperer/Q), giving you access to 17 models through a single provider.
+A [pi](https://shittycodingagent.ai/) provider extension that connects pi to the **Kiro API** (AWS CodeWhisperer/Q), exposing **19 free models across 8 families** through one provider surface.
 
-## Models
+## Why this exists
 
-| Family | Models | Context | Reasoning |
-|--------|--------|---------|-----------|
-| Claude Opus 4.6 | opus-4-6, opus-4-6-1m | 200K / 1M | ✓ |
-| Claude Sonnet 4.6 | sonnet-4-6, sonnet-4-6-1m | 200K / 1M | ✓ |
-| Claude Opus 4.5 | opus-4-5 | 200K | ✓ |
-| Claude Sonnet 4.5 | sonnet-4-5, sonnet-4-5-1m | 200K / 1M | ✓ |
-| Claude Sonnet 4 | sonnet-4 | 200K | ✓ |
-| Claude Haiku 4.5 | haiku-4-5 | 200K | ✗ |
-| DeepSeek 3.2 | deepseek-3-2 | 128K | ✓ |
-| Kimi K2.5 | kimi-k2-5 | 200K | ✓ |
-| MiniMax M2.1 | minimax-m2-1 | 128K | ✗ |
-| GLM 4.7 | glm-4-7, glm-4-7-flash | 128K | ✓ / ✗ |
-| Qwen3 Coder | qwen3-coder-next, qwen3-coder-480b | 128K | ✓ |
-| AGI Nova | agi-nova-beta-1m | 1M | ✓ |
+Kiro gives you a strong free model menu, but pi needs a provider that speaks Kiro's auth, model catalog, and streaming protocol cleanly. `pi-provider-kiro` handles that bridge, including:
 
-All models are free to use through Kiro.
+- AWS Builder ID, IAM Identity Center, Google, and GitHub login flows
+- shared credentials from an existing `kiro-cli` session when available
+- reasoning-aware streaming
+- region-aware model filtering so pi only shows models your Kiro region can actually use
 
-## Setup
+## Quick start
 
 Install the provider:
 
@@ -29,31 +19,58 @@ Install the provider:
 pi install npm:pi-provider-kiro
 ```
 
-Or install via npm directly:
+Or install it globally with npm:
 
 ```bash
 npm install -g pi-provider-kiro
 ```
 
-Then log in:
+Then log in from pi:
 
-```
+```text
 /login kiro
 ```
 
-This opens a browser for authentication. You can choose from:
-- **AWS Builder ID** — Native device code flow (works in SSH/remote environments)
-- **Google** — Social login (requires local browser or SSH port forwarding)
-- **GitHub** — Social login (requires local browser or SSH port forwarding)
+The login flow supports:
+- **AWS Builder ID** — native device-code flow, works well over SSH/remotes
+- **Your organization** — IAM Identity Center start URL
+- **Google** — social login via `kiro-cli`
+- **GitHub** — social login via `kiro-cli`
 
-If you have [kiro-cli](https://kiro.dev) installed and already logged in, credentials are picked up automatically — no second login needed.
+If you already use [kiro-cli](https://kiro.dev), the provider can reuse those credentials instead of forcing a second login.
+
+## Models
+
+| Family | Models | Context | Reasoning |
+|--------|--------|---------|-----------|
+| Claude Opus 4.6 | `claude-opus-4-6`, `claude-opus-4-6-1m` | 200K / 1M | ✓ |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6`, `claude-sonnet-4-6-1m` | 200K / 1M | ✓ |
+| Claude Opus 4.5 | `claude-opus-4-5` | 200K | ✓ |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5`, `claude-sonnet-4-5-1m` | 200K / 1M | ✓ |
+| Claude Sonnet 4 | `claude-sonnet-4` | 200K | ✓ |
+| Claude Haiku 4.5 | `claude-haiku-4-5` | 200K | ✗ |
+| DeepSeek 3.2 | `deepseek-3-2` | 128K | ✓ |
+| Kimi K2.5 | `kimi-k2-5` | 200K | ✓ |
+| MiniMax | `minimax-m2-1`, `minimax-m2-5` | 200K | ✗ |
+| GLM 4.7 | `glm-4-7`, `glm-4-7-flash` | 128K | ✓ / ✗ |
+| Qwen3 Coder | `qwen3-coder-next`, `qwen3-coder-480b` | 256K / 128K | ✓ |
+| AGI Nova | `agi-nova-beta-1m` | 1M | ✓ |
+| Auto | `auto` | 200K | ✓ |
+
+All listed models are free to use through Kiro.
 
 ## Usage
 
 Once logged in, select any Kiro model in pi:
 
-```
+```text
 /model claude-sonnet-4-6
+```
+
+Or let Kiro pick automatically:
+
+```text
+/model auto
 ```
 
 Reasoning is automatically enabled for supported models. Use `/reasoning` to adjust the thinking budget.
@@ -73,7 +90,7 @@ This provider only keeps local recovery for Kiro-specific cases:
 ```bash
 npm run build       # Compile TypeScript
 npm run check       # Type check (no emit)
-npm test            # Run all 248 tests
+npm test            # Run the Vitest suite
 npm run test:watch  # Watch mode
 ```
 
@@ -84,7 +101,7 @@ The extension is organized as one feature per file:
 ```
 src/
 ├── index.ts            # Extension registration
-├── models.ts           # 17 model definitions + ID resolution
+├── models.ts           # 19 model definitions + ID resolution
 ├── oauth.ts            # Multi-provider auth (Builder ID / Google / GitHub)
 ├── kiro-cli.ts         # kiro-cli credential sharing
 ├── transform.ts        # Message format conversion

--- a/docs/launches/2026-04-16-twitter-launch.md
+++ b/docs/launches/2026-04-16-twitter-launch.md
@@ -1,0 +1,97 @@
+# pi-provider-kiro launch pack — 2026-04-16
+
+## Status snapshot
+
+Launch surface is close, but `main` is not currently launch-clean because the latest CI run fails during `npm ci`.
+
+This prep pass fixes that blocker locally by excluding `@mariozechner/pi-tui` from the release bundle, and refreshes the public docs so the README/package metadata match the current product surface.
+
+## Verified facts
+
+- npm package live: `pi-provider-kiro@0.5.1`
+- npm dist-tag: `latest -> 0.5.1`
+- latest GitHub release: `v0.5.1`
+- latest remote commit before this prep pass: `1f799cc feat(login): interactive login with all sign-in methods and native TUI (#41)`
+- latest CI run on `main` before this prep pass: failed in `npm ci` because `prepare` triggered an esbuild bundle that tried to inline `koffi` native binaries from `@mariozechner/pi-tui`
+- local validation after the fix: `npm run build`, `npm run check`, `npm run lint`, `npm test`, and `npm pack --dry-run`
+- current model surface: 19 models across 8 families/categories, including `minimax-m2-5` and `auto`
+
+## What changed in this prep pass
+
+- Fixed the build script so CI no longer tries to bundle `@mariozechner/pi-tui`
+- Updated README first-screen copy and quick start
+- Updated model table to reflect the live 19-model surface
+- Added `auto` and `minimax-m2-5` to public docs
+- Updated package description metadata
+- Added changelog notes for the unreleased launch-prep fixes
+
+## Remaining caveats / blockers
+
+- The fix still needs to be committed, pushed, and merged before the repo is truly launch-ready.
+- A fresh GitHub Actions green run on the fix branch should be treated as a hard pre-launch gate.
+- If you want to launch a new version rather than just the repo, cut a release only after the CI fix lands on `main`.
+
+## Recommended launch angle
+
+Position this as the cleanest way to use Kiro’s free model surface from pi:
+
+- free model menu with one install command
+- cleaner auth story than hand-rolled setup
+- region-aware filtering and Kiro-specific retry/stream handling
+- supports Builder ID, org SSO, Google, and GitHub sign-in
+
+## Primary post draft
+
+pi users: I shipped a Kiro provider that gives pi one clean bridge into Kiro’s free model surface.
+
+`pi-provider-kiro` gives you 19 models across Claude, Qwen, DeepSeek, GLM, Kimi, MiniMax, AGI Nova, and Auto — with Builder ID / org SSO / Google / GitHub login support and `kiro-cli` credential reuse.
+
+Install:
+```bash
+pi install npm:pi-provider-kiro
+```
+
+Then:
+```text
+/login kiro
+/model auto
+```
+
+Repo: https://github.com/mikeyobrien/pi-provider-kiro
+npm: https://www.npmjs.com/package/pi-provider-kiro
+
+## Optional thread draft
+
+1. Kiro has a surprisingly good free model surface, but pi needed a clean provider bridge.
+2. `pi-provider-kiro` handles auth, model resolution, region filtering, and streaming so it feels native inside pi.
+3. It supports Builder ID, org SSO, Google, GitHub, and can reuse `kiro-cli` credentials if you already have them.
+4. It now exposes 19 models, including `auto`, `minimax-m2-5`, Qwen3 Coder, and 1M-context options.
+5. Install with `pi install npm:pi-provider-kiro` and log in with `/login kiro`.
+
+## Demo order
+
+1. Fresh install with `pi install npm:pi-provider-kiro`
+2. `/login kiro`
+3. Choose a login method from the new interactive menu
+4. `/model auto`
+5. Show a second switch to a named model like `/model claude-sonnet-4-6`
+
+## Pre-flight checklist
+
+- [ ] Commit and push the launch-prep branch
+- [ ] Open PR and get CI green
+- [ ] Merge to `main`
+- [ ] Confirm latest `main` CI is green
+- [ ] If shipping a new package version, cut release + verify npm publish
+- [ ] Post launch thread with repo + npm links
+
+## Likely Q&A replies
+
+**Does this require Kiro CLI?**
+No for Builder ID. Google/GitHub social login delegates to `kiro-cli`, and existing `kiro-cli` credentials can be reused automatically.
+
+**Is this free?**
+The provider is MIT and the listed Kiro models are positioned here as free through Kiro.
+
+**What’s the easiest starting point?**
+`pi install npm:pi-provider-kiro`, then `/login kiro`, then `/model auto`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-provider-kiro",
   "version": "0.5.1",
-  "description": "pi extension for Kiro API (AWS CodeWhisperer/Q) — 18 models across 8 families with OAuth authentication",
+  "description": "pi extension for the Kiro API (AWS CodeWhisperer/Q) — 19 models across 8 families with OAuth authentication",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -21,7 +21,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && esbuild dist/index.js --bundle --platform=node --format=esm --outfile=dist/index.js --allow-overwrite --external:@mariozechner/pi-ai --external:@mariozechner/pi-coding-agent",
+    "build": "tsc && esbuild dist/index.js --bundle --platform=node --format=esm --outfile=dist/index.js --allow-overwrite --external:@mariozechner/pi-ai --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-tui",
     "check": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",


### PR DESCRIPTION
## Summary
- fix the CI/build blocker by excluding `@mariozechner/pi-tui` from the esbuild release bundle
- refresh the README and package metadata so the public surface matches the current 19-model login flow
- add a launch pack artifact with launch copy, checklist, and caveats

## Why this matters
The latest `main` CI run is failing during `npm ci` because `prepare` triggers a bundle that tries to inline `koffi` native binaries from `@mariozechner/pi-tui`. That leaves the repo in a bad state for a new launch.

This PR restores a greenable path and tightens the first-click surfaces at the same time.

## Test plan
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm pack --dry-run`
