### PR TITLE
fix(login): show SSO login UI as overlay so dialog survives

### DIFF
--- a/src/login-ui.ts
+++ b/src/login-ui.ts
@@ -30,96 +30,102 @@ export async function showLoginUI(): Promise<LoginChoice> {
   if (!_ctx) return null;
   const ctx = _ctx;
 
-  return ctx.ui.custom<LoginChoice>((tui, theme, _kb, done) => {
-    const items: SelectItem[] = [
-      { value: "builder-id", label: "Builder ID", description: "AWS Builder ID (default)" },
-      { value: "idc", label: "Your organization", description: "IAM Identity Center (SSO)" },
-      { value: "google", label: "Google", description: "Social login via kiro-cli" },
-      { value: "github", label: "GitHub", description: "Social login via kiro-cli" },
-    ];
+  // overlay: true so closing this UI hides the overlay instead of restoring the
+  // editor. Restoring the editor clears the container holding pi's login dialog,
+  // which then swallows onProgress/onAuth output (issue #90).
+  return ctx.ui.custom<LoginChoice>(
+    (tui, theme, _kb, done) => {
+      const items: SelectItem[] = [
+        { value: "builder-id", label: "Builder ID", description: "AWS Builder ID (default)" },
+        { value: "idc", label: "Your organization", description: "IAM Identity Center (SSO)" },
+        { value: "google", label: "Google", description: "Social login via kiro-cli" },
+        { value: "github", label: "GitHub", description: "Social login via kiro-cli" },
+      ];
 
-    let phase: "select" | "url" = "select";
-    const container = new Container();
-    const border = new DynamicBorder((s: string) => theme.fg("accent", s));
-    const title = new Text(theme.fg("accent", theme.bold("Kiro Login")), 1, 0);
-    const hint = new Text(theme.fg("dim", "↑↓ navigate • enter select • esc cancel"), 1, 0);
-    const borderBottom = new DynamicBorder((s: string) => theme.fg("accent", s));
+      let phase: "select" | "url" = "select";
+      const container = new Container();
+      const border = new DynamicBorder((s: string) => theme.fg("accent", s));
+      const title = new Text(theme.fg("accent", theme.bold("Kiro Login")), 1, 0);
+      const hint = new Text(theme.fg("dim", "↑↓ navigate • enter select • esc cancel"), 1, 0);
+      const borderBottom = new DynamicBorder((s: string) => theme.fg("accent", s));
 
-    // Phase 1: SelectList
-    const selectList = new SelectList(items, items.length, {
-      selectedPrefix: (t: string) => theme.fg("accent", t),
-      selectedText: (t: string) => theme.fg("accent", t),
-      description: (t: string) => theme.fg("muted", t),
-      scrollInfo: (t: string) => theme.fg("dim", t),
-      noMatch: (t: string) => theme.fg("warning", t),
-    });
+      // Phase 1: SelectList
+      const selectList = new SelectList(items, items.length, {
+        selectedPrefix: (t: string) => theme.fg("accent", t),
+        selectedText: (t: string) => theme.fg("accent", t),
+        description: (t: string) => theme.fg("muted", t),
+        scrollInfo: (t: string) => theme.fg("dim", t),
+        noMatch: (t: string) => theme.fg("warning", t),
+      });
 
-    selectList.onSelect = (item) => {
-      if (item.value === "idc") {
-        switchToUrlInput();
-      } else {
-        done({ method: item.value as "builder-id" | "google" | "github" });
-      }
-    };
-    selectList.onCancel = () => done(null);
-
-    // Phase 2: URL Input
-    const urlLabel = new Text("Start URL (e.g. https://mycompany.awsapps.com/start)", 1, 0);
-    const urlInput = new Input();
-    const urlHint = new Text(theme.fg("dim", "enter submit • esc back"), 1, 0);
-
-    urlInput.onSubmit = (value) => {
-      const trimmed = value.trim();
-      if (trimmed?.startsWith("http")) {
-        done({ method: "idc", startUrl: trimmed });
-      }
-    };
-    urlInput.onEscape = () => {
-      switchToSelect();
-    };
-
-    function switchToUrlInput() {
-      phase = "url";
-      container.clear();
-      container.addChild(border);
-      container.addChild(new Text(theme.fg("accent", theme.bold("IAM Identity Center")), 1, 0));
-      container.addChild(urlLabel);
-      container.addChild(urlInput);
-      container.addChild(urlHint);
-      container.addChild(borderBottom);
-      tui.requestRender();
-    }
-
-    function switchToSelect() {
-      phase = "select";
-      urlInput.setValue("");
-      container.clear();
-      container.addChild(border);
-      container.addChild(title);
-      container.addChild(selectList);
-      container.addChild(hint);
-      container.addChild(borderBottom);
-      tui.requestRender();
-    }
-
-    // Initial state
-    switchToSelect();
-
-    return {
-      render(width: number) {
-        return container.render(width);
-      },
-      invalidate() {
-        container.invalidate();
-      },
-      handleInput(data: string) {
-        if (phase === "select") {
-          selectList.handleInput(data);
+      selectList.onSelect = (item) => {
+        if (item.value === "idc") {
+          switchToUrlInput();
         } else {
-          urlInput.handleInput(data);
+          done({ method: item.value as "builder-id" | "google" | "github" });
         }
+      };
+      selectList.onCancel = () => done(null);
+
+      // Phase 2: URL Input
+      const urlLabel = new Text("Start URL (e.g. https://mycompany.awsapps.com/start)", 1, 0);
+      const urlInput = new Input();
+      const urlHint = new Text(theme.fg("dim", "enter submit • esc back"), 1, 0);
+
+      urlInput.onSubmit = (value) => {
+        const trimmed = value.trim();
+        if (trimmed?.startsWith("http")) {
+          done({ method: "idc", startUrl: trimmed });
+        }
+      };
+      urlInput.onEscape = () => {
+        switchToSelect();
+      };
+
+      function switchToUrlInput() {
+        phase = "url";
+        container.clear();
+        container.addChild(border);
+        container.addChild(new Text(theme.fg("accent", theme.bold("IAM Identity Center")), 1, 0));
+        container.addChild(urlLabel);
+        container.addChild(urlInput);
+        container.addChild(urlHint);
+        container.addChild(borderBottom);
         tui.requestRender();
-      },
-    };
-  });
+      }
+
+      function switchToSelect() {
+        phase = "select";
+        urlInput.setValue("");
+        container.clear();
+        container.addChild(border);
+        container.addChild(title);
+        container.addChild(selectList);
+        container.addChild(hint);
+        container.addChild(borderBottom);
+        tui.requestRender();
+      }
+
+      // Initial state
+      switchToSelect();
+
+      return {
+        render(width: number) {
+          return container.render(width);
+        },
+        invalidate() {
+          container.invalidate();
+        },
+        handleInput(data: string) {
+          if (phase === "select") {
+            selectList.handleInput(data);
+          } else {
+            urlInput.handleInput(data);
+          }
+          tui.requestRender();
+        },
+      };
+    },
+    { overlay: true },
+  );
 }

--- a/src/login.ts
+++ b/src/login.ts
@@ -33,6 +33,10 @@ function getSignal(callbacks: OAuthLoginCallbacks): AbortSignal | undefined {
   return (callbacks as unknown as { signal?: AbortSignal }).signal;
 }
 
+// Per-request timeout for the OIDC register/authorize calls, so one unreachable
+// regional endpoint cannot stall region detection indefinitely.
+const PROBE_TIMEOUT_MS = 15_000;
+
 // Regions to probe when auto-detecting the IAM Identity Center OIDC region.
 // Must cover every SSO region that resolveApiRegion() maps to a Kiro API region,
 // plus the API regions themselves. Ordered by likelihood.
@@ -113,6 +117,7 @@ async function tryRegisterAndAuthorize(
 
   const regResp = await fetch(`${oidcEndpoint}/client/register`, {
     method: "POST",
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
     body: JSON.stringify({
       clientName: "pi-cli",
@@ -126,6 +131,7 @@ async function tryRegisterAndAuthorize(
 
   const devResp = await fetch(`${oidcEndpoint}/device_authorization`, {
     method: "POST",
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
     body: JSON.stringify({ clientId, clientSecret, startUrl }),
   });
@@ -158,7 +164,8 @@ async function runDeviceCodeFlowWithRegionDetection(
   getProgress(callbacks)?.("Detecting your Identity Center region...");
 
   for (const region of IDC_PROBE_REGIONS) {
-    const result = await tryRegisterAndAuthorize(startUrl, region);
+    // A hung or broken endpoint must not abort the whole probe: fail open to the next region.
+    const result = await tryRegisterAndAuthorize(startUrl, region).catch(() => null);
     if (result) {
       getProgress(callbacks)?.(`Region detected: ${region}`);
       return pollDeviceCode(

--- a/test/login-ui.test.ts
+++ b/test/login-ui.test.ts
@@ -1,0 +1,17 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { setExtensionContext, showLoginUI } from "../src/login-ui.js";
+
+describe("showLoginUI", () => {
+  it("requests overlay mode so pi does not restore the editor over the login dialog", async () => {
+    // Issue #90: non-overlay custom() calls restoreEditor() on close, which clears
+    // the container owning pi's login dialog and blanks the OAuth progress output.
+    const custom = vi.fn((_factory: unknown, _options?: unknown) => Promise.resolve(null));
+    setExtensionContext({ ui: { custom } } as unknown as ExtensionContext);
+
+    await showLoginUI();
+
+    expect(custom).toHaveBeenCalledTimes(1);
+    expect(custom.mock.calls[0]?.[1]).toEqual({ overlay: true });
+  });
+});

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -144,6 +144,36 @@ describe("Feature 10: Interactive Login", () => {
       vi.unstubAllGlobals();
     });
 
+    it("TUI: idc → a failing region probe falls open to the next region", async () => {
+      const { showLoginUI } = await import("../src/login-ui.js");
+      vi.mocked(showLoginUI).mockResolvedValueOnce({ method: "idc", startUrl: "https://mycompany.awsapps.com/start" });
+      // us-east-1 register throws (timeout/DNS); probing must continue to eu-west-1.
+      const mockFetch = vi.fn();
+      mockFetch
+        .mockRejectedValueOnce(new Error("The operation was aborted due to timeout"))
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ clientId: "c2", clientSecret: "s2" }) })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              verificationUri: "u",
+              verificationUriComplete: "u?code=X",
+              userCode: "X",
+              deviceCode: "dc",
+              interval: 1,
+              expiresIn: 10,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
+        });
+      vi.stubGlobal("fetch", mockFetch);
+      const creds = await interactiveLogin(makeCallbacks(""));
+      expect((creds as KiroCredentials).region).toBe("eu-west-1");
+      vi.unstubAllGlobals();
+    });
+
     it("TUI: null (cancelled) → falls back to onPrompt", async () => {
       // showLoginUI returns null (default mock), so fallback fires
       vi.stubGlobal("fetch", mockBuilderIdFetch());


### PR DESCRIPTION
## Summary
Fixes [#90](https://github.com/mikeyobrien/pi-provider-kiro/issues/90): SSO `/login kiro` → org flow cleared the TUI dialog on remote/SSH sessions before device URL / region feedback appeared.

### Cause
Login UI was rendered as a normal step that could be torn down when the async OIDC/device path continued, leaving an empty dialog.

### Fix
- Present login UI as an **overlay** so the SSO dialog remains visible across async steps
- Keep device URL / progress / errors on-screen while polling
- Tests cover overlay survival + login path feedback

## Test plan
- [x] `npm run check`
- [x] `npm test`
- [ ] CI green
- [ ] Manual: `/login kiro` → Your organization → start URL still shows device verification on remote SSH

Closes #90