### PR TITLE
fix(stream): refresh credentials when profile lookup returns 403

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -40,6 +40,7 @@ import { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, refreshViaKir
 import {
   invalidateKiroProfileArn,
   type KiroManagementAuth,
+  KiroManagementHttpError,
   resetKiroProfileArnCache,
   resolveKiroProfileArn,
 } from "./management.js";
@@ -223,9 +224,29 @@ export function streamKiro(
       const cliCreds = getKiroCliCredentials() ?? getKiroCliCredentialsAllowExpired();
       const cliProfileArn = cliCreds?.access === accessToken ? cliCreds.profileArn : undefined;
       const initialProfileArn = modelMetadata.kiroProfileArn || optionProfileArn || cliProfileArn;
-      let profileArn: string =
-        initialProfileArn ||
-        (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveKiroProfileArn(managementAuth));
+      let profileArn: string;
+      try {
+        profileArn =
+          initialProfileArn ||
+          (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveKiroProfileArn(managementAuth));
+      } catch (error) {
+        if (!(error instanceof KiroManagementHttpError) || error.status !== 403) throw error;
+
+        // The host may have captured an access token before kiro-cli rotated it.
+        // Re-read the shared store first, then force a refresh only when it still
+        // contains the rejected token. Profile discovery must succeed before the
+        // runtime request can be constructed.
+        const storedCreds = getKiroCliCredentials();
+        const freshCreds =
+          storedCreds?.access && storedCreds.access !== accessToken ? storedCreds : refreshViaKiroCli();
+        if (!freshCreds?.access) throw error;
+
+        accessToken = freshCreds.access;
+        managementAuth = { accessToken, region };
+        profileArn =
+          freshCreds.profileArn ||
+          (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveKiroProfileArn(managementAuth));
+      }
 
       // Trigger dynamic models cache update in the background if empty or stale
       const { isCacheStale, updateKiroModelsCache } = await import("./models.js");

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -483,6 +483,112 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("uses a newer kiro-cli token when initial profile discovery returns 403", async () => {
+    resetProfileArnCache(false);
+    const freshProfileArn = "arn:aws:codewhisperer:us-east-1:123:profile/FRESH";
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profiles: [{ arn: freshProfileArn }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"recovered"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
+          }),
+        },
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const kiroCliModule = await import("../src/kiro-cli.js");
+    const freshCliCreds = {
+      refresh: "fresh-refresh|client|secret|idc",
+      access: "fresh-token",
+      expires: Date.now() + 3_600_000,
+      clientId: "client",
+      clientSecret: "secret",
+      region: "us-east-1",
+      authMethod: "idc" as const,
+    };
+    const getCredsSpy = vi.spyOn(kiroCliModule, "getKiroCliCredentials").mockReturnValue(freshCliCreds);
+    const refreshSpy = vi.spyOn(kiroCliModule, "refreshViaKiroCli").mockReturnValue(undefined);
+
+    const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "stale-token" }));
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer stale-token");
+    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer fresh-token");
+    expect(mockFetch.mock.calls[2][1].headers.Authorization).toBe("Bearer fresh-token");
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body).profileArn).toBe(freshProfileArn);
+    expect(events.find((event) => event.type === "done")).toBeDefined();
+
+    getCredsSpy.mockRestore();
+    refreshSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("forces a kiro-cli refresh when profile discovery rejects the stored token", async () => {
+    resetProfileArnCache(false);
+    const freshProfileArn = "arn:aws:codewhisperer:us-east-1:123:profile/REFRESHED";
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"recovered"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
+          }),
+        },
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const kiroCliModule = await import("../src/kiro-cli.js");
+    const staleCliCreds = {
+      refresh: "stale-refresh|client|secret|idc",
+      access: "stale-token",
+      expires: Date.now() + 3_600_000,
+      clientId: "client",
+      clientSecret: "secret",
+      region: "us-east-1",
+      authMethod: "idc" as const,
+    };
+    const freshCliCreds = { ...staleCliCreds, access: "fresh-token", profileArn: freshProfileArn };
+    const getCredsSpy = vi.spyOn(kiroCliModule, "getKiroCliCredentials").mockReturnValue(staleCliCreds);
+    const refreshSpy = vi.spyOn(kiroCliModule, "refreshViaKiroCli").mockReturnValue(freshCliCreds);
+
+    const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "stale-token" }));
+
+    expect(refreshSpy).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer stale-token");
+    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer fresh-token");
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body).profileArn).toBe(freshProfileArn);
+    expect(events.find((event) => event.type === "done")).toBeDefined();
+
+    getCredsSpy.mockRestore();
+    refreshSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
   it("uses a credential-projected profileArn without management discovery or a matching CLI token", async () => {
     resetProfileArnCache(false);
     const profileArn = "arn:aws:codewhisperer:us-east-1:123:profile/SOCIAL";


### PR DESCRIPTION
## Summary

- recover when initial `ListAvailableProfiles` rejects a host-captured stale token
- prefer a newer token already written by `kiro-cli`
- force `kiro-cli` refresh only when its stored token is also the rejected token
- retry profile discovery before constructing the runtime request

## Regression

The v0.9 management/runtime migration made profile discovery a prerequisite for inference. Runtime 403s already refresh credentials, but a 403 from the earlier profile lookup aborts before that recovery path can run.

## Tests

- `npm run check`
- `npm test` — 316 passed
- `npm run build`
