### PR TITLE
fix: replace text-based event parser with Smithy EventStreamMarshaller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
+        "@smithy/core": "^3.24.5",
         "esbuild": "^0.25.0",
         "js-tiktoken": "^1.0.21"
       },
@@ -25,7 +26,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -81,7 +81,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -420,7 +419,6 @@
       "version": "3.973.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
       "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.2",
@@ -2629,7 +2627,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3555,10 +3552,9 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
-      "dev": true,
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -3603,7 +3599,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3646,7 +3641,6 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
       "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3659,7 +3653,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -3673,7 +3666,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -4680,7 +4672,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5232,7 +5223,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typebox": {
@@ -5269,7 +5259,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6025,7 +6014,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "@smithy/core": "^3.24.5",
     "esbuild": "^0.25.0",
     "js-tiktoken": "^1.0.21"
   },

--- a/src/bracket-tool-parser.ts
+++ b/src/bracket-tool-parser.ts
@@ -1,7 +1,34 @@
 // ABOUTME: Extracts bracket-style tool calls from content text as a fallback.
 // ABOUTME: Parses [Called func_name with args: {...}] patterns from model output.
 
-import { findJsonEnd } from "./event-parser.js";
+export function findJsonEnd(text: string, start: number): number {
+  let braceCount = 0;
+  let inString = false;
+  let escapeNext = false;
+  for (let i = start; i < text.length; i++) {
+    const char = text[i];
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+    if (char === "\\") {
+      escapeNext = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (!inString) {
+      if (char === "{") braceCount++;
+      else if (char === "}") {
+        braceCount--;
+        if (braceCount === 0) return i;
+      }
+    }
+  }
+  return -1;
+}
 
 export interface BracketToolCall {
   toolUseId: string;

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Kiro stream event parsing for JSON-based streaming responses.
-// ABOUTME: Extracts typed events from raw buffered stream data.
+// ABOUTME: Kiro stream event type definitions and JSON-to-typed-event mapping.
+// ABOUTME: Binary framing is handled by @smithy/core EventStreamMarshaller in stream.ts.
 
 export type KiroStreamEvent =
   | { type: "content"; data: string }
@@ -10,35 +10,6 @@ export type KiroStreamEvent =
   | { type: "followupPrompt"; data: string }
   | { type: "usage"; data: { inputTokens?: number; outputTokens?: number } }
   | { type: "error"; data: { error: string; message?: string } };
-
-export function findJsonEnd(text: string, start: number): number {
-  let braceCount = 0;
-  let inString = false;
-  let escapeNext = false;
-  for (let i = start; i < text.length; i++) {
-    const char = text[i];
-    if (escapeNext) {
-      escapeNext = false;
-      continue;
-    }
-    if (char === "\\") {
-      escapeNext = true;
-      continue;
-    }
-    if (char === '"') {
-      inString = !inString;
-      continue;
-    }
-    if (!inString) {
-      if (char === "{") braceCount++;
-      else if (char === "}") {
-        braceCount--;
-        if (braceCount === 0) return i;
-      }
-    }
-  }
-  return -1;
-}
 
 export function parseKiroEvent(parsed: Record<string, unknown>): KiroStreamEvent | null {
   if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };
@@ -85,58 +56,4 @@ export function parseKiroEvent(parsed: Record<string, unknown>): KiroStreamEvent
     };
   }
   return null;
