### PR TITLE
feat: add Claude Sonnet 5 model

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -11,6 +11,7 @@ export const KIRO_MODEL_IDS = new Set([
   "claude-opus-4.8",
   "claude-opus-4.7",
   "claude-opus-4.6",
+  "claude-sonnet-5",
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
   "claude-sonnet-4",
@@ -218,6 +219,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
+    "claude-sonnet-5",
     "claude-sonnet-4-6",
     "claude-sonnet-4-5",
     "claude-sonnet-4",
@@ -234,6 +236,7 @@ const MODELS_BY_REGION: Record<string, Set<string>> = {
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
+    "claude-sonnet-5",
     "claude-sonnet-4-6",
     "claude-sonnet-4-5",
     "claude-sonnet-4",
@@ -303,6 +306,19 @@ export const kiroModels = [
     cost: ZERO_COST,
     contextWindow: 1000000,
     maxTokens: 32768,
+  },
+  // Claude Sonnet 5
+  {
+    id: "claude-sonnet-5",
+    name: "Claude Sonnet 5",
+    api: "kiro-api" as const,
+    provider: "kiro" as const,
+    baseUrl: BASE_URL,
+    reasoning: true,
+    input: ["text", "image"] as ("text" | "image")[],
+    cost: ZERO_COST,
+    contextWindow: 1000000,
+    maxTokens: 65536,
   },
   // Claude Sonnet 4.6
   {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -8,6 +8,7 @@ describe("Feature 2: Model Definitions", () => {
       ["claude-opus-4-8", "claude-opus-4.8"],
       ["claude-opus-4-7", "claude-opus-4.7"],
       ["claude-opus-4-6", "claude-opus-4.6"],
+      ["claude-sonnet-5", "claude-sonnet-5"],
       ["claude-sonnet-4-6", "claude-sonnet-4.6"],
       ["claude-sonnet-4-5", "claude-sonnet-4.5"],
       ["claude-sonnet-4", "claude-sonnet-4"],
@@ -27,8 +28,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("KIRO_MODEL_IDS", () => {
-    it("contains 13 model IDs", () => {
-      expect(KIRO_MODEL_IDS.size).toBe(13);
+    it("contains 14 model IDs", () => {
+      expect(KIRO_MODEL_IDS.size).toBe(14);
     });
   });
 
@@ -73,8 +74,8 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("model catalog", () => {
-    it("defines 13 models", () => {
-      expect(kiroModels).toHaveLength(13);
+    it("defines 14 models", () => {
+      expect(kiroModels).toHaveLength(14);
     });
 
     it("claude-haiku-4-5 has reasoning=false", () => {

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -23,13 +23,13 @@ describe("Feature 1: Extension Registration", () => {
     expect(registerProvider.mock.calls[0][0]).toBe("kiro");
   });
 
-  it("registers 12 models", async () => {
+  it("registers 14 models", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
     mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
-    expect(config.models).toHaveLength(13);
+    expect(config.models).toHaveLength(14);
   });
 
   it("registers OAuth with name 'Kiro (Builder ID / Google / GitHub)'", async () => {


### PR DESCRIPTION
Adds Claude Sonnet 5 to the Kiro provider model catalog, following the same pattern as #83.

## Changes
- Added `claude-sonnet-5` to `KIRO_MODEL_IDS`
- Added `claude-sonnet-5` to both `us-east-1` and `eu-central-1` region allowlists
- Added full model definition (reasoning, text+image input, 1M context, 64K max tokens)
- Updated model and registration tests for the new model count (13 → 14)

## Verification
- `git diff --check`
- `npm install` (also ran the package `prepare` build)
- `npm run check`
- `npm test` — 15 test files passed, 276 tests passed

## AI disclosure
This pull request was generated by an AI assistant at the request of the repository contributor.

Model used: GPT-5.5 via Hermes Agent (`openai-codex` provider).