### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-22
+
+### Fixed
+
+- Restore user-visible Claude thinking output after the Kiro runtime migration by retaining structured adaptive effort while also sending the thinking markers required by the runtime ([#95](https://github.com/mikeyobrien/pi-provider-kiro/pull/95)).
+
 ## [0.9.0] - 2026-07-20
 
 ### Added
@@ -182,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: 17 models across 7 families, OAuth device code flow, kiro-cli SQLite credential fallback, streaming pipeline with thinking tag parser
 
-[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/mikeyobrien/pi-provider-kiro/compare/v0.7.0...v0.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-kiro",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@smithy/core": "^3.24.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-kiro",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "pi extension for the Kiro API (AWS CodeWhisperer/Q) — 12 kiro-cli-verified models with OAuth authentication",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- release the Claude thinking-output regression fix from #95
- bump package metadata to `0.9.1`
- document the fix and update changelog comparison links

## Validation

- `npm run check`
- `npm run lint`
- `npm test` — 297 passed
- `npm run build`
- `npm pack --dry-run`
- live Claude Sonnet 4.6 runtime smoke completed while developing #95

After merge, publishing GitHub release `v0.9.1` will trigger npm provenance publishing.