-}
-
-// Known JSON key patterns that start Kiro event objects. Using specific
-// patterns avoids matching stray '{"' sequences in the binary AWS Event
-// Stream framing that wraps each JSON payload.
-const EVENT_PATTERNS = [
-  '{"content":',
-  '{"name":',
-  '{"input":',
-  '{"stop":',
-  '{"contextUsagePercentage":',
-  '{"followupPrompt":',
-  '{"usage":',
-  '{"toolUseId":',
-  '{"unit":',
-  '{"error":',
-  '{"Error":',
-  '{"message":',
-];
-
-function findNextEventStart(buffer: string, from: number): number {
-  let earliest = -1;
-  for (const pattern of EVENT_PATTERNS) {
-    const idx = buffer.indexOf(pattern, from);
-    if (idx >= 0 && (earliest < 0 || idx < earliest)) earliest = idx;
-  }
-  return earliest;
-}
-
-export function parseKiroEvents(buffer: string): { events: KiroStreamEvent[]; remaining: string } {
-  const events: KiroStreamEvent[] = [];
-  let pos = 0;
-
-  while (pos < buffer.length) {
-    const jsonStart = findNextEventStart(buffer, pos);
-    if (jsonStart < 0) break;
-
-    const jsonEnd = findJsonEnd(buffer, jsonStart);
-    if (jsonEnd < 0) {
-      // Incomplete JSON at end of buffer — preserve for next call
-      return { events, remaining: buffer.substring(jsonStart) };
-    }
-
-    try {
-      const parsed = JSON.parse(buffer.substring(jsonStart, jsonEnd + 1));
-      const event = parseKiroEvent(parsed);
-      if (event) events.push(event);
-    } catch {
-      /* skip brace-balanced but non-JSON content */
-    }
-    pos = jsonEnd + 1;
-  }
-
-  return { events, remaining: "" };
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -17,9 +17,11 @@ import type {
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
 import * as PiAi from "@earendil-works/pi-ai";
+import { UniversalEventStreamMarshaller } from "@smithy/core/event-streams";
+import type { Message } from "@smithy/types";
 import { parseBracketToolCalls } from "./bracket-tool-parser.js";
 import { debugEnabled, debugLog } from "./debug.js";
-import { parseKiroEvents } from "./event-parser.js";
+import { parseKiroEvent } from "./event-parser.js";
 import { addPlaceholderTools, HISTORY_LIMIT, HISTORY_LIMIT_CONTEXT_WINDOW, truncateHistory } from "./history.js";
 import { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, refreshViaKiroCli } from "./kiro-cli.js";
 import { resolveKiroModel } from "./models.js";
@@ -54,6 +56,11 @@ import { TRUNCATION_NOTICE, wasPreviousResponseTruncated } from "./truncation.js
 
 const CAPACITY_LOG_DIR = join(homedir(), ".pi", "logs");
 const CAPACITY_LOG_FILE = join(CAPACITY_LOG_DIR, "capacity-retries.log");
+
+const eventStreamMarshaller = new UniversalEventStreamMarshaller({
+  utf8Encoder: (input: Uint8Array) => new TextDecoder().decode(input),
+  utf8Decoder: (input: string) => new TextEncoder().encode(input),
+});
 
 let capacityLogDirCreated = false;
 
@@ -504,10 +511,8 @@ export function streamKiro(
         // 403 retry: continue outer loop
         if (!response.ok) continue;
         stream.push({ type: "start", partial: output });
-        const reader = response.body?.getReader();
-        if (!reader) throw new Error("No response body");
-        const decoder = new TextDecoder();
-        let buffer = "";
+        if (!response.body) throw new Error("No response body");
+        const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
         let totalContent = "";
         let lastContentData = "";
         let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
@@ -524,119 +529,140 @@ export function streamKiro(
         };
         const IDLE_TIMEOUT = 300_000;
         let idleTimer: ReturnType<typeof setTimeout> | null = null;
+        let idleCancelled = false;
         const resetIdle = () => {
           if (idleTimer) clearTimeout(idleTimer);
           idleTimer = setTimeout(() => {
             idleCancelled = true;
-            void reader.cancel().catch(() => {});
+            void bodyReader.cancel().catch(() => {});
           }, IDLE_TIMEOUT);
         };
         let gotFirstToken = false;
         let firstTokenTimedOut = false;
-        let idleCancelled = false;
         let streamError: string | null = null;
         const FIRST_TOKEN_SENTINEL = Symbol("firstTokenTimeout");
+
+        // Smithy EventStreamMarshaller handles: chunk reassembly, CRC validation,
+        // protocol error/exception detection, and payload deserialization.
+        const bodyIterable: AsyncIterable<Uint8Array> = {
+          async *[Symbol.asyncIterator]() {
+            try {
+              while (true) {
+                const { done, value } = await bodyReader.read();
+                if (done) return;
+                yield value;
+              }
+            } finally {
+              bodyReader.releaseLock();
+            }
+          },
+        };
+        const utf8Decoder = new TextDecoder();
+        const eventStream = eventStreamMarshaller.deserialize(bodyIterable, async (event: Record<string, Message>) => {
+          const key = Object.keys(event)[0]!;
+          const msg = event[key]!;
+          const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
+          return { [key]: parsed } as Record<string, unknown>;
+        });
+        const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;
+
         while (true) {
-          let readResult: ReadableStreamReadResult<Uint8Array>;
-          if (!gotFirstToken) {
-            // First-token timeout: race the first read against a deadline.
-            // Keep a reference to the read promise so we can suppress its
-            // rejection if the timeout wins — otherwise an abort that fires
-            // after the race settles leaves a dangling rejected promise.
-            const readPromise = reader.read();
-            const result = await Promise.race([
-              readPromise,
-              new Promise<typeof FIRST_TOKEN_SENTINEL>((resolve) =>
-                setTimeout(() => resolve(FIRST_TOKEN_SENTINEL), firstTokenTimeoutForModel(model.id)),
-              ),
-            ]);
-            if (result === FIRST_TOKEN_SENTINEL) {
-              readPromise.catch(() => {}); // suppress dangling rejection
-              void reader.cancel().catch(() => {});
-              firstTokenTimedOut = true;
+          let iterResult: IteratorResult<Record<string, unknown>>;
+          try {
+            if (!gotFirstToken) {
+              const readPromise = iterator.next();
+              const result = await Promise.race([
+                readPromise,
+                new Promise<typeof FIRST_TOKEN_SENTINEL>((resolve) =>
+                  setTimeout(() => resolve(FIRST_TOKEN_SENTINEL), firstTokenTimeoutForModel(model.id)),
+                ),
+              ]);
+              if (result === FIRST_TOKEN_SENTINEL) {
+                readPromise.catch(() => {}); // suppress dangling rejection
+                void bodyReader.cancel().catch(() => {});
+                firstTokenTimedOut = true;
+                break;
+              }
+              iterResult = result as IteratorResult<Record<string, unknown>>;
+              gotFirstToken = true;
+              resetIdle();
+            } else {
+              iterResult = await iterator.next();
+            }
+          } catch (e) {
+            // Smithy throws on :message-type error/exception headers
+            streamError =
+              e instanceof Error
+                ? e.message
+                : (typeof e === "object" && e !== null ? JSON.stringify(e) : String(e)) || "Unknown stream error";
+            break;
+          }
+          const { done, value } = iterResult;
+          if (done) break;
+          resetIdle();
+          const eventPayload = Object.values(value as Record<string, unknown>)[0] as Record<string, unknown>;
+          const event = parseKiroEvent(eventPayload);
+          if (!event) continue;
+          if (debugEnabled()) debugLog("stream.events", [event]);
+          switch (event.type) {
+            case "contextUsage": {
+              const pct = event.data.contextUsagePercentage;
+              output.usage.input = Math.round((pct / 100) * model.contextWindow);
+              (output.usage as unknown as Record<string, unknown>).contextPercent = pct;
+              receivedContextUsage = true;
               break;
             }
-            readResult = result as ReadableStreamReadResult<Uint8Array>;
-            gotFirstToken = true;
-            resetIdle(); // Start idle timer after first token received
-          } else {
-            readResult = await reader.read();
-          }
-          const { done, value } = readResult;
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const { events, remaining } = parseKiroEvents(buffer);
-          buffer = remaining;
-          if (debugEnabled() && events.length > 0) debugLog("stream.events", events);
-          // Reset idle timer on any bytes received — large tool call inputs
-          // span many chunks that parse as zero events (incomplete JSON) but
-          // the stream is still actively flowing.
-          resetIdle();
-          for (const event of events) {
-            switch (event.type) {
-              case "contextUsage": {
-                const pct = event.data.contextUsagePercentage;
-                output.usage.input = Math.round((pct / 100) * model.contextWindow);
-                // Pass through the raw percentage so rho-web (and other UIs)
-                // can display it directly instead of back-calculating from
-                // input tokens / guessed context window — which breaks when
-                // the usage event later overwrites usage.input.
-                (output.usage as unknown as Record<string, unknown>).contextPercent = pct;
-                receivedContextUsage = true;
-                break;
-              }
-              case "content": {
-                if (event.data === lastContentData) continue;
-                lastContentData = event.data;
-                totalContent += event.data;
-                if (thinkingParser) {
-                  thinkingParser.processChunk(event.data);
-                } else {
-                  if (textBlockIndex === null) {
-                    textBlockIndex = output.content.length;
-                    output.content.push({ type: "text", text: "" });
-                    stream.push({ type: "text_start", contentIndex: textBlockIndex, partial: output });
-                  }
-                  (output.content[textBlockIndex] as TextContent).text += event.data;
-                  stream.push({ type: "text_delta", contentIndex: textBlockIndex, delta: event.data, partial: output });
+            case "content": {
+              if (event.data === lastContentData) continue;
+              lastContentData = event.data;
+              totalContent += event.data;
+              if (thinkingParser) {
+                thinkingParser.processChunk(event.data);
+              } else {
+                if (textBlockIndex === null) {
+                  textBlockIndex = output.content.length;
+                  output.content.push({ type: "text", text: "" });
+                  stream.push({ type: "text_start", contentIndex: textBlockIndex, partial: output });
                 }
-                break;
+                (output.content[textBlockIndex] as TextContent).text += event.data;
+                stream.push({ type: "text_delta", contentIndex: textBlockIndex, delta: event.data, partial: output });
               }
-              case "toolUse": {
-                const tc = event.data;
-                sawAnyToolCalls = true;
-                if (!currentToolCall || currentToolCall.toolUseId !== tc.toolUseId) {
-                  flushToolCall();
-                  currentToolCall = { toolUseId: tc.toolUseId, name: tc.name, input: "" };
-                }
-                currentToolCall.input += tc.input || "";
-                if (tc.input) totalContent += tc.input;
-                if (tc.stop) flushToolCall();
-                break;
-              }
-              case "toolUseInput": {
-                if (currentToolCall) currentToolCall.input += event.data.input || "";
-                if (event.data.input) totalContent += event.data.input;
-                break;
-              }
-              case "toolUseStop": {
-                if (event.data.stop) flushToolCall();
-                break;
-              }
-              case "usage": {
-                usageEvent = event.data;
-                break;
-              }
-              case "error": {
-                const errMsg = event.data.message ? `${event.data.error}: ${event.data.message}` : event.data.error;
-                streamError = errMsg;
-                void reader.cancel().catch(() => {});
-                break;
-              }
-              // followupPrompt events are intentionally ignored
+              break;
             }
-            if (streamError) break;
+            case "toolUse": {
+              const tc = event.data;
+              sawAnyToolCalls = true;
+              if (!currentToolCall || currentToolCall.toolUseId !== tc.toolUseId) {
+                flushToolCall();
+                currentToolCall = { toolUseId: tc.toolUseId, name: tc.name, input: "" };
+              }
+              currentToolCall.input += tc.input || "";
+              if (tc.input) totalContent += tc.input;
+              if (tc.stop) flushToolCall();
+              break;
+            }
+            case "toolUseInput": {
+              if (currentToolCall) currentToolCall.input += event.data.input || "";
+              if (event.data.input) totalContent += event.data.input;
+              break;
+            }
+            case "toolUseStop": {
+              if (event.data.stop) flushToolCall();
+              break;
+            }
+            case "usage": {
+              usageEvent = event.data;
+              break;
+            }
+            case "error": {
+              const errMsg = event.data.message ? `${event.data.error}: ${event.data.message}` : event.data.error;
+              streamError = errMsg;
+              void bodyReader.cancel().catch(() => {});
+              break;
+            }
+            // followupPrompt events are intentionally ignored
           }
+          if (streamError) break;
         }
         if (idleTimer) clearTimeout(idleTimer);
         if (firstTokenTimedOut || idleCancelled || streamError) {

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { findJsonEnd, parseKiroEvent, parseKiroEvents } from "../src/event-parser.js";
+import { findJsonEnd } from "../src/bracket-tool-parser.js";
+import { parseKiroEvent } from "../src/event-parser.js";
 
 describe("Feature 8: Stream Event Parsing", () => {
   describe("findJsonEnd", () => {
@@ -82,110 +83,6 @@ describe("Feature 8: Stream Event Parsing", () => {
       const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: { cmd: "ls" } });
       expect(e?.type).toBe("toolUse");
       expect(e?.type === "toolUse" && e.data.input).toBe('{"cmd":"ls"}');
-    });
-  });
-
-  describe("parseKiroEvents", () => {
-    it("parses single event", () => {
-      const { events, remaining } = parseKiroEvents('{"content":"hello"}');
-      expect(events).toHaveLength(1);
-      expect(events[0]).toEqual({ type: "content", data: "hello" });
-      expect(remaining).toBe("");
-    });
-
-    it("parses multiple events in one chunk", () => {
-      const { events } = parseKiroEvents('{"content":"a"}{"content":"b"}{"content":"c"}');
-      expect(events).toHaveLength(3);
-    });
-
-    it("returns remaining for incomplete JSON", () => {
-      const { events, remaining } = parseKiroEvents('{"content":"done"}{"content":"incomp');
-      expect(events).toHaveLength(1);
-      expect(remaining).toContain("incomp");
-    });
-
-    it("handles mixed event types", () => {
-      const buf = '{"content":"hi"}{"name":"bash","toolUseId":"t1","input":"{}"}{"contextUsagePercentage":50}';
-      const { events } = parseKiroEvents(buf);
-      expect(events.map((e) => e.type)).toEqual(["content", "toolUse", "contextUsage"]);
-    });
-
-    it("skips garbage between events", () => {
-      const { events } = parseKiroEvents('garbage{"content":"hi"}more');
-      expect(events).toHaveLength(1);
-    });
-
-    it("returns empty for empty buffer", () => {
-      const { events } = parseKiroEvents("");
-      expect(events).toHaveLength(0);
-    });
-
-    it("parses JSON events with keys in non-standard order", () => {
-      const buf = '{"toolUseId":"tc1","name":"write","input":"{\\"path\\":\\"f.txt\\"}","stop":true}';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(1);
-      expect(events[0].type).toBe("toolUse");
-      expect(events[0].type === "toolUse" && events[0].data.name).toBe("write");
-      expect(events[0].type === "toolUse" && events[0].data.toolUseId).toBe("tc1");
-    });
-
-    it("skips events where known key is not the first key", () => {
-      // Pattern-based search requires known keys to be first (matching Kiro API behavior)
-      const buf = '{"timestamp":123,"content":"hello"}';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(0);
-    });
-
-    it("parses stop event when toolUseId is the first key", () => {
-      const buf = '{"toolUseId":"tc1","stop":true}';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(1);
-      expect(events[0]).toEqual({ type: "toolUseStop", data: { stop: true } });
-    });
-
-    it("handles multiple events with standard key orders", () => {
-      const buf =
-        '{"content":"hi"}{"toolUseId":"tc1","name":"bash","input":"{}","stop":true}{"contextUsagePercentage":50}';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(3);
-      expect(events.map((e) => e.type)).toEqual(["content", "toolUse", "contextUsage"]);
-    });
-
-    it("parses followupPrompt event in stream", () => {
-      const buf = '{"content":"hi"}{"followupPrompt":"Next?"}{"contextUsagePercentage":10}';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(3);
-      expect(events[1]).toEqual({ type: "followupPrompt", data: "Next?" });
-    });
-
-    it("parses usage event in stream", () => {
-      const buf = '{"content":"hi"}{"usage":{"inputTokens":200,"outputTokens":80}}{"contextUsagePercentage":10}';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(3);
-      expect(events[1].type).toBe("usage");
-    });
-
-    it("followupPrompt and usage events don't interfere with other events", () => {
-      const buf = '{"followupPrompt":"Next?"}{"usage":{"inputTokens":1}}{"content":"hi"}';
-      const { events } = parseKiroEvents(buf);
-      expect(events.map((e) => e.type)).toEqual(["followupPrompt", "usage", "content"]);
-    });
-
-    it("ignores stray braces in binary stream framing", () => {
-      // Simulates Kiro's binary event framing which contains stray '{' before JSON
-      const buf = '\x00\x83{   \\9:event-type assistantResponseEvent{"content":"hello"}\x00\x84';
-      const { events, remaining } = parseKiroEvents(buf);
-      expect(events).toHaveLength(1);
-      expect(events[0]).toEqual({ type: "content", data: "hello" });
-      expect(remaining).toBe("");
-    });
-
-    it("handles multiple events with binary framing between them", () => {
-      const buf = '\x00{  framing{"content":"a"}\x00{  framing{"content":"b"}\x00';
-      const { events } = parseKiroEvents(buf);
-      expect(events).toHaveLength(2);
-      expect(events[0]).toEqual({ type: "content", data: "a" });
-      expect(events[1]).toEqual({ type: "content", data: "b" });
     });
   });
 });

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -1,0 +1,27 @@
+import { EventStreamCodec } from "@smithy/core/event-streams";
+
+const codec = new EventStreamCodec(
+  (input: Uint8Array) => new TextDecoder().decode(input),
+  (input: string) => new TextEncoder().encode(input),
+);
+
+export function encodeEventMessage(payload: object): Uint8Array {
+  return codec.encode({
+    headers: {
+      ":event-type": { type: "string", value: "assistantResponseEvent" },
+      ":message-type": { type: "string", value: "event" },
+    },
+    body: new TextEncoder().encode(JSON.stringify(payload)),
+  });
+}
+
+export function concatMessages(...msgs: Uint8Array[]): Uint8Array {
+  const total = msgs.reduce((sum, m) => sum + m.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const m of msgs) {
+    result.set(m, offset);
+    offset += m.length;
+  }
+  return result;
+}

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -9,9 +9,11 @@ import type {
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import type { KiroHistoryEntry } from "../src/transform.js";
+import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
 
 const ts = Date.now();
 const zeroUsage = {
@@ -58,16 +60,39 @@ async function collect(stream: ReturnType<typeof streamKiro>): Promise<Assistant
   return events;
 }
 
+/** Parse concatenated JSON objects from a string (e.g. '{"a":1}{"b":2}') into individual objects */
+function parseJsonObjects(body: string): object[] {
+  const objects: object[] = [];
+  let pos = 0;
+  while (pos < body.length) {
+    const start = body.indexOf("{", pos);
+    if (start < 0) break;
+    const end = findJsonEnd(body, start);
+    if (end < 0) break;
+    objects.push(JSON.parse(body.substring(start, end + 1)));
+    pos = end + 1;
+  }
+  return objects;
+}
+
+/** Encode a concatenated-JSON string into binary Event Stream frames */
+function encodeBody(body: string): Uint8Array {
+  return concatMessages(...parseJsonObjects(body).map((o) => encodeEventMessage(o)));
+}
+
 function mockFetchOk(body: string) {
+  const frames = encodeBody(body);
   return vi.fn().mockResolvedValueOnce({
     ok: true,
     body: {
       getReader: () => ({
         read: vi
           .fn()
-          .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(body) })
+          .mockResolvedValueOnce({ done: false, value: frames })
           .mockResolvedValueOnce({ done: true, value: undefined }),
+        releaseLock: () => {},
       }),
+      cancel: async () => {},
     },
   });
 }
@@ -75,12 +100,12 @@ function mockFetchOk(body: string) {
 function mockFetchChunked(chunks: string[]) {
   const readMock = vi.fn();
   for (const chunk of chunks) {
-    readMock.mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(chunk) });
+    readMock.mockResolvedValueOnce({ done: false, value: encodeBody(chunk) });
   }
   readMock.mockResolvedValueOnce({ done: true, value: undefined });
   return vi.fn().mockResolvedValueOnce({
     ok: true,
-    body: { getReader: () => ({ read: readMock }) },
+    body: { getReader: () => ({ read: readMock, releaseLock: () => {} }), cancel: async () => {} },
   });
 }
 
@@ -151,9 +176,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"Hi"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"Hi"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -422,7 +448,7 @@ describe("Feature 9: Streaming Integration", () => {
     const readMock = vi.fn().mockImplementation(async () => {
       readCount++;
       if (readCount === 1) {
-        return { done: false, value: new TextEncoder().encode('{"content":"chunk1"}') };
+        return { done: false, value: encodeBody('{"content":"chunk1"}') };
       }
       // Abort after first chunk
       ac.abort();
@@ -431,7 +457,7 @@ describe("Feature 9: Streaming Integration", () => {
     });
     const mockFetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      body: { getReader: () => ({ read: readMock }) },
+      body: { getReader: () => ({ read: readMock, releaseLock: () => {} }), cancel: async () => {} },
     });
     vi.stubGlobal("fetch", mockFetch);
 
@@ -821,9 +847,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -906,9 +933,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -1260,6 +1288,7 @@ describe("Feature 9: Streaming Integration", () => {
             getReader: () => ({
               read: () => new Promise(() => {}), // never resolves
               cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
             }),
           },
         };
@@ -1273,9 +1302,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       };
@@ -1321,6 +1351,7 @@ describe("Feature 9: Streaming Integration", () => {
           cancel: () => {
             return Promise.reject(cancelError);
           },
+          releaseLock: () => {},
         }),
       },
     });
@@ -1370,9 +1401,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -1406,9 +1438,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -1442,9 +1475,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -1490,9 +1524,10 @@ describe("Feature 9: Streaming Integration", () => {
               .fn()
               .mockResolvedValueOnce({
                 done: false,
-                value: new TextEncoder().encode('{"content":"ok"}{"contextUsagePercentage":5}'),
+                value: encodeBody('{"content":"ok"}{"contextUsagePercentage":5}'),
               })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -1832,8 +1867,9 @@ describe("Feature 9: Streaming Integration", () => {
           getReader: () => ({
             read: vi
               .fn()
-              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(emptyResponse) })
+              .mockResolvedValueOnce({ done: false, value: encodeBody(emptyResponse) })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       })
@@ -1843,8 +1879,9 @@ describe("Feature 9: Streaming Integration", () => {
           getReader: () => ({
             read: vi
               .fn()
-              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(goodResponse) })
+              .mockResolvedValueOnce({ done: false, value: encodeBody(goodResponse) })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -1878,8 +1915,9 @@ describe("Feature 9: Streaming Integration", () => {
         getReader: () => ({
           read: vi
             .fn()
-            .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(emptyResponse) })
+            .mockResolvedValueOnce({ done: false, value: encodeBody(emptyResponse) })
             .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
         }),
       },
     });
@@ -1957,8 +1995,9 @@ describe("Feature 9: Streaming Integration", () => {
         getReader: () => ({
           read: vi
             .fn()
-            .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(echoResponse) })
+            .mockResolvedValueOnce({ done: false, value: encodeBody(echoResponse) })
             .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
         }),
       },
     });
@@ -1971,8 +2010,9 @@ describe("Feature 9: Streaming Integration", () => {
           getReader: () => ({
             read: vi
               .fn()
-              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(goodResponse) })
+              .mockResolvedValueOnce({ done: false, value: encodeBody(goodResponse) })
               .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
           }),
         },
       });
