### PR TITLE
fix: add named exports for downstream consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ import { loginKiro, refreshKiroToken } from "./oauth.js";
 import { streamKiro } from "./stream.js";
 import { fetchKiroUsage } from "./usage.js";
 
+export type { KiroStreamEvent } from "./event-parser.js";
+export { KIRO_MODEL_IDS, kiroModels, resolveApiRegion, resolveKiroModel } from "./models.js";
+export { streamKiro } from "./stream.js";
+
 export default function (pi: ExtensionAPI) {
   // Capture ctx for the custom TUI login component
   pi.on("session_start", async (_event, ctx) => {


### PR DESCRIPTION
## Summary

- Re-exports `kiroModels`, `KIRO_MODEL_IDS`, `resolveApiRegion`, `resolveKiroModel`, `streamKiro`, and `KiroStreamEvent` (type) from the package entry point
- Fixes regression introduced in v0.7.0 where the switch from `tsc + esbuild rebundle` to `esbuild from source` collapsed all modules into a single bundle with only `export default`

## Root cause

The v0.7.0 build change:
```
- "build": "tsc && esbuild dist/index.js --bundle ..."
+ "build": "esbuild src/index.ts --bundle ..."
```

eliminated the intermediate per-module `.js` files. Since `src/index.ts` only had `export default`, downstream consumers (e.g. KermesAgent) that imported `{ streamKiro, kiroModels, KIRO_MODEL_IDS }` got `undefined` for all named imports.

## Test plan

- [x] `npm run lint` -- biome clean
- [x] `npm run check` -- tsc clean
- [x] `npm run build` -- bundle exports verified via grep
- [x] `npm test` -- 287 passing
- [x] Verified `dist/index.js` export block contains all expected symbols