### PR TITLE
Prevent context loss after compaction

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -71,16 +71,18 @@ export function injectSyntheticToolCalls(history: KiroHistoryEntry[]): KiroHisto
   return result;
 }
 
-export function truncateHistory(history: KiroHistoryEntry[], limit: number): KiroHistoryEntry[] {
-  let sanitized = sanitizeHistory(stripHistoryImages(history));
-  let historySize = JSON.stringify(sanitized).length;
-  while (historySize > limit && sanitized.length > 2) {
-    sanitized.shift();
-    while (sanitized.length > 0 && !sanitized[0]?.userInputMessage) sanitized.shift();
-    sanitized = sanitizeHistory(sanitized);
-    historySize = JSON.stringify(sanitized).length;
+export function prepareHistory(history: KiroHistoryEntry[]): KiroHistoryEntry[] {
+  return injectSyntheticToolCalls(sanitizeHistory(stripHistoryImages(history)));
+}
+
+/** Fail before sending rather than silently discarding conversation context. */
+export function assertHistoryWithinLimit(history: KiroHistoryEntry[], limit: number): void {
+  const size = JSON.stringify(history).length;
+  if (size > limit) {
+    throw new Error(
+      `Kiro API error: context_length_exceeded (local history ${size} chars / ${history.length} entries exceeds ${limit}-char limit)`,
+    );
   }
-  return injectSyntheticToolCalls(sanitized);
 }
 
 export function extractToolNamesFromHistory(history: KiroHistoryEntry[]): Set<string> {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -29,7 +29,13 @@ import {
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
 import { parseKiroEvent } from "./event-parser.js";
-import { addPlaceholderTools, HISTORY_LIMIT, HISTORY_LIMIT_CONTEXT_WINDOW, truncateHistory } from "./history.js";
+import {
+  addPlaceholderTools,
+  assertHistoryWithinLimit,
+  HISTORY_LIMIT,
+  HISTORY_LIMIT_CONTEXT_WINDOW,
+  prepareHistory,
+} from "./history.js";
 import { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, refreshViaKiroCli } from "./kiro-cli.js";
 import {
   invalidateKiroProfileArn,
@@ -279,10 +285,9 @@ export function streamKiro(
           systemPrepended,
           currentMsgStartIdx,
         } = buildHistory(normalized, kiroModelId, effectiveSystemPrompt);
-        // Scale history limit to model context window
-        // HISTORY_LIMIT (850K chars) is sized for 200K token models
+        // Preserve semantic context locally; Pi owns lossy compaction.
+        const history = prepareHistory(rawHistory);
         const dynamicHistoryLimit = Math.floor((model.contextWindow / HISTORY_LIMIT_CONTEXT_WINDOW) * HISTORY_LIMIT);
-        const history = truncateHistory(rawHistory, dynamicHistoryLimit);
         const toolResultLimit = TOOL_RESULT_LIMIT;
         const currentMessages = normalized.slice(currentMsgStartIdx);
         const firstMsg = currentMessages[0];
@@ -368,6 +373,9 @@ export function streamKiro(
           if (effectiveSystemPrompt && !systemPrepended)
             currentContent = `${effectiveSystemPrompt}\n\n${currentContent}`;
         }
+        // Current assistant tool calls are outbound history too, so enforce the
+        // budget only after they have been appended.
+        assertHistoryWithinLimit(history, dynamicHistoryLimit);
         // Prepend truncation notice if the previous assistant response was cut off
         if (wasPreviousResponseTruncated(context.messages)) {
           currentContent = `${TRUNCATION_NOTICE}\n\n${currentContent}`;

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   addPlaceholderTools,
+  assertHistoryWithinLimit,
   extractToolNamesFromHistory,
   HISTORY_LIMIT,
   HISTORY_LIMIT_CONTEXT_WINDOW,
   injectSyntheticToolCalls,
+  prepareHistory,
   sanitizeHistory,
   stripHistoryImages,
-  truncateHistory,
 } from "../src/history.js";
 import type { KiroHistoryEntry, KiroToolResult, KiroToolSpec, KiroToolUse } from "../src/transform.js";
 
@@ -130,42 +131,51 @@ describe("Feature 6: History Management", () => {
     });
   });
 
-  describe("truncateHistory", () => {
-    it("returns history unchanged if under limit", () => {
+  describe("prepareHistory and history budget", () => {
+    it("preserves valid history at the limit", () => {
       const h = [userEntry("hi"), assistantEntry("hello")];
-      expect(truncateHistory(h, HISTORY_LIMIT)).toHaveLength(2);
+      const prepared = prepareHistory(h);
+      const size = JSON.stringify(prepared).length;
+
+      expect(prepared).toEqual(h);
+      expect(() => assertHistoryWithinLimit(prepared, size)).not.toThrow();
     });
 
-    it("removes oldest entries when over limit", () => {
-      const big = Array.from({ length: 100 }, (_, _i) => [
-        userEntry(`msg ${"x".repeat(10000)}`),
-        assistantEntry(`reply ${"y".repeat(10000)}`),
-      ]).flat();
-      const r = truncateHistory(big, 50000);
-      expect(JSON.stringify(r).length).toBeLessThanOrEqual(50000);
-      if (r.length > 0) expect(r[0].userInputMessage).toBeDefined();
+    it("raises overflow instead of dropping a compacted anchor and tool-only suffix", () => {
+      const result = (id: string): KiroToolResult => ({
+        toolUseId: id,
+        content: [{ text: "x".repeat(300) }],
+        status: "success",
+      });
+      const h = [
+        userEntry("SYSTEM PROMPT\n\n<summary>ORIGINAL TASK</summary>"),
+        assistantEntry("", [{ name: "read", toolUseId: "tc1", input: {} }]),
+        userEntry("Tool results provided.", [result("tc1")]),
+        assistantEntry("", [{ name: "read", toolUseId: "tc2", input: {} }]),
+        userEntry("Tool results provided.", [result("tc2")]),
+      ];
+      const prepared = prepareHistory(h);
+      const size = JSON.stringify(prepared).length;
+
+      expect(prepared).toHaveLength(h.length);
+      expect(prepared[0].userInputMessage?.content).toContain("ORIGINAL TASK");
+      expect(() => assertHistoryWithinLimit(prepared, size - 1)).toThrow(/context_length_exceeded/);
+      expect(() => assertHistoryWithinLimit(prepared, size - 1)).toThrow(`${size} chars / ${h.length} entries`);
     });
 
-    it("scaled limit for 1M context model retains history that fixed limit would truncate", () => {
-      // Build history that exceeds HISTORY_LIMIT (850K) but fits within a 1M-scaled limit
+    it("scales the non-lossy budget with the model context window", () => {
       const entrySize = 10000;
-      const count = Math.ceil(HISTORY_LIMIT / entrySize) + 10; // just over 850K chars
-      const big = Array.from({ length: count }, (_, i) => [
-        userEntry(`msg-${i} ${"x".repeat(entrySize)}`),
-        assistantEntry(`reply-${i} ${"y".repeat(entrySize)}`),
-      ]).flat();
-      const serializedSize = JSON.stringify(big).length;
-      expect(serializedSize).toBeGreaterThan(HISTORY_LIMIT);
-
-      // Fixed limit truncates
-      const fixedResult = truncateHistory(big, HISTORY_LIMIT);
-      expect(fixedResult.length).toBeLessThan(big.length);
-
-      // Scaled limit for 1M context window retains everything
+      const count = Math.ceil(HISTORY_LIMIT / entrySize) + 10;
+      const prepared = prepareHistory(
+        Array.from({ length: count }, (_, i) => [
+          userEntry(`msg-${i} ${"x".repeat(entrySize)}`),
+          assistantEntry(`reply-${i} ${"y".repeat(entrySize)}`),
+        ]).flat(),
+      );
       const scaledLimit = Math.floor((1_000_000 / HISTORY_LIMIT_CONTEXT_WINDOW) * HISTORY_LIMIT);
-      expect(scaledLimit).toBe(4_250_000);
-      const scaledResult = truncateHistory(big, scaledLimit);
-      expect(scaledResult.length).toBe(big.length);
+
+      expect(() => assertHistoryWithinLimit(prepared, HISTORY_LIMIT)).toThrow(/context_length_exceeded/);
+      expect(() => assertHistoryWithinLimit(prepared, scaledLimit)).not.toThrow();
     });
   });
 
@@ -243,8 +253,8 @@ describe("Feature 6: History Management", () => {
     });
   });
 
-  describe("truncateHistory with images", () => {
-    it("strips images from history entries during truncation", () => {
+  describe("prepareHistory with images", () => {
+    it("strips images from prepared history", () => {
       const h: KiroHistoryEntry[] = [
         {
           userInputMessage: {
@@ -258,14 +268,14 @@ describe("Feature 6: History Management", () => {
         userEntry("thanks"),
         assistantEntry("welcome"),
       ];
-      const result = truncateHistory(h, HISTORY_LIMIT);
+      const result = prepareHistory(h);
       // All image data should be stripped from history
       for (const entry of result) {
         expect(entry.userInputMessage?.images).toBeUndefined();
       }
     });
 
-    it("converges when a single image entry exceeds the limit", () => {
+    it("removes a huge image before enforcing the limit", () => {
       const hugeImage = "x".repeat(2_000_000); // 2MB base64
       const h: KiroHistoryEntry[] = [
         {
@@ -280,8 +290,9 @@ describe("Feature 6: History Management", () => {
         userEntry("what did you see?"),
         assistantEntry("A cat"),
       ];
-      const result = truncateHistory(h, HISTORY_LIMIT);
+      const result = prepareHistory(h);
       const resultSize = JSON.stringify(result).length;
+      expect(() => assertHistoryWithinLimit(result, HISTORY_LIMIT)).not.toThrow();
       expect(resultSize).toBeLessThanOrEqual(HISTORY_LIMIT);
       // Should still have entries (not wiped out)
       expect(result.length).toBeGreaterThan(0);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -8,6 +8,7 @@ import type {
   TextContent,
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
+import { isContextOverflow } from "@earendil-works/pi-ai/compat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
@@ -53,6 +54,50 @@ function makeContext(userMsg = "Hello"): Context {
     systemPrompt: "You are helpful",
     messages: [{ role: "user", content: userMsg, timestamp: Date.now() }],
     tools: [],
+  };
+}
+
+function makeToolCall(id: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id, name: "read", arguments: { path: `/tmp/${id}` } }],
+    api: "kiro-api",
+    provider: "kiro",
+    model: "claude-sonnet-4-5",
+    usage: zeroUsage,
+    stopReason: "toolUse",
+    timestamp: ts,
+  };
+}
+
+function makeToolResult(id: string): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "read",
+    content: [{ type: "text", text: "x".repeat(300) }],
+    isError: false,
+    timestamp: ts,
+  };
+}
+
+function makeCompactedToolContext(): Context {
+  return {
+    systemPrompt: "SYSTEM_MARKER",
+    messages: [
+      {
+        role: "user",
+        content: "The conversation was compacted:\n\n<summary>COMPACTION_SUMMARY_MARKER</summary>",
+        timestamp: ts,
+      },
+      makeToolCall("tc1"),
+      makeToolResult("tc1"),
+      makeToolCall("tc2"),
+      makeToolResult("tc2"),
+      makeToolCall("tc3"),
+      makeToolResult("tc3"),
+    ],
+    tools: [{ name: "read", description: "Read a file", parameters: { type: "object", properties: {} } }],
   };
 }
 
@@ -1435,6 +1480,55 @@ describe("Feature 9: Streaming Integration", () => {
     const error = events.find((e) => e.type === "error");
     expect(error).toBeDefined();
     expect(error?.type === "error" && error.error.stopReason).toBe("error");
+
+    vi.unstubAllGlobals();
+  });
+
+  // =========================================================================
+  // Local overflow recovery and post-compaction context preservation
+  // =========================================================================
+
+  it("sends the system/compaction anchor and complete tool groups when within budget", async () => {
+    const mockFetch = mockFetchOk('{"content":"Done"}{"contextUsagePercentage":5}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(streamKiro(makeModel(), makeCompactedToolContext(), { apiKey: "tok" }));
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const history = body.conversationState.history as KiroHistoryEntry[];
+    const historyText = JSON.stringify(history);
+    const toolUseIds = history
+      .flatMap((entry) => entry.assistantResponseMessage?.toolUses ?? [])
+      .map((t) => t.toolUseId);
+    const historyResultIds = history
+      .flatMap((entry) => entry.userInputMessage?.userInputMessageContext?.toolResults ?? [])
+      .map((result) => result.toolUseId);
+    const currentResultIds = (
+      body.conversationState.currentMessage.userInputMessage.userInputMessageContext?.toolResults ?? []
+    ).map((result: { toolUseId: string }) => result.toolUseId);
+
+    expect(events.some((event) => event.type === "done")).toBe(true);
+    expect(historyText.match(/SYSTEM_MARKER/g) ?? []).toHaveLength(1);
+    expect(historyText.match(/COMPACTION_SUMMARY_MARKER/g) ?? []).toHaveLength(1);
+    expect(toolUseIds).toEqual(["tc1", "tc2", "tc3"]);
+    expect(historyResultIds).toEqual(["tc1", "tc2"]);
+    expect(currentResultIds).toEqual(["tc3"]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a Pi-recognized overflow without sending or dropping compacted context", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    const model = makeModel({ contextWindow: 100 });
+
+    const events = await collect(streamKiro(model, makeCompactedToolContext(), { apiKey: "tok" }));
+    const error = events.find((event) => event.type === "error");
+    const message = error?.type === "error" ? error.error : undefined;
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(message?.errorMessage).toMatch(/context_length_exceeded.*local history/);
+    expect(message?.errorMessage).not.toContain("COMPACTION_SUMMARY_MARKER");
+    expect(message && isContextOverflow(message, model.contextWindow)).toBe(true);
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
In long, tool-heavy sessions, the provider could exceed its local history limit after Pi had already compacted the conversation. It would then drop the oldest history entry, which contained both the system prompt and Pi's compaction summary.

That could also invalidate the remaining tool-call/result chain, causing most or all history to be removed. The next request still succeeded, but the model no longer knew its instructions, original task, or previous work.

### What changed

The provider no longer silently truncates oversized history. It now:

- preserves the complete prepared history
- checks the size after current tool calls are included
- returns `context_length_exceeded` before making a request if it is too large

Pi recognizes that error and performs its normal compaction/retry flow instead of receiving a request with missing context.

Added regression tests covering the compaction summary, system prompt, tool-call/result pairing, and the no-request-on-overflow behavior.