@@ -2007,8 +2047,9 @@ describe("Feature 9: Streaming Integration", () => {
             getReader: () => ({
               read: vi
                 .fn()
-                .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(echoResponse) })
+                .mockResolvedValueOnce({ done: false, value: encodeBody(echoResponse) })
                 .mockResolvedValueOnce({ done: true, value: undefined }),
+              releaseLock: () => {},
             }),
           },
         })
@@ -2018,8 +2059,9 @@ describe("Feature 9: Streaming Integration", () => {
             getReader: () => ({
               read: vi
                 .fn()
-                .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(goodResponse) })
+                .mockResolvedValueOnce({ done: false, value: encodeBody(goodResponse) })
                 .mockResolvedValueOnce({ done: true, value: undefined }),
+              releaseLock: () => {},
             }),
           },
         });
@@ -2050,8 +2092,9 @@ describe("Feature 9: Streaming Integration", () => {
         getReader: () => ({
           read: vi
             .fn()
-            .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(echoResponse) })
+            .mockResolvedValueOnce({ done: false, value: encodeBody(echoResponse) })
             .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
         }),
       },
     });


### PR DESCRIPTION
see issue #77. AWS Kiro uses the `Amazon Event Stream` wire protocol, this is binary framed protocol with length and crc32 metadata on frames.

