### PR TITLE
fix(stream): expose native adaptive Claude thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore visible summarized thinking for Claude Sonnet 5, Opus 4.8, and other adaptive-thinking models by requesting and parsing Kiro's native thinking stream events.
+
 ## [0.9.1] - 2026-07-22
 
 ### Fixed

--- a/src/effort.ts
+++ b/src/effort.ts
@@ -7,11 +7,15 @@ export type KiroEffortField = "reasoning" | "output_config";
 export interface KiroEffortConfig {
   field: KiroEffortField;
   values: readonly string[];
+  summarizedThinking: boolean;
 }
 
 export type KiroAdditionalModelRequestFields =
   | { reasoning: { effort: string } }
-  | { output_config: { effort: string }; thinking: { type: "adaptive" } };
+  | {
+      output_config: { effort: string };
+      thinking: { type: "adaptive"; display?: "summarized" };
+    };
 
 type ModelWithKiroEffortMetadata = Model<Api> & {
   additionalModelRequestFieldsSchema?: unknown;
@@ -51,7 +55,13 @@ export function deriveKiroEffort(schema: unknown): KiroEffortConfig | undefined 
     if (!isRecord(effortSchema) || !Array.isArray(effortSchema.enum) || effortSchema.enum.length === 0) continue;
     if (!effortSchema.enum.every((value) => typeof value === "string" && value.length > 0)) continue;
 
-    return { field, values: [...new Set(effortSchema.enum as string[])] };
+    const thinkingSchema = schema.properties.thinking;
+    const displaySchema =
+      isRecord(thinkingSchema) && isRecord(thinkingSchema.properties) ? thinkingSchema.properties.display : undefined;
+    const summarizedThinking =
+      isRecord(displaySchema) && Array.isArray(displaySchema.enum) && displaySchema.enum.includes("summarized");
+
+    return { field, values: [...new Set(effortSchema.enum as string[])], summarizedThinking };
   }
 
   return undefined;
@@ -61,13 +71,13 @@ export function deriveKiroEffort(schema: unknown): KiroEffortConfig | undefined 
 export function fallbackKiroEffort(kiroModelId: string): KiroEffortConfig | undefined {
   const normalizedId = kiroModelId.toLowerCase().replace(/(\d)-(\d)/g, "$1.$2");
   if (normalizedId.startsWith("openai-gpt")) {
-    return { field: "reasoning", values: GPT_EFFORT_VALUES };
+    return { field: "reasoning", values: GPT_EFFORT_VALUES, summarizedThinking: false };
   }
   if (CLAUDE_EXTENDED_EFFORT_MODELS.has(normalizedId)) {
-    return { field: "output_config", values: CLAUDE_EXTENDED_EFFORT_VALUES };
+    return { field: "output_config", values: CLAUDE_EXTENDED_EFFORT_VALUES, summarizedThinking: true };
   }
   if (CLAUDE_MAX_EFFORT_MODELS.has(normalizedId)) {
-    return { field: "output_config", values: CLAUDE_MAX_EFFORT_VALUES };
+    return { field: "output_config", values: CLAUDE_MAX_EFFORT_VALUES, summarizedThinking: false };
   }
   return undefined;
 }
@@ -131,6 +141,12 @@ export function buildKiroAdditionalModelRequestFields(
   if (!effort) return undefined;
 
   return config.field === "output_config"
-    ? { output_config: { effort }, thinking: { type: "adaptive" } }
+    ? {
+        output_config: { effort },
+        thinking: {
+          type: "adaptive",
+          ...(config.summarizedThinking ? { display: "summarized" as const } : {}),
+        },
+      }
     : { reasoning: { effort } };
 }

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -3,6 +3,8 @@
 
 export type KiroStreamEvent =
   | { type: "content"; data: string }
+  | { type: "thinkingText"; data: string }
+  | { type: "thinkingSignature"; data: string }
   | { type: "toolUse"; data: { name: string; toolUseId: string; input: string; stop?: boolean } }
   | { type: "toolUseInput"; data: { input: string } }
   | { type: "toolUseStop"; data: { stop: boolean } }
@@ -13,6 +15,8 @@ export type KiroStreamEvent =
 
 export function parseKiroEvent(parsed: Record<string, unknown>): KiroStreamEvent | null {
   if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };
