### PR TITLE
fix: disable text tool recovery for Claude models

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -31,6 +31,8 @@ export interface KiroModel extends Model<"kiro-api"> {
   additionalModelRequestFieldsSchema?: Record<string, unknown>;
   tokenLimits?: KiroTokenLimits;
   firstTokenTimeout?: number;
+  /** Senpi should trust Kiro's native tool-use events instead of parsing XML-like text. */
+  recoverTextToolCalls?: boolean;
   kiroRegion?: string;
   /** Credential-scoped profile ARN attached only to the in-memory model projection. */
   kiroProfileArn?: string;
@@ -48,7 +50,7 @@ interface ManagementModelsCache {
   regions: Record<string, ManagementCacheRegion>;
 }
 
-export const kiroModels: KiroModel[] = [
+const bootstrapKiroModels: KiroModel[] = [
   {
     id: "claude-opus-4-8",
     kiroModelId: "claude-opus-4.8",
@@ -254,6 +256,10 @@ export const kiroModels: KiroModel[] = [
   },
 ];
 
+export const kiroModels: KiroModel[] = bootstrapKiroModels.map((model) =>
+  model.id.startsWith("claude-") ? { ...model, recoverTextToolCalls: false } : model,
+);
+
 const BOOTSTRAP_KIRO_MODEL_IDS = kiroModels.map((model) => model.kiroModelId);
 
 /** Exact service IDs known from either the bootstrap list or a valid management cache. */
@@ -458,6 +464,7 @@ export function mapKiroCatalogModels(catalogModels: KiroCatalogModel[], region: 
       reasoning: effortValues !== undefined || (schema === undefined && hasReasoningFamilyFallback(id)),
       ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
       input: existing ? [...existing.input] : isClaude ? ["text", "image"] : ["text"],
+      recoverTextToolCalls: isClaude ? false : undefined,
       cost: ZERO_COST,
       contextWindow: tokenLimits?.maxInputTokens ?? DEFAULT_CONTEXT_WINDOW,
       maxTokens: tokenLimits?.maxOutputTokens ?? DEFAULT_MAX_TOKENS,

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -163,6 +163,15 @@ describe("Feature 2: Model Definitions", () => {
       expect(opus?.contextWindow).not.toBe(kiroModels.find((model) => model.id === opus?.id)?.contextWindow);
     });
 
+    it("disables text tool-call recovery only for Claude catalog models", () => {
+      const claudeModels = mapped.filter((model) => model.id.startsWith("claude-"));
+      const nonClaudeModels = mapped.filter((model) => !model.id.startsWith("claude-"));
+
+      expect(claudeModels.length).toBeGreaterThan(0);
+      expect(claudeModels.every((model) => model.recoverTextToolCalls === false)).toBe(true);
+      expect(nonClaudeModels.every((model) => model.recoverTextToolCalls === undefined)).toBe(true);
+    });
+
     it("treats a null schema as absent for auto", () => {
       const [auto] = mapKiroCatalogModels([{ modelId: "auto", additionalModelRequestFieldsSchema: null }], TEST_REGION);
 
@@ -275,6 +284,15 @@ describe("Feature 2: Model Definitions", () => {
       const nonClaudeModels = kiroModels.filter((model) => !model.id.startsWith("claude-") && model.id !== "auto");
       expect(claudeModels.every((model) => model.input.includes("text") && model.input.includes("image"))).toBe(true);
       expect(nonClaudeModels.every((model) => model.input.length === 1 && model.input[0] === "text")).toBe(true);
+    });
+
+    it("disables text tool-call recovery only for Claude bootstrap models", () => {
+      const claudeModels = kiroModels.filter((model) => model.id.startsWith("claude-"));
+      const nonClaudeModels = kiroModels.filter((model) => !model.id.startsWith("claude-"));
+
+      expect(claudeModels.length).toBeGreaterThan(0);
+      expect(claudeModels.every((model) => model.recoverTextToolCalls === false)).toBe(true);
+      expect(nonClaudeModels.every((model) => model.recoverTextToolCalls === undefined)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- set `recoverTextToolCalls: false` for bootstrap Claude models
- apply the same metadata to Claude models returned by the management catalog
- leave non-Claude Kiro models unchanged

## Why

Kiro already emits native structured tool-use events for Claude models. Senpi's fallback text tool-call recovery can parse XML-like response text a second time, which can duplicate or reorder tool-call events. Users currently need a local `models.json` override to disable that recovery.

## Tests

- `npm test` — 18 files, 309 tests passed
- `npm run check`
- `npm run lint`
- `npm run build`
