### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-20
+
+### Added
+
+- Claude Sonnet 5 and Claude Fable 5 models ([#87](https://github.com/mikeyobrien/pi-provider-kiro/pull/87), [#83](https://github.com/mikeyobrien/pi-provider-kiro/pull/83)).
+- Schema-driven reasoning effort, model token limits, and region-keyed catalog caching.
+
+### Changed
+
+- Migrated model discovery and inference to Kiro's management and runtime services, matching the current kiro-cli and kiro-agent REST protocols ([#91](https://github.com/mikeyobrien/pi-provider-kiro/pull/91)).
+
+### Fixed
+
+- Map pi's highest supported reasoning level to Kiro `max` for models whose catalog omits `xhigh`.
+
 ## [0.8.0] - 2026-05-29
 
 ### Added
@@ -167,7 +182,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: 17 models across 7 families, OAuth device code flow, kiro-cli SQLite credential fallback, streaming pipeline with thinking tag parser
 
-[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.5.2...v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-kiro",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@smithy/core": "^3.24.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "pi extension for the Kiro API (AWS CodeWhisperer/Q) — 12 kiro-cli-verified models with OAuth authentication",
   "type": "module",
   "license": "MIT",

--- a/src/management.ts
+++ b/src/management.ts
@@ -5,8 +5,8 @@ import { createHash } from "node:crypto";
 import { redactSensitiveText } from "./debug.js";
 import { getKiroEndpoints } from "./endpoints.js";
 
-const LIST_PROFILES_TARGET = "AmazonCodeWhispererService.ListAvailableProfiles";
-const LIST_MODELS_TARGET = "AmazonCodeWhispererService.ListAvailableModels";
+const LIST_PROFILES_PATH = "List-Available-Profiles";
+const LIST_MODELS_PATH = "List-Available-Models";
 
 export interface KiroManagementAuth {
   accessToken: string;
@@ -20,7 +20,7 @@ export interface KiroCatalogModel {
     maxOutputTokens?: number;
     [key: string]: unknown;
   };
-  additionalModelRequestFieldsSchema?: Record<string, unknown>;
+  additionalModelRequestFieldsSchema?: Record<string, unknown> | null;
   [key: string]: unknown;
 }
 
@@ -53,8 +53,38 @@ export class KiroManagementHttpError extends Error {
   }
 }
 
-function operationName(target: string): string {
-  return target.slice(target.lastIndexOf(".") + 1);
+async function requestManagement<TResponse>(
+  auth: KiroManagementAuth,
+  operation: string,
+  path: string,
+  method: "GET" | "POST",
+  body: Record<string, unknown>,
+): Promise<TResponse> {
+  const url = new URL(path, getKiroEndpoints(auth.region).management);
+  const request: RequestInit = {
+    method,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${auth.accessToken}`,
+    },
+  };
+  if (method === "GET") {
+    for (const [name, value] of Object.entries(body)) {
+      if (value !== undefined) url.searchParams.set(name, String(value));
+    }
+  } else {
+    request.headers = { ...request.headers, "Content-Type": "application/json" };
+    request.body = JSON.stringify(body);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), request);
+  } catch (error) {
+    throw new Error(`Kiro management ${operation} request failed in ${auth.region}`, { cause: error });
+  }
+
+  return parseManagementResponse<TResponse>(response, operation, auth.region);
 }
 
 function profileCacheKey(auth: KiroManagementAuth): string {
@@ -81,32 +111,6 @@ async function parseManagementResponse<TResponse>(
     throw new Error(`Kiro management ${operation} returned invalid JSON in ${region}`, { cause: error });
   }
 }
-
-async function postManagement<TResponse>(
-  auth: KiroManagementAuth,
-  target: string,
-  body: Record<string, unknown>,
-): Promise<TResponse> {
-  const operation = operationName(target);
-  let response: Response;
-  try {
-    response = await fetch(getKiroEndpoints(auth.region).management, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-amz-json-1.0",
-        Accept: "application/json",
-        Authorization: `Bearer ${auth.accessToken}`,
-        "X-Amz-Target": target,
-      },
-      body: JSON.stringify(body),
-    });
-  } catch (error) {
-    throw new Error(`Kiro management ${operation} request failed in ${auth.region}`, { cause: error });
-  }
-
-  return parseManagementResponse<TResponse>(response, operation, auth.region);
-}
-
 export function resetKiroProfileArnCache(): void {
   profileArnCache.clear();
   pendingProfileRequests.clear();
@@ -129,7 +133,13 @@ export async function resolveKiroProfileArn(auth: KiroManagementAuth, providedAr
   if (pending) return pending;
 
   const request = (async () => {
-    const response = await postManagement<KiroListAvailableProfilesResponse>(auth, LIST_PROFILES_TARGET, {});
+    const response = await requestManagement<KiroListAvailableProfilesResponse>(
+      auth,
+      "ListAvailableProfiles",
+      LIST_PROFILES_PATH,
+      "POST",
+      {},
+    );
     const arn = response.profiles?.find((profile) => profile.arn)?.arn;
     if (!arn) {
       throw new Error(`Kiro management ListAvailableProfiles returned no profile in ${auth.region}`);
@@ -150,10 +160,16 @@ export async function listAvailableModels(
   auth: KiroManagementAuth,
   profileArn: string,
 ): Promise<KiroListAvailableModelsResponse> {
-  const response = await postManagement<KiroListAvailableModelsResponse>(auth, LIST_MODELS_TARGET, {
-    origin: "KIRO_CLI",
-    profileArn,
-  });
+  const response = await requestManagement<KiroListAvailableModelsResponse>(
+    auth,
+    "ListAvailableModels",
+    LIST_MODELS_PATH,
+    "GET",
+    {
+      origin: "KIRO_CLI",
+      profileArn,
+    },
+  );
 
   if (!Array.isArray(response.models) || response.models.length === 0) {
     throw new Error(`Kiro management ListAvailableModels returned no models in ${auth.region}`);

--- a/src/models.ts
+++ b/src/models.ts
@@ -57,7 +57,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    thinkingLevelMap: { xhigh: "xhigh" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -72,7 +72,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    thinkingLevelMap: { xhigh: "xhigh" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -87,7 +87,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { max: "max" },
+    thinkingLevelMap: { xhigh: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -101,7 +101,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    thinkingLevelMap: { xhigh: "xhigh" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -115,7 +115,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { max: "max" },
+    thinkingLevelMap: { xhigh: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -168,7 +168,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    thinkingLevelMap: { xhigh: "xhigh" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -386,7 +386,7 @@ function deriveThinkingLevelMap(effortValues: readonly string[] | undefined): Th
   if (!effortValues) return undefined;
   const thinkingLevelMap: ThinkingLevelMap = {};
   if (effortValues.includes("xhigh")) thinkingLevelMap.xhigh = "xhigh";
-  if (effortValues.includes("max")) thinkingLevelMap.max = "max";
+  else if (effortValues.includes("max")) thinkingLevelMap.xhigh = "max";
   return Object.keys(thinkingLevelMap).length > 0 ? thinkingLevelMap : undefined;
 }
 
@@ -399,7 +399,8 @@ function validateCatalogMetadata(model: KiroCatalogModel): {
   schema?: Record<string, unknown>;
   tokenLimits?: KiroTokenLimits;
 } {
-  const schema = model.additionalModelRequestFieldsSchema;
+  const rawSchema = model.additionalModelRequestFieldsSchema;
+  const schema = rawSchema ?? undefined;
   if (schema !== undefined && !isRecord(schema)) {
     throw new Error(`Kiro management catalog model ${model.modelId} has an invalid request-fields schema`);
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -206,7 +206,7 @@ export function streamKiro(
         additionalModelRequestFieldsSchema?: Record<string, unknown>;
       };
       const region = modelMetadata.kiroRegion ?? getKiroRegionFromEndpoint(model.baseUrl) ?? "us-east-1";
-      const endpoint = getKiroEndpoints(region).runtime;
+      const endpoint = new URL("generateAssistantResponse", getKiroEndpoints(region).runtime).toString();
       let managementAuth: KiroManagementAuth = { accessToken, region };
 
       const optionProfileArn =
@@ -253,15 +253,13 @@ export function streamKiro(
       let systemPrompt = context.systemPrompt ?? "";
       if (thinkingEnabled && !effortConfig) {
         const budget =
-          options?.reasoning === "max"
-            ? 70000
-            : options?.reasoning === "xhigh"
-              ? 50000
-              : options?.reasoning === "high"
-                ? 30000
-                : options?.reasoning === "medium"
-                  ? 20000
-                  : 10000;
+          options?.reasoning === "xhigh"
+            ? 50000
+            : options?.reasoning === "high"
+              ? 30000
+              : options?.reasoning === "medium"
+                ? 20000
+                : 10000;
         systemPrompt = `<thinking_mode>enabled</thinking_mode><max_thinking_length>${budget}</max_thinking_length>${systemPrompt ? `\n${systemPrompt}` : ""}`;
       }
       let retryCount = 0;
@@ -427,10 +425,9 @@ export function streamKiro(
           response = await fetch(endpoint, {
             method: "POST",
             headers: {
-              "Content-Type": "application/x-amz-json-1.0",
-              Accept: "application/json",
+              "Content-Type": "application/json",
+              Accept: "application/vnd.amazon.eventstream",
               Authorization: `Bearer ${accessToken}`,
-              "X-Amz-Target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
               "x-amzn-codewhisperer-optout": "true",
               "amz-sdk-invocation-id": crypto.randomUUID(),
               "amz-sdk-request": "attempt=1; max=1",
@@ -569,8 +566,9 @@ export function streamKiro(
         };
         const utf8Decoder = new TextDecoder();
         const eventStream = eventStreamMarshaller.deserialize(bodyIterable, async (event: Record<string, Message>) => {
-          const key = Object.keys(event)[0]!;
-          const msg = event[key]!;
+          const entry = Object.entries(event)[0];
+          if (!entry) throw new Error("Received an empty event stream message");
+          const [key, msg] = entry;
           const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
           return { [key]: parsed } as Record<string, unknown>;
         });

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -27,9 +27,10 @@ describe("Kiro management control plane", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, request] = fetchMock.mock.calls[0];
-    expect(url).toBe("https://management.us-east-1.kiro.dev/");
+    expect(url).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
     expect(request.method).toBe("POST");
-    expect(request.headers["X-Amz-Target"]).toBe("AmazonCodeWhispererService.ListAvailableProfiles");
+    expect(request.headers["Content-Type"]).toBe("application/json");
+    expect(request.headers["X-Amz-Target"]).toBeUndefined();
     expect(JSON.parse(request.body)).toEqual({});
   });
 
@@ -57,11 +58,12 @@ describe("Kiro management control plane", () => {
 
     expect(catalog.models).toEqual([fable]);
     expect(catalog.defaultModelId).toBe("claude-fable-5");
-    const [url, request] = fetchMock.mock.calls[0];
-    expect(url).toBe("https://management.us-east-1.kiro.dev/");
-    expect(request.method).toBe("POST");
-    expect(request.headers["X-Amz-Target"]).toBe("AmazonCodeWhispererService.ListAvailableModels");
-    expect(JSON.parse(request.body)).toEqual({ origin: "KIRO_CLI", profileArn });
+    const [rawUrl, request] = fetchMock.mock.calls[0];
+    const url = new URL(rawUrl);
+    expect(`${url.origin}${url.pathname}`).toBe("https://management.us-east-1.kiro.dev/List-Available-Models");
+    expect(request.method).toBe("GET");
+    expect(request.headers["X-Amz-Target"]).toBeUndefined();
+    expect(Object.fromEntries(url.searchParams)).toEqual({ origin: "KIRO_CLI", profileArn });
   });
 
   it("surfaces a management failure without trying a fallback host", async () => {
@@ -77,6 +79,6 @@ describe("Kiro management control plane", () => {
     );
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/");
+    expect(fetchMock.mock.calls[0][0]).toContain("https://management.us-east-1.kiro.dev/List-Available-Models?");
   });
 });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -124,7 +124,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "claude-opus-4-8",
         kiroModelId: "claude-opus-4.8",
         reasoning: true,
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        thinkingLevelMap: { xhigh: "xhigh" },
         contextWindow: 900_000,
         maxTokens: 100_000,
       },
@@ -132,7 +132,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "claude-sonnet-4-6",
         kiroModelId: "claude-sonnet-4.6",
         reasoning: true,
-        thinkingLevelMap: { max: "max" },
+        thinkingLevelMap: { xhigh: "max" },
         contextWindow: 200_000,
         maxTokens: 8_192,
       },
@@ -147,7 +147,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "claude-fable-5",
         kiroModelId: "claude-fable-5",
         reasoning: true,
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        thinkingLevelMap: { xhigh: "xhigh" },
         contextWindow: 1_000_000,
         maxTokens: 128_000,
       },
@@ -161,6 +161,22 @@ describe("Feature 2: Model Definitions", () => {
       expect(opus?.additionalModelRequestFieldsSchema).toEqual(catalogFixture[1].additionalModelRequestFieldsSchema);
       expect(opus?.tokenLimits).toEqual(catalogFixture[1].tokenLimits);
       expect(opus?.contextWindow).not.toBe(kiroModels.find((model) => model.id === opus?.id)?.contextWindow);
+    });
+
+    it("treats a null schema as absent for auto", () => {
+      const [auto] = mapKiroCatalogModels([{ modelId: "auto", additionalModelRequestFieldsSchema: null }], TEST_REGION);
+
+      expect(auto).toMatchObject({ id: "auto", reasoning: true });
+      expect(auto.additionalModelRequestFieldsSchema).toBeUndefined();
+    });
+
+    it("rejects malformed non-null schemas", () => {
+      expect(() =>
+        mapKiroCatalogModels(
+          [{ modelId: "auto", additionalModelRequestFieldsSchema: "invalid" as never }],
+          TEST_REGION,
+        ),
+      ).toThrow("invalid request-fields schema");
     });
 
     it("preserves the exact service ID for request-time model resolution", () => {
@@ -264,29 +280,33 @@ describe("Feature 2: Model Definitions", () => {
 
   describe("thinkingLevelMap", () => {
     const THROUGH_HIGH = ["off", "minimal", "low", "medium", "high"] satisfies ModelThinkingLevel[];
-    const THROUGH_XHIGH_AND_MAX = [...THROUGH_HIGH, "xhigh", "max"] satisfies ModelThinkingLevel[];
-    const THROUGH_HIGH_AND_MAX = [...THROUGH_HIGH, "max"] satisfies ModelThinkingLevel[];
-    const XHIGH_AND_MAX_MODELS = ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"];
-    const MAX_WITHOUT_XHIGH_MODELS = ["claude-opus-4-6", "claude-sonnet-4-6"];
+    const THROUGH_XHIGH = [...THROUGH_HIGH, "xhigh"] satisfies ModelThinkingLevel[];
+    const XHIGH_MODELS = [
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-5",
+      "claude-sonnet-4-6",
+      "claude-fable-5",
+    ];
 
-    it("advertises xhigh and max only when both are mapped", () => {
-      for (const model of kiroModels.filter((candidate) => XHIGH_AND_MAX_MODELS.includes(candidate.id))) {
-        expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_XHIGH_AND_MAX);
+    it("advertises xhigh for models with xhigh or max effort", () => {
+      for (const model of kiroModels.filter((candidate) => XHIGH_MODELS.includes(candidate.id))) {
+        expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_XHIGH);
       }
     });
 
-    it("supports the max-without-xhigh hole", () => {
-      for (const model of kiroModels.filter((candidate) => MAX_WITHOUT_XHIGH_MODELS.includes(candidate.id))) {
-        expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_HIGH_AND_MAX);
+    it("maps xhigh to max when max is the model's highest effort", () => {
+      for (const model of kiroModels.filter((candidate) =>
+        ["claude-opus-4-6", "claude-sonnet-4-6"].includes(candidate.id),
+      )) {
+        expect(model.thinkingLevelMap?.xhigh).toBe("max");
       }
     });
 
     it("limits other reasoning models to standard levels", () => {
       for (const model of kiroModels.filter(
-        (candidate) =>
-          candidate.reasoning &&
-          !XHIGH_AND_MAX_MODELS.includes(candidate.id) &&
-          !MAX_WITHOUT_XHIGH_MODELS.includes(candidate.id),
+        (candidate) => candidate.reasoning && !XHIGH_MODELS.includes(candidate.id),
       )) {
         expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_HIGH);
       }

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -38,7 +38,7 @@ function makeModel(overrides?: Partial<TestKiroModel>): TestKiroModel {
     name: "Sonnet",
     api: "kiro-api",
     provider: "kiro",
-    baseUrl: "https://runtime.us-east-1.kiro.dev/",
+    baseUrl: "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -163,10 +163,10 @@ describe("Feature 9: Streaming Integration", () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, opts] = mockFetch.mock.calls[0];
-    expect(url).toBe("https://runtime.us-east-1.kiro.dev/");
+    expect(url).toBe("https://runtime.us-east-1.kiro.dev/generateAssistantResponse");
     expect(opts.method).toBe("POST");
     expect(opts.headers.Authorization).toBe("Bearer test-token");
-    expect(opts.headers["X-Amz-Target"]).toBe("AmazonCodeWhispererStreamingService.GenerateAssistantResponse");
+    expect(opts.headers["X-Amz-Target"]).toBeUndefined();
     expect(JSON.parse(opts.body).profileArn).toBeDefined();
 
     const done = events.find((e) => e.type === "done");
@@ -214,42 +214,19 @@ describe("Feature 9: Streaming Integration", () => {
         id: "claude-opus-4-8",
         kiroModelId: "claude-opus-4.8",
         name: "Claude Opus 4.8",
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        thinkingLevelMap: { xhigh: "xhigh" },
         additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "xhigh", "max"]),
       },
       reasoning: "xhigh" as const,
       expected: { output_config: { effort: "xhigh" }, thinking: { type: "adaptive" } },
     },
     {
-      name: "keeps Claude max distinct from xhigh",
-      model: {
-        id: "claude-opus-4-8",
-        kiroModelId: "claude-opus-4.8",
-        name: "Claude Opus 4.8",
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-        additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "xhigh", "max"]),
-      },
-      reasoning: "max" as const,
-      expected: { output_config: { effort: "max" }, thinking: { type: "adaptive" } },
-    },
-    {
-      name: "uses the known Claude max fallback only when schema is unavailable",
-      model: {
-        id: "claude-opus-4-8",
-        kiroModelId: "claude-opus-4.8",
-        name: "Claude Opus 4.8",
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-      },
-      reasoning: "max" as const,
-      expected: { output_config: { effort: "max" }, thinking: { type: "adaptive" } },
-    },
-    {
-      name: "clamps the xhigh hole to max before building Claude fields",
+      name: "maps Pi xhigh to Kiro max when xhigh is unavailable",
       model: {
         id: "claude-sonnet-4-6",
         kiroModelId: "claude-sonnet-4.6",
         name: "Claude Sonnet 4.6",
-        thinkingLevelMap: { max: "max" },
+        thinkingLevelMap: { xhigh: "max" },
         additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "max"]),
       },
       reasoning: "xhigh" as const,
@@ -276,12 +253,12 @@ describe("Feature 9: Streaming Integration", () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":10}');
     vi.stubGlobal("fetch", mockFetch);
 
-    await collect(streamKiro(makeModel(), makeContext(), { apiKey: "test-token", reasoning: "max" }));
+    await collect(streamKiro(makeModel(), makeContext(), { apiKey: "test-token", reasoning: "xhigh" }));
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.additionalModelRequestFields).toBeUndefined();
     expect(body.conversationState.currentMessage.userInputMessage.content).toContain(
-      "<max_thinking_length>70000</max_thinking_length>",
+      "<max_thinking_length>50000</max_thinking_length>",
     );
 
     vi.unstubAllGlobals();
@@ -297,7 +274,7 @@ describe("Feature 9: Streaming Integration", () => {
           id: "claude-opus-4-8",
           kiroModelId: "claude-opus-4.8",
           name: "Claude Opus 4.8",
-          thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+          thinkingLevelMap: { xhigh: "xhigh" },
           additionalModelRequestFieldsSchema: { type: "object", properties: {}, additionalProperties: false },
         }),
         makeContext(),
@@ -347,8 +324,8 @@ describe("Feature 9: Streaming Integration", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     // First call is ListAvailableProfiles on the management host.
-    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/");
-    expect(mockFetch.mock.calls[0][1].headers["X-Amz-Target"]).toBe("AmazonCodeWhispererService.ListAvailableProfiles");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(mockFetch.mock.calls[0][1].headers["X-Amz-Target"]).toBeUndefined();
     // Second call includes profileArn in the body
     const body = JSON.parse(mockFetch.mock.calls[1][1].body);
     expect(body.profileArn).toBe(testArn);
@@ -378,7 +355,7 @@ describe("Feature 9: Streaming Integration", () => {
     );
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    expect(mockFetch.mock.calls[0][0]).toBe("https://runtime.us-east-1.kiro.dev/");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://runtime.us-east-1.kiro.dev/generateAssistantResponse");
     expect(JSON.parse(mockFetch.mock.calls[0][1].body).profileArn).toBe(profileArn);
     expect(events.find((event) => event.type === "done")).toBeDefined();
 
@@ -396,7 +373,7 @@ describe("Feature 9: Streaming Integration", () => {
     const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
     const error = events.find((event) => event.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("returned no profile");
 
@@ -415,7 +392,7 @@ describe("Feature 9: Streaming Integration", () => {
     const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
     const error = events.find((event) => event.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("ListAvailableProfiles failed");
 
@@ -451,8 +428,8 @@ describe("Feature 9: Streaming Integration", () => {
 
     const events = await collect(streamKiro(makeModel({ baseUrl: endpoint }), makeContext(), { apiKey: "tok" }));
 
-    expect(mockFetch.mock.calls[0][0]).toBe("https://management.eu-central-1.kiro.dev/");
-    expect(mockFetch.mock.calls[1][0]).toBe(endpoint);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.eu-central-1.kiro.dev/List-Available-Profiles");
+    expect(mockFetch.mock.calls[1][0]).toBe(`${endpoint}generateAssistantResponse`);
     expect(events.find((event) => event.type === "done")).toBeDefined();
 
     vi.unstubAllGlobals();
@@ -1929,9 +1906,9 @@ describe("Feature 9: Streaming Integration", () => {
     expect(refreshSpy).toHaveBeenCalledOnce();
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(mockFetch.mock.calls.map(([url]) => url)).toEqual([
-      "https://runtime.us-east-1.kiro.dev/",
-      "https://management.us-east-1.kiro.dev/",
-      "https://runtime.us-east-1.kiro.dev/",
+      "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+      "https://management.us-east-1.kiro.dev/List-Available-Profiles",
+      "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
     ]);
     expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer stale-token");
     expect(JSON.parse(mockFetch.mock.calls[0][1].body).profileArn).toBe(staleProfileArn);
@@ -2000,8 +1977,8 @@ describe("Feature 9: Streaming Integration", () => {
     expect(refreshSpy).toHaveBeenCalledOnce();
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch.mock.calls.map(([url]) => url)).toEqual([
-      "https://runtime.us-east-1.kiro.dev/",
-      "https://runtime.us-east-1.kiro.dev/",
+      "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+      "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
     ]);
     expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer fresh-social-token");
     expect(JSON.parse(mockFetch.mock.calls[1][1].body).profileArn).toBe(socialProfileArn);
@@ -2054,12 +2031,12 @@ describe("Feature 9: Streaming Integration", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
     // 1st: ListAvailableProfiles with stale token on management.
-    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
     expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer stale-token");
     // 2nd: generateAssistantResponse with stale token → 403
     expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer stale-token");
     // 3rd: ListAvailableProfiles fails with the fresh token on management.
-    expect(mockFetch.mock.calls[2][0]).toBe("https://management.us-east-1.kiro.dev/");
+    expect(mockFetch.mock.calls[2][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
     expect(mockFetch.mock.calls[2][1].headers.Authorization).toBe("Bearer fresh-access-token");
     const error = events.find((event) => event.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("ListAvailableProfiles failed");

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -143,8 +143,8 @@ describe("fetchKiroUsage", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expectUsageRequest(fetchMock.mock.calls[0][0]);
-    expect(fetchMock.mock.calls[1][0]).toBe("https://management.us-east-1.kiro.dev/");
-    expect(fetchMock.mock.calls[1][1].headers["X-Amz-Target"]).toBe("AmazonCodeWhispererService.ListAvailableProfiles");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(fetchMock.mock.calls[1][1].headers["X-Amz-Target"]).toBeUndefined();
     expectUsageRequest(fetchMock.mock.calls[2][0], profileArn);
   });
 


### PR DESCRIPTION
## Summary

- release Claude Sonnet 5 and Claude Fable 5
- migrate discovery and inference to Kiro management/runtime REST services
- add schema-driven effort and token-limit metadata
- map pi `xhigh` to Kiro `max` where required
- accept the live catalog's nullable `additionalModelRequestFieldsSchema` for `auto`

## Validation

- `npm run check`
- `npm run lint`
- `npm test` — 296 passed
- `npm run build`
- `npm pack --dry-run`
- live pi smoke: `claude-haiku-4-5`
- live pi smoke: `claude-fable-5` with high thinking
- live pi smoke: `gpt-5-6-sol` with high thinking
- audited against `~/Code/kiro-cli` and `../kiro-agent` generated REST protocols

After merge, publish GitHub release `v0.9.0` to trigger npm provenance publishing.