### PR TITLE
fix(stream): send required content field and stop mislabeling malformed-request 400s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Send a placeholder instead of an empty `content` when a turn carries no text, and stop reporting Kiro's generic "Improperly formed request." rejection as a context overflow. A host that appends a message whose role falls outside pi-ai's `Message` union produced `content: ""`, which Kiro rejects with `400 REQUEST_BODY_INVALID`; relabeling that as `context_length_exceeded` then drove the caller into a compaction loop against a request that was structurally invalid rather than oversized. Also covers image-only and empty-text user messages.
+
 ## [0.9.3] - 2026-07-24
 
 ### Fixed

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -28,7 +28,14 @@ export function exponentialBackoff(attempt: number, baseMs: number, maxMs: numbe
 
 export const MAX_RETRY_DELAY = 10_000;
 
-export const TOO_BIG_PATTERNS = ["CONTENT_LENGTH_EXCEEDS_THRESHOLD", "Input is too long", "Improperly formed"];
+// Size markers only. "Improperly formed request." is Kiro's generic
+// request-validation rejection (reason `REQUEST_BODY_INVALID`) — it is returned
+// for a malformed body of any size, including an empty `content` field or a
+// history referencing tools absent from the catalog. Classifying it as
+// "too big" made every such 400 surface as `context_length_exceeded`, which
+// sends the caller into a compaction loop it can never satisfy: the request is
+// invalid, not oversized, so no amount of history reduction fixes it.
+export const TOO_BIG_PATTERNS = ["CONTENT_LENGTH_EXCEEDS_THRESHOLD", "Input is too long"];
 const NON_RETRYABLE_BODY_PATTERNS = ["MONTHLY_REQUEST_COUNT"];
 const CAPACITY_PATTERN = "INSUFFICIENT_MODEL_CAPACITY";
 export const CAPACITY_MAX_RETRIES = 3;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -59,6 +59,7 @@ import {
   buildHistory,
   convertImagesToKiro,
   convertToolsToKiro,
+  EMPTY_CONTENT_PLACEHOLDER,
   extractImages,
   getContentText,
   type KiroHistoryEntry,
@@ -397,6 +398,10 @@ export function streamKiro(
           const imgs = extractImages(firstMsg);
           if (imgs.length > 0) currentImages = convertImagesToKiro(imgs as ImageContent[]);
         }
+        // `content` is required: Kiro answers an empty one with a 400
+        // "Improperly formed request." Fall back to a neutral prompt so a turn
+        // that carries only images (or an empty-text user message) still sends.
+        if (currentContent === "") currentContent = EMPTY_CONTENT_PLACEHOLDER;
         // kiro-cli does not enforce alternation — the API accepts
         // non-alternating history. No synthetic padding needed.
         const request: KiroRequest = {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -46,6 +46,14 @@ export interface KiroHistoryEntry {
 
 export const TOOL_RESULT_LIMIT = 250000;
 
+/** Kiro rejects a current message whose `content` is empty with a 400
+ *  "Improperly formed request." (reason `REQUEST_BODY_INVALID`) — the field is
+ *  required even when the turn carries its payload elsewhere (images, tool
+ *  results). A turn can legitimately reach the request builder with no text:
+ *  an image-only user message, or a user message whose text is empty. Send a
+ *  neutral prompt in that case so the attachments still reach the model. */
+export const EMPTY_CONTENT_PLACEHOLDER = "Please proceed with the task.";
+
 export function sanitizeSurrogates(text: string): string {
   // Replace unpaired high surrogates (0xD800-0xDBFF not followed by low surrogate)
   // Replace unpaired low surrogates (0xDC00-0xDFFF not preceded by high surrogate)

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -80,8 +80,12 @@ describe("isTooBigError", () => {
     expect(isTooBigError(400, "Input is too long for model")).toBe(true);
   });
 
-  it("returns true for 400 with 'Improperly formed'", () => {
-    expect(isTooBigError(400, "Improperly formed request")).toBe(true);
+  // "Improperly formed request." is Kiro's generic request-validation
+  // rejection, not a size signal. Reporting it as a too-big error makes the
+  // caller compact a history that was never the problem.
+  it("returns false for 400 'Improperly formed request'", () => {
+    expect(isTooBigError(400, '{"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}')).toBe(false);
+    expect(isTooBigError(400, "Improperly formed request")).toBe(false);
   });
 
   it("returns false for 400 without matching pattern", () => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
-import type { KiroHistoryEntry } from "../src/transform.js";
+import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
 import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
 
 const ts = Date.now();
@@ -1198,6 +1198,127 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  // =========================================================================
+  // Required `content` field
+  // —————————————————————————————————————————————————————————————————————————
+  // Kiro rejects a current message with an empty `content` as
+  // "Improperly formed request." (reason REQUEST_BODY_INVALID). A turn can
+  // reach the request builder with no text — an image-only user message, or a
+  // user message whose text is empty — so a placeholder must be substituted.
+  // =========================================================================
+
+  // These use a prior turn so the system prompt is already consumed by the
+  // first history entry: on the very first message the prompt is prepended to
+  // the current content, which masks an empty text payload.
+  const settledTurn = (): Context["messages"] => [
+    { role: "user", content: "earlier question", timestamp: ts },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "earlier answer" }],
+      api: "kiro-api",
+      provider: "kiro",
+      model: "claude-sonnet-4-5",
+      usage: zeroUsage,
+      stopReason: "stop",
+      timestamp: ts,
+    } satisfies AssistantMessage,
+  ];
+
+  it("sends placeholder content for an image-only user message", async () => {
+    const image: ImageContent = { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [...settledTurn(), { role: "user", content: [image], timestamp: ts }],
+      tools: [],
+    };
+    const mockFetch = mockFetchOk('{"content":"Nice picture."}{"contextUsagePercentage":2}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(streamKiro(makeModel(), context, { apiKey: "tok" }));
+
+    const currentMsg = JSON.parse(mockFetch.mock.calls[0][1].body).conversationState.currentMessage.userInputMessage;
+    expect(currentMsg.content).toBe(EMPTY_CONTENT_PLACEHOLDER);
+    // The image itself must still reach the model.
+    expect(currentMsg.images).toHaveLength(1);
+    expect(events.some((event) => event.type === "done")).toBe(true);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("sends placeholder content for an empty-text user message", async () => {
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [...settledTurn(), { role: "user", content: "", timestamp: ts }],
+      tools: [],
+    };
+    const mockFetch = mockFetchOk('{"content":"Go on."}{"contextUsagePercentage":1}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    await collect(streamKiro(makeModel(), context, { apiKey: "tok" }));
+
+    const currentMsg = JSON.parse(mockFetch.mock.calls[0][1].body).conversationState.currentMessage.userInputMessage;
+    expect(currentMsg.content).toBe(EMPTY_CONTENT_PLACEHOLDER);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps real user text untouched", async () => {
+    const mockFetch = mockFetchOk('{"content":"Hi."}{"contextUsagePercentage":1}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    await collect(streamKiro(makeModel(), makeContext("Explain this repo"), { apiKey: "tok" }));
+
+    const currentMsg = JSON.parse(mockFetch.mock.calls[0][1].body).conversationState.currentMessage.userInputMessage;
+    expect(currentMsg.content).toContain("Explain this repo");
+
+    vi.unstubAllGlobals();
+  });
+
+  // The observed failure: a host appended a reminder message carrying a role
+  // outside pi-ai's `Message` union ("developer") after a settled assistant
+  // turn. None of the current-message branches matched it, so `content` went
+  // out empty and Kiro answered 400 REQUEST_BODY_INVALID — which the provider
+  // then relabeled `context_length_exceeded`, sending the caller into a
+  // compaction loop against a request that was structurally invalid, not large.
+  it("sends placeholder content when the turn ends on an unrecognized role", async () => {
+    const settledAssistant: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Done." }],
+      api: "kiro-api",
+      provider: "kiro",
+      model: "claude-sonnet-4-5",
+      usage: zeroUsage,
+      stopReason: "stop",
+      timestamp: ts,
+    };
+    const reminder = {
+      role: "developer",
+      content: [{ type: "text", text: "<system-reminder>2 incomplete todos</system-reminder>" }],
+      attribution: "agent",
+      timestamp: ts,
+    };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: "Do the work", timestamp: ts },
+        settledAssistant,
+        reminder as unknown as Context["messages"][number],
+      ],
+      tools: [],
+    };
+    const mockFetch = mockFetchOk('{"content":"Continuing."}{"contextUsagePercentage":4}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(streamKiro(makeModel(), context, { apiKey: "tok" }));
+
+    const currentMsg = JSON.parse(mockFetch.mock.calls[0][1].body).conversationState.currentMessage.userInputMessage;
+    expect(currentMsg.content).not.toBe("");
+    expect(events.some((event) => event.type === "done")).toBe(true);
+    expect(events.some((event) => event.type === "error")).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
   it("synthesizes placeholder tool specs when context.tools is undefined but history references tools", async () => {
     const assistantWithTool: AssistantMessage = {
       role: "assistant",
@@ -1592,6 +1713,31 @@ describe("Feature 9: Streaming Integration", () => {
     const error = events.find((e) => e.type === "error");
     expect(error).toBeDefined();
     expect(error?.type === "error" && error.error.errorMessage).toContain("context_length_exceeded");
+
+    vi.unstubAllGlobals();
+  });
+
+  // A malformed-body 400 is not an overflow. Reporting it as one sends the
+  // caller into a compaction loop that can never clear the error, because the
+  // request is invalid rather than oversized.
+  it("does NOT report 400 'Improperly formed request' as a context overflow", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: () => Promise.resolve('{"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}'),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const model = makeModel();
+    const events = await collect(streamKiro(model, makeContext(), { apiKey: "tok" }));
+    const error = events.find((e) => e.type === "error");
+    const message = error?.type === "error" ? error.error : undefined;
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(message?.errorMessage).not.toContain("context_length_exceeded");
+    expect(message?.errorMessage).toContain("Improperly formed request.");
+    expect(message && isContextOverflow(message, model.contextWindow)).toBe(false);
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Problem

Kiro requires `content` on the current message and rejects an empty one:

```
400 {"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}
```

The current-message assembly in `src/stream.ts` branches on `assistant`, `toolResult`, and `user`. A turn matching none of them leaves `currentContent` at its `""` initializer, and the request goes out with an empty required field. Two reachable cases:

- **An image-only user message.** `getContentText()` returns `""` for content holding only image blocks, so a follow-up turn carrying just an image sends empty text. On the very first message the system prompt is prepended and masks this; once history exists, nothing fills it.
- **A user message whose text is empty.**

The same path is reached when a host appends a message whose role falls outside pi-ai's `Message` union (`UserMessage | AssistantMessage | ToolResultMessage`) — for example a `developer`-role reminder injected after a settled assistant turn.

Separately, `TOO_BIG_PATTERNS` classified `"Improperly formed"` as a size marker, so the provider rewrote every such 400 as `context_length_exceeded`. That string is Kiro's generic request-validation rejection, not a size signal — this repo already handles one non-size cause of it (history referencing tools absent from the catalog). The relabel sends the caller into a compaction loop it can never satisfy: the request is structurally invalid, not oversized, so reducing history never clears it.

Captured from a real failure, the rejected request was **282 KB against a 1,000,000-token window**, with 43 intact, correctly-paired history entries. Nothing about it was too large.

## Changes

- Substitute a neutral prompt when `content` would otherwise be empty, so the turn still sends and any attached images reach the model.
- Remove `"Improperly formed"` from `TOO_BIG_PATTERNS`. Genuine overflow still arrives as HTTP 413 or `CONTENT_LENGTH_EXCEEDS_THRESHOLD`, both retained.

Note on scope: this substitutes a placeholder rather than forwarding the text of whatever message produced the empty content. For an unrecognized-role message that text is already dropped from the outbound request today, independent of this change. Folding it into the request instead of discarding it would be a behavior change beyond stopping the 400, so I left it out; happy to follow up separately if you'd prefer that direction.

## Verification

`npm test` 314/314, clean `npm run check` and `npm run lint`.

Each new test was confirmed to fail with the corresponding source change reverted, and to pass with it applied. That negative control caught a flaw in two of them: `makeModel()` sets `reasoning: true`, so the thinking-mode system prompt was being prepended to the empty content and masking the bug. They now establish a prior turn so the prompt is already consumed, and assert the exact placeholder rather than merely "not empty".

Also exercised against a live Kiro endpoint. Before the change, requests reaching this path returned `REQUEST_BODY_INVALID`. After, across 362 requests: zero with empty `content`, zero `REQUEST_BODY_INVALID`. The two requests that hit the new guard sent the placeholder and streamed a normal response.
