### PR TITLE
feat: add Claude Opus 5 model

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -50,6 +50,21 @@ interface ManagementModelsCache {
 
 export const kiroModels: KiroModel[] = [
   {
+    id: "claude-opus-5",
+    kiroModelId: "claude-opus-5",
+    name: "Claude Opus 5",
+    api: "kiro-api",
+    provider: "kiro",
+    baseUrl: BASE_URL,
+    reasoning: true,
+    thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+    input: ["text", "image"],
+    cost: ZERO_COST,
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    firstTokenTimeout: 180_000,
+  },
+  {
     id: "claude-opus-4-8",
     kiroModelId: "claude-opus-4.8",
     name: "Claude Opus 4.8",

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -75,6 +75,7 @@ afterEach(() => {
 describe("Feature 2: Model Definitions", () => {
   describe("resolveKiroModel", () => {
     it.each([
+      ["claude-opus-5", "claude-opus-5"],
       ["claude-opus-4-8", "claude-opus-4.8"],
       ["claude-sonnet-5", "claude-sonnet-5"],
       ["claude-haiku-4-5", "claude-haiku-4.5"],
@@ -263,7 +264,7 @@ describe("Feature 2: Model Definitions", () => {
 
   describe("bootstrap model catalog", () => {
     it("keeps conservative, zero-cost bootstrap metadata", () => {
-      expect(kiroModels).toHaveLength(15);
+      expect(kiroModels).toHaveLength(16);
       expect(kiroModels.every((model) => model.baseUrl === "https://runtime.us-east-1.kiro.dev/")).toBe(true);
       expect(kiroModels.every((model) => model.cost.input === 0 && model.cost.output === 0)).toBe(true);
       expect(kiroModels.find((model) => model.id === "claude-haiku-4-5")?.reasoning).toBe(false);
@@ -282,7 +283,13 @@ describe("Feature 2: Model Definitions", () => {
     const THROUGH_HIGH = ["off", "minimal", "low", "medium", "high"] satisfies ModelThinkingLevel[];
     const THROUGH_XHIGH_AND_MAX = [...THROUGH_HIGH, "xhigh", "max"] satisfies ModelThinkingLevel[];
     const THROUGH_HIGH_AND_MAX = [...THROUGH_HIGH, "max"] satisfies ModelThinkingLevel[];
-    const XHIGH_AND_MAX_MODELS = ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-5", "claude-fable-5"];
+    const XHIGH_AND_MAX_MODELS = [
+      "claude-opus-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-sonnet-5",
+      "claude-fable-5",
+    ];
     const MAX_WITHOUT_XHIGH_MODELS = ["claude-opus-4-6", "claude-sonnet-4-6"];
 
     it("advertises xhigh and max independently when both are supported", () => {

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -33,13 +33,13 @@ describe("Feature 1: Extension Registration", () => {
     expect(registerProvider.mock.calls[0][0]).toBe("kiro");
   });
 
-  it("registers 15 models", async () => {
+  it("registers 16 models", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
     mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
-    expect(config.models).toHaveLength(15);
+    expect(config.models).toHaveLength(16);
   });
 
   it("preserves the existing OAuth and kiro-cli credential contract", async () => {


### PR DESCRIPTION
## Summary

- add `claude-opus-5` to the bootstrap catalog, following #83 and #87
- metadata matches the management catalog entry: 1M input, 128K output, text+image, `firstTokenTimeout` of 180s like the other Opus models
- `output_config.effort` advertises `xhigh` and `max`, so `thinkingLevelMap` mirrors Opus 4.8

Catalog entry from `List-Available-Models` (`origin=KIRO_CLI`, us-east-1):

```json
{
  "modelId": "claude-opus-5",
  "description": "Experimental preview of Claude Opus 5 model with 1M context window",
  "tokenLimits": { "maxInputTokens": 1000000, "maxOutputTokens": 128000 },
  "supportedInputTypes": ["TEXT", "IMAGE"],
  "rateMultiplier": 2.2
}
```

## Validation

- `npm run check`
- `npm run lint`
- `npm test` — 306 passed
- `npm run build`
- `npm pack --dry-run`
- live round-trip against `claude-opus-5` on an IdC profile (us-east-1), streamed response returned normally