### PR TITLE
fix(stream): replace removed createAssistantMessageEventStream factory

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -16,7 +16,7 @@ import type {
   ToolCall,
   ToolResultMessage,
 } from "@mariozechner/pi-ai";
-import { calculateCost, createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import * as PiAi from "@mariozechner/pi-ai";
 import { parseBracketToolCalls } from "./bracket-tool-parser.js";
 import { debugEnabled, debugLog } from "./debug.js";
 import { parseKiroEvents } from "./event-parser.js";
@@ -196,7 +196,13 @@ export function streamKiro(
   context: Context,
   options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
-  const stream = createAssistantMessageEventStream();
+  // pi-ai's barrel re-exports the class as type-only before the runtime class re-export, so
+  // a named import of AssistantMessageEventStream resolves to a type. Read it from the
+  // namespace import to get the actual constructor. Replaces the removed
+  // createAssistantMessageEventStream() factory (gone in @oh-my-pi/pi-ai).
+  const StreamCtor = (PiAi as unknown as { AssistantMessageEventStream: new () => AssistantMessageEventStream })
+    .AssistantMessageEventStream;
+  const stream = new StreamCtor();
   (async () => {
     const output: AssistantMessage = {
       role: "assistant",
@@ -687,7 +693,7 @@ export function streamKiro(
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
         output.usage.totalTokens = output.usage.input + output.usage.output;
         try {
-          calculateCost(model, output.usage);
+          PiAi.calculateCost(model, output.usage);
         } catch {
           // Model might not have cost info, use zeros
           output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };


### PR DESCRIPTION
Closes #73.

## Summary

Switches `streamKiro` from the `createAssistantMessageEventStream()` factory to instantiating `AssistantMessageEventStream` directly. The factory is gone from `@oh-my-pi/pi-ai` (Oh My Pi's pi-ai fork), but the class itself is still exported by both `@mariozechner/pi-ai@^0.53.0` and `@oh-my-pi/pi-ai@^15`. No behavior change in Pi.

Uses a namespace import because pi-ai's barrel re-exports the symbol as type-only via `types.ts` before the runtime class re-export, so a named import resolves to a type at the package root. This is the same workaround OMP's own tests use.

## Test plan

- [x] `npm run check`
- [x] `npm test` (294 passing)
- [x] `npm run build`
- [x] Built `dist/index.js` loads under OMP without the export-not-found error and registers the kiro provider with all models
- [x] Built `dist/index.js` still loads under Pi