### PR TITLE
feat: add claude opus 4.8 model support

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -8,6 +8,7 @@ const CACHE_PATH = join(homedir(), ".kiro-models-cache.json");
 
 // Valid Kiro model IDs - API accepts friendly names directly
 export const KIRO_MODEL_IDS = new Set([
+  "claude-opus-4.8",
   "claude-opus-4.7",
   "claude-opus-4.6",
   "claude-sonnet-4.6",
@@ -214,6 +215,7 @@ export function resolveApiRegion(ssoRegion: string | undefined): string {
  */
 const MODELS_BY_REGION: Record<string, Set<string>> = {
   "us-east-1": new Set([
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
@@ -229,6 +231,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
   ]),
   // API-verified 2026-04-14 (eu-west-1 IdC token), glm-5 removed 2026-05-05 (us-east-1 only)
   "eu-central-1": new Set([
+    "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
@@ -259,7 +262,20 @@ const BASE_URL = "https://q.us-east-1.amazonaws.com/generateAssistantResponse";
 const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 
 export const kiroModels = [
-  // Claude Opus 4.7
+  {
+    id: "claude-opus-4-8",
+    name: "Claude Opus 4.8",
+    api: "kiro-api" as const,
+    provider: "kiro" as const,
+    baseUrl: BASE_URL,
+    reasoning: true,
+    thinkingLevelMap: { xhigh: "xhigh" },
+    input: ["text", "image"] as ("text" | "image")[],
+    cost: ZERO_COST,
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    firstTokenTimeout: 180_000,
+  },
   {
     id: "claude-opus-4-7",
     name: "Claude Opus 4.7",

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -5,6 +5,7 @@ describe("Feature 2: Model Definitions", () => {
   describe("resolveKiroModel", () => {
     it.each([
       // Claude models - dash to dot conversion
+      ["claude-opus-4-8", "claude-opus-4.8"],
       ["claude-opus-4-7", "claude-opus-4.7"],
       ["claude-opus-4-6", "claude-opus-4.6"],
       ["claude-sonnet-4-6", "claude-sonnet-4.6"],
@@ -26,8 +27,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("KIRO_MODEL_IDS", () => {
-    it("contains 12 model IDs", () => {
-      expect(KIRO_MODEL_IDS.size).toBe(12);
+    it("contains 13 model IDs", () => {
+      expect(KIRO_MODEL_IDS.size).toBe(13);
     });
   });
 
@@ -72,8 +73,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("model catalog", () => {
-    it("defines 12 models", () => {
-      expect(kiroModels).toHaveLength(12);
+    it("defines 13 models", () => {
+      expect(kiroModels).toHaveLength(13);
     });
 
     it("claude-haiku-4-5 has reasoning=false", () => {
@@ -136,7 +137,7 @@ describe("Feature 2: Model Definitions", () => {
       });
     }
 
-    const XHIGH_MODELS = ["claude-opus-4-7", "claude-opus-4-6"];
+    const XHIGH_MODELS = ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6"];
 
     it("Opus 4.7/4.6 models offer xhigh (and all other levels)", () => {
       for (const m of kiroModels.filter((x) => XHIGH_MODELS.includes(x.id))) {

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -29,7 +29,7 @@ describe("Feature 1: Extension Registration", () => {
     mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
-    expect(config.models).toHaveLength(12);
+    expect(config.models).toHaveLength(13);
   });
 
   it("registers OAuth with name 'Kiro (Builder ID / Google / GitHub)'", async () => {


### PR DESCRIPTION
Adds Claude Opus 4.8 to the model catalog.

## Changes
- Added `claude-opus-4.8` to `KIRO_MODEL_IDS`
- Added to both `us-east-1` and `eu-central-1` region sets
- Added model definition (1M context, 128k max tokens, reasoning + xhigh thinking, 180s first token timeout)
- Updated tests to reflect the new model count (12 → 13)