this commit replaces the current hand-rolled parser which ignores the binary framing with AWS's (imho well-maintained) open source implementation (@smithy/core/event-streams)

we already have transitive dev dependencies on this package via pi-ai

The current parser attempts to convert the binary frame to UTF-8 and pick over UTF-8 patterns - however this unreliable in under real network conditions and introduces a new class of bugs:

 1. Silent event loss - when a TCP chunk boundary lands inside a pattern prefix (e.g. splitting "type":"), `findNextEventStart` will fail to match and the event will be silently discarded. This is non-deterministic and depends entirely on how the network delivers chunks, making it hard to reproduce and nearly impossible to test reliably.
 2. Binary corruption - forcing binary-framed data through TextDecoder as UTF-8 is incorrect. The binary framing layer uses multi-byte length and CRC32 fields that are not valid UTF-8. This could produce garbled output, pattern matching failures or throw on certain invalid UTF-8 byte sequences

this commit replace the parser with UniversalEventStreamMarshaller from @smithy/core/event-streams (the same library AWS SDKs use to handle this protocol). It operates on raw binary chunks and correctly handles message boundary reassembly, so chunk-split events are never lost.

 the marshaller handles:
 - Binary message boundary reassembly (`getChunkedStream`)
 - CRC32 frame validation - malformed frames are caught at the protocol level rather than producing silent
   garbage
 - Protocol-level :exception and :error event detection
 - Correct payload extraction from binary framing headers
