### PR TITLE
Restore `max` as a distinct thinking level

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -57,7 +57,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh" },
+    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -72,7 +72,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh" },
+    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -87,7 +87,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "max" },
+    thinkingLevelMap: { max: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -101,7 +101,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh" },
+    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -115,7 +115,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "max" },
+    thinkingLevelMap: { max: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -168,7 +168,7 @@ export const kiroModels: KiroModel[] = [
     provider: "kiro",
     baseUrl: BASE_URL,
     reasoning: true,
-    thinkingLevelMap: { xhigh: "xhigh" },
+    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
@@ -386,7 +386,7 @@ function deriveThinkingLevelMap(effortValues: readonly string[] | undefined): Th
   if (!effortValues) return undefined;
   const thinkingLevelMap: ThinkingLevelMap = {};
   if (effortValues.includes("xhigh")) thinkingLevelMap.xhigh = "xhigh";
-  else if (effortValues.includes("max")) thinkingLevelMap.xhigh = "max";
+  if (effortValues.includes("max")) thinkingLevelMap.max = "max";
   return Object.keys(thinkingLevelMap).length > 0 ? thinkingLevelMap : undefined;
 }
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -41,7 +41,7 @@ const catalogFixture: KiroCatalogModel[] = [
     modelId: "openai-gpt-5.6",
     displayName: "GPT 5.6",
     tokenLimits: { maxInputTokens: 278_528, maxOutputTokens: 128_000 },
-    additionalModelRequestFieldsSchema: effortSchema("reasoning", ["low", "medium", "high", "xhigh"]),
+    additionalModelRequestFieldsSchema: effortSchema("reasoning", ["none", "low", "medium", "high", "xhigh", "max"]),
   },
   {
     modelId: "claude-opus-4.8",
@@ -116,7 +116,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "openai-gpt-5-6",
         kiroModelId: "openai-gpt-5.6",
         reasoning: true,
-        thinkingLevelMap: { xhigh: "xhigh" },
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
         contextWindow: 278_528,
         maxTokens: 128_000,
       },
@@ -124,7 +124,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "claude-opus-4-8",
         kiroModelId: "claude-opus-4.8",
         reasoning: true,
-        thinkingLevelMap: { xhigh: "xhigh" },
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
         contextWindow: 900_000,
         maxTokens: 100_000,
       },
@@ -132,7 +132,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "claude-sonnet-4-6",
         kiroModelId: "claude-sonnet-4.6",
         reasoning: true,
-        thinkingLevelMap: { xhigh: "max" },
+        thinkingLevelMap: { max: "max" },
         contextWindow: 200_000,
         maxTokens: 8_192,
       },
