### PR TITLE
Add KIRO_DEBUG logging and refresh kiro-cli tokens on 403

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Debug logging — dumps requests, responses, stream events, and errors
+// ABOUTME: to a log file when KIRO_DEBUG=1. Custom path via KIRO_DEBUG_LOG.
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const ENABLED = !!process.env.KIRO_DEBUG && process.env.KIRO_DEBUG !== "0";
+const LOG_FILE = process.env.KIRO_DEBUG_LOG || join(homedir(), ".pi", "logs", "kiro-debug.log");
+
+let dirReady = false;
+
+export function debugEnabled(): boolean {
+  return ENABLED;
+}
+
+export function debugLog(section: string, data?: unknown): void {
+  if (!ENABLED) return;
+  try {
+    if (!dirReady) {
+      mkdirSync(dirname(LOG_FILE), { recursive: true });
+      dirReady = true;
+    }
+    const ts = new Date().toISOString();
+    const body =
+      data === undefined ? "" : typeof data === "string" ? ` ${data}` : ` ${JSON.stringify(data, redact, 2)}`;
+    appendFileSync(LOG_FILE, `${ts} [${section}]${body}\n`);
+  } catch {
+    // best-effort; never break the provider
+  }
+}
+
+/** Redact auth tokens in JSON output. */
+function redact(key: string, value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const k = key.toLowerCase();
+  if (k === "authorization" || k === "access" || k === "refresh" || k.includes("token") || k.includes("secret")) {
+    return value.length > 8 ? `${value.slice(0, 4)}…${value.slice(-4)}(${value.length})` : "<redacted>";
+  }
+  return value;
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -18,9 +18,10 @@ import type {
 } from "@mariozechner/pi-ai";
 import { calculateCost, createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { parseBracketToolCalls } from "./bracket-tool-parser.js";
+import { debugEnabled, debugLog } from "./debug.js";
 import { parseKiroEvents } from "./event-parser.js";
 import { addPlaceholderTools, HISTORY_LIMIT, HISTORY_LIMIT_CONTEXT_WINDOW, truncateHistory } from "./history.js";
-import { getKiroCliCredentials } from "./kiro-cli.js";
+import { getKiroCliCredentials, refreshViaKiroCli } from "./kiro-cli.js";
 import { resolveKiroModel } from "./models.js";
 import {
   capacityRetryConfig,
@@ -222,6 +223,19 @@ export function streamKiro(
       let profileArn = await resolveProfileArn(accessToken, endpoint);
       const kiroModelId = resolveKiroModel(model.id);
       const thinkingEnabled = !!options?.reasoning || model.reasoning;
+      debugLog("request.init", {
+        endpoint,
+        model: model.id,
+        kiroModelId,
+        contextWindow: model.contextWindow,
+        thinkingEnabled,
+        reasoning: options?.reasoning,
+        messageCount: context.messages.length,
+        toolCount: context.tools?.length ?? 0,
+        hasSystemPrompt: !!context.systemPrompt,
+        profileArn,
+        sessionId: options?.sessionId,
+      });
       let systemPrompt = context.systemPrompt ?? "";
       if (thinkingEnabled) {
         const budget =
@@ -380,6 +394,15 @@ export function streamKiro(
         while (true) {
           const mid = crypto.randomUUID().replace(/-/g, "");
           const ua = `aws-sdk-rust/1.0.0 ua/2.1 os/other lang/rust api/codewhispererstreaming#1.28.3 m/E app/AmazonQ-For-CLI md/appVersion-1.28.3-${mid}`;
+          debugLog("request.send", {
+            attempt: retryCount,
+            capacityAttempt: capacityRetryCount,
+            historyLen: history.length,
+            currentContentLen: currentContent.length,
+            hasImages: !!currentImages,
+            toolResultCount: currentToolResults.length,
+            request,
+          });
           response = await fetch(endpoint, {
             method: "POST",
             headers: {
@@ -404,6 +427,7 @@ export function streamKiro(
             } catch {
               errText = "";
             }
+            debugLog("response.error", { status: response.status, statusText: response.statusText, body: errText });
             // Retry transient capacity errors with longer backoff
             if (isCapacityError(errText) && capacityRetryCount < capacityRetryConfig.maxRetries) {
               capacityRetryCount++;
@@ -422,8 +446,9 @@ export function streamKiro(
             if (response.status === 403 && !isCapacityError(errText) && retryCount < maxRetries) {
               retryCount++;
               // On 403, try to get a fresh token before retrying — the current
-              // one may have been rotated by kiro-cli or another session.
-              const freshCreds = getKiroCliCredentials();
+              // one may have been rotated by kiro-cli or another session. If
+              // the cached kiro-cli token is also stale, actively refresh it.
+              const freshCreds = getKiroCliCredentials() ?? refreshViaKiroCli();
               if (freshCreds?.access) accessToken = freshCreds.access;
 
               // Re-resolve profileArn with fresh credentials
@@ -517,6 +542,7 @@ export function streamKiro(
           buffer += decoder.decode(value, { stream: true });
           const { events, remaining } = parseKiroEvents(buffer);
           buffer = remaining;
+          if (debugEnabled() && events.length > 0) debugLog("stream.events", events);
           // Reset idle timer on any bytes received — large tool call inputs
           // span many chunks that parse as zero events (incomplete JSON) but
           // the stream is still actively flowing.
@@ -720,12 +746,21 @@ export function streamKiro(
           output.stopReason = emittedToolCalls > 0 ? "toolUse" : "stop";
         }
         stream.push({ type: "done", reason: output.stopReason as "stop" | "toolUse", message: output });
+        debugLog("response.done", {
+          stopReason: output.stopReason,
+          emittedToolCalls,
+          sawAnyToolCalls,
+          textLen: textBlockIndex !== null ? (output.content[textBlockIndex] as TextContent).text.length : 0,
+          usage: output.usage,
+          content: output.content,
+        });
         stream.end();
         break;
       }
     } catch (error) {
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
       output.errorMessage = error instanceof Error ? error.message : String(error);
+      debugLog("response.caught", { stopReason: output.stopReason, error: output.errorMessage });
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }


### PR DESCRIPTION
## Summary

Two independent improvements:

### 1. `KIRO_DEBUG` logging

New env-gated debug logger (`src/debug.ts`) that dumps everything needed to diagnose streaming issues:

- `request.init` — endpoint, model, reasoning, message/tool counts, profileArn
- `request.send` — attempt counters, history length, full request body per attempt
- `response.error` — HTTP status + raw error body (4xx/5xx)
- `stream.events` — parsed Kiro stream events (content, toolUse, usage, contextUsage, error)
- `response.done` — stopReason, emitted tool-call count, text length, usage, content blocks
- `response.caught` — thrown errors

Auth tokens, refresh tokens, and anything matching `authorization`/`token`/`secret` are redacted (`abcd…wxyz(len)`).

**Usage:**

```bash
KIRO_DEBUG=1 pi chat
tail -f ~/.pi/logs/kiro-debug.log

# or custom path
KIRO_DEBUG=1 KIRO_DEBUG_LOG=/tmp/kiro.log pi chat
```

Disabled by default — zero cost when the env var isn't set.

### 2. Recover from expired kiro-cli tokens on 403

On `403 Forbidden` ("bearer token is invalid"), the retry handler previously called `getKiroCliCredentials()`, which returns `undefined` when the cached token is already expired. The result was silently reusing the same stale `accessToken` and exhausting all 3 retries.

Now falls back to `refreshViaKiroCli()`, which shells out to `kiro-cli debug refresh-auth-token` and re-reads the DB — the same mechanism kiro-cli itself uses.

**Why this matters:** Consumers like KermesAgent seed their own `auth.json` from kiro-cli's SQLite DB once at startup. When tokens rotate mid-session (another kiro-cli process refreshes, IDC invalidates the old token), those consumers hit 403s with no recovery path. The normal `pi` CLI doesn't hit this because it owns its own OAuth flow end-to-end.

## Test plan

- `npm test` — 291/291 tests pass
- `npm run check` — typecheck clean