### PR TITLE
fix(stream): synthesize placeholder tools when context.tools is empty

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -372,15 +372,18 @@ export function streamKiro(
         if (wasPreviousResponseTruncated(context.messages)) {
           currentContent = `${TRUNCATION_NOTICE}\n\n${currentContent}`;
         }
+        // Always synthesize placeholder specs for tool names referenced in
+        // history, even when context.tools is empty/undefined. Without this,
+        // an "advisor-style" call that inherits a tool-rich conversation but
+        // declares no current tools is rejected by Kiro as "Improperly formed
+        // request" because history references toolUses with no tool catalog.
         let uimc: { toolResults?: KiroToolResult[]; tools?: KiroToolSpec[] } | undefined;
-        if (currentToolResults.length > 0 || (context.tools && context.tools.length > 0)) {
+        const baseTools = context.tools?.length ? convertToolsToKiro(context.tools) : [];
+        const finalTools = history.length > 0 ? addPlaceholderTools(baseTools, history) : baseTools;
+        if (currentToolResults.length > 0 || finalTools.length > 0) {
           uimc = {};
           if (currentToolResults.length > 0) uimc.toolResults = currentToolResults;
-          if (context.tools?.length) {
-            let kt = convertToolsToKiro(context.tools);
-            if (history.length > 0) kt = addPlaceholderTools(kt, history);
-            uimc.tools = kt;
-          }
+          if (finalTools.length > 0) uimc.tools = finalTools;
         }
         if (firstMsg?.role === "user") {
           const imgs = extractImages(firstMsg);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -749,6 +749,129 @@ describe("Feature 9: Streaming Integration", () => {
   });
 
   // =========================================================================
+  // Placeholder tools when context.tools is empty/undefined (advisor path)
+  // —————————————————————————————————————————————————————————————————————————
+  // When a caller passes no current tools (advisor strategy) but the inherited
+  // conversation references prior toolUses, Kiro rejects the request as
+  // "Improperly formed" unless those tool names are declared. The provider
+  // must synthesize placeholder specs in that case.
+  // =========================================================================
+
+  it("synthesizes placeholder tool specs when context.tools is [] but history references tools", async () => {
+    const assistantWithTool: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "tc1", name: "calc", arguments: { expr: "2+2" } }],
+      api: "kiro-api",
+      provider: "kiro",
+      model: "claude-sonnet-4-5",
+      usage: zeroUsage,
+      stopReason: "toolUse",
+      timestamp: ts,
+    };
+    const toolResult: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "tc1",
+      toolName: "calc",
+      content: [{ type: "text", text: "4" }],
+      isError: false,
+      timestamp: ts,
+    };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: "Calculate 2+2", timestamp: ts },
+        assistantWithTool,
+        toolResult,
+        { role: "user", content: "Now please advise on the situation above.", timestamp: ts },
+      ],
+      tools: [],
+    };
+
+    const mockFetch = mockFetchOk('{"content":"Sure."}{"contextUsagePercentage":3}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), context, { apiKey: "tok" });
+    await collect(stream);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const tools = body.conversationState.currentMessage.userInputMessage.userInputMessageContext?.tools as
+      | Array<{ toolSpecification: { name: string } }>
+      | undefined;
+    expect(tools).toBeDefined();
+    expect(tools?.map((t) => t.toolSpecification.name)).toContain("calc");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("synthesizes placeholder tool specs when context.tools is undefined but history references tools", async () => {
+    const assistantWithTool: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "tc1", name: "calc", arguments: { expr: "2+2" } }],
+      api: "kiro-api",
+      provider: "kiro",
+      model: "claude-sonnet-4-5",
+      usage: zeroUsage,
+      stopReason: "toolUse",
+      timestamp: ts,
+    };
+    const toolResult: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "tc1",
+      toolName: "calc",
+      content: [{ type: "text", text: "4" }],
+      isError: false,
+      timestamp: ts,
+    };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: "Calculate 2+2", timestamp: ts },
+        assistantWithTool,
+        toolResult,
+        { role: "user", content: "Now please advise on the situation above.", timestamp: ts },
+      ],
+      // tools intentionally omitted
+    };
+
+    const mockFetch = mockFetchOk('{"content":"Sure."}{"contextUsagePercentage":3}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), context, { apiKey: "tok" });
+    await collect(stream);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const tools = body.conversationState.currentMessage.userInputMessage.userInputMessageContext?.tools as
+      | Array<{ toolSpecification: { name: string } }>
+      | undefined;
+    expect(tools).toBeDefined();
+    expect(tools?.map((t) => t.toolSpecification.name)).toContain("calc");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("omits userInputMessageContext.tools when context.tools is [] and history has no tool uses", async () => {
+    // Plain user-only conversation with no current tools must not emit a tools
+    // array — preserves prior behavior for the genuinely tool-less case.
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [{ role: "user", content: "Hello", timestamp: ts }],
+      tools: [],
+    };
+
+    const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":1}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), context, { apiKey: "tok" });
+    await collect(stream);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const uimc = body.conversationState.currentMessage.userInputMessage.userInputMessageContext;
+    expect(uimc?.tools).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  // =========================================================================
   // Non-retryable errors (complement to retry test)
   // =========================================================================
 


### PR DESCRIPTION
Closes #75.

## Summary

Lifts `addPlaceholderTools` out of the `context.tools?.length` branch in `streamKiro` so placeholder specs are synthesized whenever the truncated history contains tool references, regardless of whether the caller passed any current tools.

## Root cause

`src/stream.ts` previously only ran `addPlaceholderTools` *inside* the `if (context.tools?.length)` branch:

```ts
if (context.tools?.length) {
  let kt = convertToolsToKiro(context.tools);
  if (history.length > 0) kt = addPlaceholderTools(kt, history);
  uimc.tools = kt;
}
```

So a caller passing `tools: []` (or omitting `tools`) on top of a tool-using conversation produced a payload whose `history` referenced toolUses with no `userInputMessageContext.tools` declaration. The Kiro backend rejects this as `400 "Improperly formed request"`. The advisor strategy in `@juicesharp/rpiv-advisor` hits it on every call because its no-tools contract is `tools: []`.

## Fix

```ts
const baseTools = context.tools?.length ? convertToolsToKiro(context.tools) : [];
const finalTools = history.length > 0 ? addPlaceholderTools(baseTools, history) : baseTools;
if (currentToolResults.length > 0 || finalTools.length > 0) {
  uimc = {};
  if (currentToolResults.length > 0) uimc.toolResults = currentToolResults;
  if (finalTools.length > 0) uimc.tools = finalTools;
}
```

This is a true superset of the previous behavior:
- `tools` non-empty + history without toolUses → unchanged.
- `tools` non-empty + history with toolUses → unchanged (placeholders still synthesized).
- `tools` empty/undefined + history without toolUses → unchanged (`addPlaceholderTools` returns input when historyNames is empty; `finalTools.length === 0` so `uimc.tools` stays unset).
- `tools` empty/undefined + history with toolUses → **fixed** (placeholders now emitted; request no longer rejected).

## Test plan

- Three regression tests added in `test/stream.test.ts`:
  - `synthesizes placeholder tool specs when context.tools is [] but history references tools` — primary advisor-shape case.
  - `synthesizes placeholder tool specs when context.tools is undefined but history references tools` — same fix for the omitted-`tools` path.
  - `omits userInputMessageContext.tools when context.tools is [] and history has no tool uses` — guards against over-emitting tools in the genuinely tool-less case.
- [x] `npm run check`
- [x] `npm run lint` (biome clean)
- [x] `npm test` (289 passing, was 286)
- [x] `npm run build`
- [x] Verified end-to-end: replaced installed `dist/index.js` with the built fork, reproduced the original failure on `main`, confirmed advisor calls succeed against `kiro:claude-opus-4-7` with the patch applied.