+  if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
+  if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
   if (parsed.name && parsed.toolUseId) {
     const input =
       typeof parsed.input === "string"

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -13,6 +13,7 @@ import type {
   Model,
   SimpleStreamOptions,
   TextContent,
+  ThinkingContent,
   ToolCall,
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
@@ -529,6 +530,30 @@ export function streamKiro(
         let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
+        let nativeThinkingBlockIndex: number | null = null;
+        let nativeThinkingEnded = false;
+        const ensureNativeThinkingBlock = (): { block: ThinkingContent; contentIndex: number } => {
+          if (nativeThinkingBlockIndex === null) {
+            nativeThinkingBlockIndex = output.content.length;
+            output.content.push({ type: "thinking", thinking: "" });
+            stream.push({ type: "thinking_start", contentIndex: nativeThinkingBlockIndex, partial: output });
+          }
+          return {
+            block: output.content[nativeThinkingBlockIndex] as ThinkingContent,
+            contentIndex: nativeThinkingBlockIndex,
+          };
+        };
+        const endNativeThinking = () => {
+          if (nativeThinkingBlockIndex === null || nativeThinkingEnded) return;
+          nativeThinkingEnded = true;
+          const block = output.content[nativeThinkingBlockIndex] as ThinkingContent;
+          stream.push({
+            type: "thinking_end",
+            contentIndex: nativeThinkingBlockIndex,
+            content: block.thinking,
+            partial: output,
+          });
+        };
         let textBlockIndex: number | null = null;
         let emittedToolCalls = 0;
         let sawAnyToolCalls = false;
@@ -624,7 +649,28 @@ export function streamKiro(
               receivedContextUsage = true;
               break;
             }
+            case "thinkingText": {
+              if (!thinkingEnabled) break;
+              const { block, contentIndex } = ensureNativeThinkingBlock();
+              block.thinking += event.data;
+              totalContent += event.data;
+              stream.push({
+                type: "thinking_delta",
+                contentIndex,
+                delta: event.data,
+                partial: output,
+              });
+              break;
+            }
+            case "thinkingSignature": {
+              if (!thinkingEnabled) break;
+              const { block } = ensureNativeThinkingBlock();
+              block.thinkingSignature = event.data;
+              endNativeThinking();
+              break;
+            }
             case "content": {
+              endNativeThinking();
               if (event.data === lastContentData) continue;
               lastContentData = event.data;
               totalContent += event.data;
@@ -693,6 +739,7 @@ export function streamKiro(
         if (currentToolCall && emitToolCall(currentToolCall, output, stream)) {
           emittedToolCalls++;
         }
+        endNativeThinking();
         if (thinkingParser) {
           thinkingParser.finalize();
           textBlockIndex = thinkingParser.getTextBlockIndex();

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -30,6 +30,20 @@ describe("Feature 8: Stream Event Parsing", () => {
       expect(parseKiroEvent({ content: "Hello " })).toEqual({ type: "content", data: "Hello " });
     });
 
+    it("parses summarized thinking text", () => {
+      expect(parseKiroEvent({ text: "Considering options" })).toEqual({
+        type: "thinkingText",
+        data: "Considering options",
+      });
+    });
+
+    it("parses summarized thinking signature", () => {
+      expect(parseKiroEvent({ signature: "opaque-signature" })).toEqual({
+        type: "thinkingSignature",
+        data: "opaque-signature",
+      });
+    });
+
     it("parses toolUse event", () => {
       const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: '{"cmd":"ls"}' });
       expect(e?.type).toBe("toolUse");

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -181,6 +181,59 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("emits native summarized thinking text and preserves its signature", async () => {
+    const mockFetch = mockFetchOk(
+      '{"text":"Considering "}{"text":"divisibility"}{"signature":"opaque-signature"}{"content":"No"}{"contextUsagePercentage":10}',
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const events = await collect(
+        streamKiro(
+          makeModel({
+            id: "claude-sonnet-5",
+            kiroModelId: "claude-sonnet-5",
+            additionalModelRequestFieldsSchema: {
+              type: "object",
+              properties: {
+                thinking: {
+                  type: "object",
+                  properties: { display: { type: "string", enum: ["summarized", "omitted"] } },
+                },
+                output_config: {
+                  type: "object",
+                  properties: { effort: { type: "string", enum: ["low", "medium", "high", "xhigh"] } },
+                },
+              },
+            },
+          }),
+          makeContext(),
+          { apiKey: "test-token", reasoning: "high" },
+        ),
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.additionalModelRequestFields).toEqual({
+        output_config: { effort: "high" },
+        thinking: { type: "adaptive", display: "summarized" },
+      });
+      const types = events.map((event) => event.type);
+      expect(types.indexOf("thinking_start")).toBeLessThan(types.indexOf("thinking_delta"));
+      expect(types.indexOf("thinking_delta")).toBeLessThan(types.indexOf("thinking_end"));
+      expect(types.indexOf("thinking_end")).toBeLessThan(types.indexOf("text_start"));
+      const done = events.find((event) => event.type === "done");
+      const thinking =
+        done?.type === "done" ? done.message.content.find((block) => block.type === "thinking") : undefined;
+      expect(thinking).toMatchObject({
+        type: "thinking",
+        thinking: "Considering divisibility",
+        thinkingSignature: "opaque-signature",
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("keeps visible-thinking markers when Claude uses structured adaptive effort", async () => {
     const mockFetch = mockFetchOk(
       '{"content":"<thinking>Checked divisibility</thinking>\\n\\nNo"}{"contextUsagePercentage":10}',


### PR DESCRIPTION
## Summary

- request summarized adaptive thinking when Kiro's model catalog advertises it
- parse native `{ "text": ... }` thinking chunks and `{ "signature": ... }` terminators
- emit Pi `thinking_start`, `thinking_delta`, and `thinking_end` events while preserving `thinkingSignature`
- retain legacy `<thinking>` parsing for older Claude models

## Root cause

#95 restored legacy tagged thinking for Claude Sonnet 4.6, but newer adaptive models use a different stream protocol. Claude Sonnet 5 and Claude Opus 4.8 return summarized reasoning as native `text` frames followed by an opaque `signature` frame, then final-answer `content` frames. `parseKiroEvent()` did not recognize either native frame, so it silently discarded reasoning that the runtime had sent.

The #95 Opus 4.8 test asserted only that legacy prompt markers were present; its mocked response contained final `content` only. It therefore could not detect the native-frame parser gap.

## Live verification

Live-tested against `runtime.us-east-1.kiro.dev` using real Kiro credentials and the production provider code, without fetch mutation.

### Claude Sonnet 5

Observed event order:

```text
start → thinking_start → thinking_delta… → thinking_end → text_start → text_delta… → text_end → done
```

Result contained a non-empty `thinking` block, final text block, and non-empty `thinkingSignature`.

### Claude Opus 4.8

Observed same event order and a non-empty signed thinking block before final text.

## Automated verification

- `npm run lint`
- `npm run check`
- `npm run build`
- `npm test` — 300 tests passed
- focused native-thinking regression covers request fields, raw frame parsing, event ordering, content, and signature preservation
