### PR TITLE
fix(deps): declare pi-tui and esbuild as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@biomejs/biome": "2.4.2",
     "@mariozechner/pi-ai": "^0.53.0",
     "@mariozechner/pi-coding-agent": "^0.53.0",
+    "@mariozechner/pi-tui": "^0.53.0",
+    "esbuild": "^0.27.0",
     "js-tiktoken": "^1.0.21",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.53.0
         version: 0.53.1(ws@8.20.0)(zod@3.25.76)
+      '@mariozechner/pi-tui':
+        specifier: ^0.53.0
+        version: 0.53.1
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.7
       js-tiktoken:
         specifier: ^1.0.21
         version: 1.0.21


### PR DESCRIPTION
## Problem

`pnpm install` (and any strict package manager: pnpm, Yarn PnP, Bun isolated mode) fails the `prepare` script with:

```
> pi-provider-kiro@0.6.1 build
> tsc && esbuild dist/index.js ...

src/login-ui.ts:10:69 - error TS2307: Cannot find module '@mariozechner/pi-tui' or its corresponding type declarations.

10 import { Container, Input, type SelectItem, SelectList, Text } from "@mariozechner/pi-tui";
                                                                       ~~~~~~~~~~~~~~~~~~~~~~
```

If you work past that error, the next failure is `sh: line 1: esbuild: command not found`.

## Root cause

Two undeclared dependencies:

1. **`@mariozechner/pi-tui`** — imported by `src/login-ui.ts` (introduced in #41) but only present as a transitive dep of `@mariozechner/pi-coding-agent`.
2. **`esbuild`** — invoked by the `build` script but only reachable transitively via `vitest → vite → esbuild`.

npm's flat hoisting installs both at top-level `node_modules/`, so the build works accidentally. pnpm's strict install correctly refuses to expose undeclared transitive deps.

`pnpm why` confirms:

```
esbuild@0.27.7
└─┬ vite@7.3.2
  └─┬ vitest@3.2.4
    └── pi-provider-kiro@0.6.1 (devDependencies)
```

## Fix

Declare both explicitly in `devDependencies`:

```diff
   "devDependencies": {
     "@biomejs/biome": "2.4.2",
     "@mariozechner/pi-ai": "^0.53.0",
     "@mariozechner/pi-coding-agent": "^0.53.0",
+    "@mariozechner/pi-tui": "^0.53.0",
+    "esbuild": "^0.27.0",
     "js-tiktoken": "^1.0.21",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }
```

`pi-tui` version range matches the other `@mariozechner/*` deps. `esbuild` is pinned to the same major already being resolved transitively.

The `build` script already externalizes `@mariozechner/pi-tui`, so this change only affects dev-time resolution (type-check + build), not the shipped bundle.

## Verification

- `pnpm install` (clean, no `node_modules`) runs `prepare` → `build` end-to-end
- `pnpm run check` (tsc --noEmit) clean
- `pnpm run build` produces `dist/index.js` (5.4mb)
- `pnpm test` — 294/294 tests pass