@@ -147,7 +147,7 @@ describe("Feature 2: Model Definitions", () => {
         id: "claude-fable-5",
         kiroModelId: "claude-fable-5",
         reasoning: true,
-        thinkingLevelMap: { xhigh: "xhigh" },
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
         contextWindow: 1_000_000,
         maxTokens: 128_000,
       },
@@ -280,33 +280,29 @@ describe("Feature 2: Model Definitions", () => {
 
   describe("thinkingLevelMap", () => {
     const THROUGH_HIGH = ["off", "minimal", "low", "medium", "high"] satisfies ModelThinkingLevel[];
-    const THROUGH_XHIGH = [...THROUGH_HIGH, "xhigh"] satisfies ModelThinkingLevel[];
-    const XHIGH_MODELS = [
-      "claude-opus-4-8",
-      "claude-opus-4-7",
-      "claude-opus-4-6",
-      "claude-sonnet-5",
-      "claude-sonnet-4-6",
-      "claude-fable-5",
-    ];
+    const THROUGH_XHIGH_AND_MAX = [...THROUGH_HIGH, "xhigh", "max"] satisfies ModelThinkingLevel[];
+    const THROUGH_HIGH_AND_MAX = [...THROUGH_HIGH, "max"] satisfies ModelThinkingLevel[];
+    const XHIGH_AND_MAX_MODELS = ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"];
+    const MAX_WITHOUT_XHIGH_MODELS = ["claude-opus-4-6", "claude-sonnet-4-6"];
 
-    it("advertises xhigh for models with xhigh or max effort", () => {
-      for (const model of kiroModels.filter((candidate) => XHIGH_MODELS.includes(candidate.id))) {
-        expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_XHIGH);
+    it("advertises xhigh and max independently when both are supported", () => {
+      for (const model of kiroModels.filter((candidate) => XHIGH_AND_MAX_MODELS.includes(candidate.id))) {
+        expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_XHIGH_AND_MAX);
       }
     });
 
-    it("maps xhigh to max when max is the model's highest effort", () => {
-      for (const model of kiroModels.filter((candidate) =>
-        ["claude-opus-4-6", "claude-sonnet-4-6"].includes(candidate.id),
-      )) {
-        expect(model.thinkingLevelMap?.xhigh).toBe("max");
+    it("preserves a max-without-xhigh capability hole", () => {
+      for (const model of kiroModels.filter((candidate) => MAX_WITHOUT_XHIGH_MODELS.includes(candidate.id))) {
+        expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_HIGH_AND_MAX);
       }
     });
 
     it("limits other reasoning models to standard levels", () => {
       for (const model of kiroModels.filter(
-        (candidate) => candidate.reasoning && !XHIGH_MODELS.includes(candidate.id),
+        (candidate) =>
+          candidate.reasoning &&
+          !XHIGH_AND_MAX_MODELS.includes(candidate.id) &&
+          !MAX_WITHOUT_XHIGH_MODELS.includes(candidate.id),
       )) {
         expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(THROUGH_HIGH);
       }

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -181,7 +181,7 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("emits native summarized thinking text and preserves its signature", async () => {
+  it("emits native summarized thinking at max effort and preserves its signature", async () => {
     const mockFetch = mockFetchOk(
       '{"text":"Considering "}{"text":"divisibility"}{"signature":"opaque-signature"}{"content":"No"}{"contextUsagePercentage":10}',
     );
@@ -193,6 +193,7 @@ describe("Feature 9: Streaming Integration", () => {
           makeModel({
             id: "claude-sonnet-5",
             kiroModelId: "claude-sonnet-5",
+            thinkingLevelMap: { xhigh: "xhigh", max: "max" },
             additionalModelRequestFieldsSchema: {
               type: "object",
               properties: {
@@ -202,19 +203,19 @@ describe("Feature 9: Streaming Integration", () => {
                 },
                 output_config: {
                   type: "object",
-                  properties: { effort: { type: "string", enum: ["low", "medium", "high", "xhigh"] } },
+                  properties: { effort: { type: "string", enum: ["low", "medium", "high", "xhigh", "max"] } },
                 },
               },
             },
           }),
           makeContext(),
-          { apiKey: "test-token", reasoning: "high" },
+          { apiKey: "test-token", reasoning: "max" },
         ),
       );
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.additionalModelRequestFields).toEqual({
-        output_config: { effort: "high" },
+        output_config: { effort: "max" },
         thinking: { type: "adaptive", display: "summarized" },
       });
       const types = events.map((event) => event.type);
@@ -302,7 +303,7 @@ describe("Feature 9: Streaming Integration", () => {
         id: "claude-opus-4-8",
         kiroModelId: "claude-opus-4.8",
         name: "Claude Opus 4.8",
-        thinkingLevelMap: { xhigh: "xhigh" },
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
         additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "xhigh", "max"]),
       },
       reasoning: "xhigh" as const,
@@ -315,7 +316,7 @@ describe("Feature 9: Streaming Integration", () => {
         id: "claude-sonnet-4-6",
         kiroModelId: "claude-sonnet-4.6",
         name: "Claude Sonnet 4.6",
-        thinkingLevelMap: { xhigh: "max" },
+        thinkingLevelMap: { max: "max" },
         additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "max"]),
       },
       reasoning: "xhigh" as const,
@@ -369,7 +370,7 @@ describe("Feature 9: Streaming Integration", () => {
           id: "claude-opus-4-8",
           kiroModelId: "claude-opus-4.8",
           name: "Claude Opus 4.8",
-          thinkingLevelMap: { xhigh: "xhigh" },
+          thinkingLevelMap: { xhigh: "xhigh", max: "max" },
           additionalModelRequestFieldsSchema: { type: "object", properties: {}, additionalProperties: false },
         }),
         makeContext(),


### PR DESCRIPTION
This restores `max` thinking level after [the v0.9.0 release](https://github.com/mikeyobrien/pi-provider-kiro/pull/92) reverted that part of #91 by folding `max` into `xhigh`. 

I think the original behavior was right: pi supports max natively, and Kiro’s model effort enums genuinely differ, some models support both `xhigh` and `max`, while others support max without `xhigh`.