### PR TITLE
chore(release): v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-04-16
+
 ### Fixed
 
 - Exclude `@mariozechner/pi-tui` from the release bundle so `npm ci` / CI builds stop trying to inline `koffi` native binaries during `prepare`
@@ -119,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: 17 models across 7 families, OAuth device code flow, kiro-cli SQLite credential fallback, streaming pipeline with thinking tag parser
 
-[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.1...v0.5.2
 [0.4.2]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.4.0...v0.4.1
 [0.5.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.0...v0.5.1

--- a/docs/launches/2026-04-16-twitter-launch.md
+++ b/docs/launches/2026-04-16-twitter-launch.md
@@ -2,34 +2,29 @@
 
 ## Status snapshot
 
-Launch surface is close, but `main` is not currently launch-clean because the latest CI run fails during `npm ci`.
-
-This prep pass fixes that blocker locally by excluding `@mariozechner/pi-tui` from the release bundle, and refreshes the public docs so the README/package metadata match the current product surface.
+`main` is launch-clean again and ready for a new package release. The CI/build blocker caused by bundling `@mariozechner/pi-tui` has been fixed on `main`, and this release prep branch cuts the next package version from that repaired state.
 
 ## Verified facts
 
-- npm package live: `pi-provider-kiro@0.5.1`
-- npm dist-tag: `latest -> 0.5.1`
-- latest GitHub release: `v0.5.1`
-- latest remote commit before this prep pass: `1f799cc feat(login): interactive login with all sign-in methods and native TUI (#41)`
-- latest CI run on `main` before this prep pass: failed in `npm ci` because `prepare` triggered an esbuild bundle that tried to inline `koffi` native binaries from `@mariozechner/pi-tui`
-- local validation after the fix: `npm run build`, `npm run check`, `npm run lint`, `npm test`, and `npm pack --dry-run`
+- npm package live before this release: `pi-provider-kiro@0.5.1`
+- npm dist-tag before this release: `latest -> 0.5.1`
+- current release candidate version: `0.5.2`
+- latest GitHub release before this release: `v0.5.1`
+- launch-readiness fix merged on `main`: PR `#49`, merge commit `1b0cfa0`
+- latest `main` CI after the fix: success (`24521221133`)
+- local release validation target: `npm ci`, `npm run build`, `npm run check`, `npm run lint`, `npm test`, and `npm pack --dry-run`
 - current model surface: 19 models across 8 families/categories, including `minimax-m2-5` and `auto`
 
-## What changed in this prep pass
+## What ships in v0.5.2
 
-- Fixed the build script so CI no longer tries to bundle `@mariozechner/pi-tui`
-- Updated README first-screen copy and quick start
-- Updated model table to reflect the live 19-model surface
-- Added `auto` and `minimax-m2-5` to public docs
-- Updated package description metadata
-- Added changelog notes for the unreleased launch-prep fixes
+- Fix the build so `npm ci` / CI no longer fail when `prepare` runs the bundle step
+- Keep `@mariozechner/pi-tui` external so native `koffi` binaries are not inlined into the release bundle
+- Ship the refreshed README/package metadata that now match the real 19-model login and model surface
 
 ## Remaining caveats / blockers
 
-- The fix still needs to be committed, pushed, and merged before the repo is truly launch-ready.
-- A fresh GitHub Actions green run on the fix branch should be treated as a hard pre-launch gate.
-- If you want to launch a new version rather than just the repo, cut a release only after the CI fix lands on `main`.
+- The release is not done until the `Publish` workflow triggered by `v0.5.2` finishes successfully.
+- npm registry verification after publish is a hard gate; do not treat the GitHub release alone as success.
 
 ## Recommended launch angle
 
@@ -78,11 +73,11 @@ npm: https://www.npmjs.com/package/pi-provider-kiro
 
 ## Pre-flight checklist
 
-- [ ] Commit and push the launch-prep branch
-- [ ] Open PR and get CI green
-- [ ] Merge to `main`
-- [ ] Confirm latest `main` CI is green
-- [ ] If shipping a new package version, cut release + verify npm publish
+- [x] Commit and push the launch-prep branch
+- [x] Open PR and get CI green
+- [x] Merge to `main`
+- [x] Confirm latest `main` CI is green
+- [ ] Cut `v0.5.2` release + verify npm publish
 - [ ] Post launch thread with repo + npm links
 
 ## Likely Q&A replies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-kiro",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "pi extension for the Kiro API (AWS CodeWhisperer/Q) — 19 models across 8 families with OAuth authentication",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `pi-provider-kiro` from `0.5.1` to `0.5.2`
- turn the current unreleased launch-readiness fixes into a real package release
- update the launch pack so it reflects the new release path and current repo state

## What ships in 0.5.2
- keep `@mariozechner/pi-tui` external in the esbuild bundle so `prepare` no longer breaks CI / `npm ci`
- ship the refreshed README and package metadata for the current 19-model surface

## Test plan
- [x] `npm ci`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm pack --dry-run`
