### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-18
+
+### Added
+
+- `KIRO_DEBUG` env var for structured debug logging of requests, stream events, and responses with redacted auth tokens ([#57](https://github.com/mikeyobrien/pi-provider-kiro/pull/57))
+
+### Fixed
+
+- Recover from expired kiro-cli tokens on 403 by falling back to `refreshViaKiroCli()` instead of silently reusing the stale access token ([#57](https://github.com/mikeyobrien/pi-provider-kiro/pull/57))
+
 ## [0.6.0] - 2026-04-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-kiro",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "pi extension for the Kiro API (AWS CodeWhisperer/Q) — 19 models across 8 families with OAuth authentication",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Release v0.6.1 — `KIRO_DEBUG` logging + kiro-cli token refresh on 403.

See [CHANGELOG.md](https://github.com/mikeyobrien/pi-provider-kiro/blob/release/v0.6.1/CHANGELOG.md) for details.