### PR TITLE
feat: add Claude Opus 4.7 model

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@
 
 // Valid Kiro model IDs - API accepts friendly names directly
 export const KIRO_MODEL_IDS = new Set([
+  "claude-opus-4.7",
   "claude-opus-4.6",
   "claude-opus-4.6-1m",
   "claude-sonnet-4.6",
@@ -69,6 +70,7 @@ export function resolveApiRegion(ssoRegion: string | undefined): string {
  */
 const MODELS_BY_REGION: Record<string, Set<string>> = {
   "us-east-1": new Set([
+    "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-opus-4-6-1m",
     "claude-sonnet-4-6",
@@ -91,6 +93,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
   ]),
   // API-verified 2026-04-14 (eu-west-1 IdC token)
   "eu-central-1": new Set([
+    "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
     "claude-opus-4-5",
@@ -121,6 +124,20 @@ const BASE_URL = "https://q.us-east-1.amazonaws.com/generateAssistantResponse";
 const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 
 export const kiroModels = [
+  // Claude Opus 4.7
+  {
+    id: "claude-opus-4-7",
+    name: "Claude Opus 4.7",
+    api: "kiro-api" as const,
+    provider: "kiro" as const,
+    baseUrl: BASE_URL,
+    reasoning: true,
+    input: ["text", "image"] as ("text" | "image")[],
+    cost: ZERO_COST,
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    firstTokenTimeout: 180_000,
+  },
   // Claude Opus 4.6
   {
     id: "claude-opus-4-6",

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,10 +1,21 @@
 // ABOUTME: Stream recovery helpers and Kiro-specific error classification.
 // ABOUTME: Keeps provider-local retry logic limited to auth refresh and stream quirks.
 
+import { kiroModels } from "./models.js";
+
 // kiro-cli uses 5-minute read/operation timeouts (DEFAULT_TIMEOUT_DURATION)
 // and 5-minute stalled stream grace period. 90s matches the TUI's
 // INITIAL_RESPONSE_TIMEOUT_MS for the first event from the backend.
 export const FIRST_TOKEN_TIMEOUT = 90_000;
+
+export function firstTokenTimeoutForModel(modelId: string): number {
+  // Allow test overrides via retryConfig.firstTokenTimeoutMs
+  if (retryConfig.firstTokenTimeoutMs !== FIRST_TOKEN_TIMEOUT) {
+    return retryConfig.firstTokenTimeoutMs;
+  }
+  const model = kiroModels.find((m) => m.id === modelId);
+  return model?.firstTokenTimeout ?? FIRST_TOKEN_TIMEOUT;
+}
 
 // Mutable config for values that tests need to override
 export const retryConfig = {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -25,6 +25,7 @@ import { resolveKiroModel } from "./models.js";
 import {
   capacityRetryConfig,
   exponentialBackoff,
+  firstTokenTimeoutForModel,
   isCapacityError,
   isNonRetryableBodyError,
   isTooBigError,
@@ -486,7 +487,7 @@ export function streamKiro(
             const result = await Promise.race([
               readPromise,
               new Promise<typeof FIRST_TOKEN_SENTINEL>((resolve) =>
-                setTimeout(() => resolve(FIRST_TOKEN_SENTINEL), retryConfig.firstTokenTimeoutMs),
+                setTimeout(() => resolve(FIRST_TOKEN_SENTINEL), firstTokenTimeoutForModel(model.id)),
               ),
             ]);
             if (result === FIRST_TOKEN_SENTINEL) {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -33,8 +33,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("KIRO_MODEL_IDS", () => {
-    it("contains 19 model IDs", () => {
-      expect(KIRO_MODEL_IDS.size).toBe(19);
+    it("contains 20 model IDs", () => {
+      expect(KIRO_MODEL_IDS.size).toBe(20);
     });
   });
 
@@ -75,8 +75,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("model catalog", () => {
-    it("defines 19 models", () => {
-      expect(kiroModels).toHaveLength(19);
+    it("defines 20 models", () => {
+      expect(kiroModels).toHaveLength(20);
     });
 
     it("claude-haiku-4-5 has reasoning=false", () => {
@@ -119,9 +119,9 @@ describe("Feature 2: Model Definitions", () => {
       expect(kiroModels.every((m) => m.cost.input === 0 && m.cost.output === 0)).toBe(true);
     });
 
-    it("opus models have 32K max tokens", () => {
+    it("opus models have expected max tokens", () => {
       const opusModels = kiroModels.filter((m) => m.id.includes("opus"));
-      expect(opusModels.every((m) => m.maxTokens === 32768)).toBe(true);
+      expect(opusModels.every((m) => m.maxTokens === 32768 || m.maxTokens === 128000)).toBe(true);
     });
 
     it("non-Claude models (except auto) have 8K max tokens", () => {

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -29,7 +29,7 @@ describe("Feature 1: Extension Registration", () => {
     mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
-    expect(config.models).toHaveLength(19);
+    expect(config.models).toHaveLength(20);
   });
 
   it("registers OAuth with name 'Kiro (Builder ID / Google / GitHub)'", async () => {


### PR DESCRIPTION
Adds Claude Opus 4.7 support, now available via `kiro-cli chat --list-models`.

## Changes
- Add `claude-opus-4.7` to `KIRO_MODEL_IDS` and `kiroModels`
- 1M context window, 128k max output, reasoning enabled, text+image input
- Available in `us-east-1` and `eu-central-1` regions
- Model-aware first-token timeout (180s) — Opus 4.7 is an experimental preview model with higher first-token latency; the default 90s caused timeouts with session history
- `firstTokenTimeout` is a new optional field on model definitions, defaulting to 90s when absent

## Testing
- All 279 unit tests pass
- Smoke-tested via `pi --provider kiro --model claude-opus-4-7 --print`
- Verified first-token latency can exceed 90s with session context (measured 99s)

## Source
- Confirmed available via `kiro-cli chat --list-models` (experimental preview, 2.20x credits)
- Specs from https://docs.anthropic.com/en/docs/about-claude/models