### PR TITLE
Resolve Kiro profile before fetching usage

### DIFF
--- a/src/usage.ts
+++ b/src/usage.ts
@@ -3,12 +3,7 @@
 
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
 import { resolveApiRegion } from "./endpoints.js";
-import {
-  getUsageLimits,
-  type KiroManagementAuth,
-  KiroManagementHttpError,
-  resolveKiroProfileArn,
-} from "./management.js";
+import { getUsageLimits, type KiroManagementAuth, resolveKiroProfileArn } from "./management.js";
 import type { KiroCredentials } from "./oauth.js";
 
 const MANAGE_USAGE_URL = "https://app.kiro.dev/account/usage";
@@ -144,21 +139,13 @@ function mapBucket(bucket: KiroUsageBreakdown, index: number): KiroProviderUsage
 }
 
 async function fetchRawUsage(auth: KiroManagementAuth, profileArn?: string): Promise<KiroGetUsageLimitsResponse> {
-  const request = {
-    profileArn,
-    origin: "KIRO_CLI" as const,
-    resourceType: "CREDIT" as const,
-    isEmailRequired: false as const,
-  };
-
-  try {
-    return await getUsageLimits<KiroGetUsageLimitsResponse>(auth, request);
-  } catch (error) {
-    if (profileArn || !(error instanceof KiroManagementHttpError) || error.status !== 403) throw error;
-  }
-
-  const resolvedProfileArn = await resolveKiroProfileArn(auth);
-  return getUsageLimits<KiroGetUsageLimitsResponse>(auth, { ...request, profileArn: resolvedProfileArn });
+  const resolvedProfileArn = await resolveKiroProfileArn(auth, profileArn);
+  return getUsageLimits<KiroGetUsageLimitsResponse>(auth, {
+    profileArn: resolvedProfileArn,
+    origin: "KIRO_CLI",
+    resourceType: "CREDIT",
+    isEmailRequired: false,
+  });
 }
 
 export async function fetchKiroUsage(credentials: OAuthCredentials): Promise<KiroProviderUsage> {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -48,11 +48,11 @@ function usageResponse() {
   };
 }
 
-function expectUsageRequest(rawUrl: string, expectedProfileArn?: string): void {
+function expectUsageRequest(rawUrl: string, expectedProfileArn: string): void {
   const url = new URL(rawUrl);
   expect(`${url.origin}${url.pathname}`).toBe("https://management.us-east-1.kiro.dev/Get-Usage-Limits");
   expect(Object.fromEntries(url.searchParams)).toEqual({
-    ...(expectedProfileArn ? { profileArn: expectedProfileArn } : {}),
+    profileArn: expectedProfileArn,
     origin: "KIRO_CLI",
     resourceType: "CREDIT",
     isEmailRequired: "false",
@@ -112,23 +112,9 @@ describe("fetchKiroUsage", () => {
     });
   });
 
-  it("supports profile-less usage when the credential has no profile ARN", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(usageResponse()),
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    await fetchKiroUsage(creds);
-
-    expect(fetchMock).toHaveBeenCalledOnce();
-    expectUsageRequest(fetchMock.mock.calls[0][0]);
-  });
-
-  it("resolves a profile and retries once when profile-less usage is forbidden", async () => {
+  it("resolves a profile before fetching usage when the credential has no profile ARN", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ profiles: [{ arn: profileArn }] }),
@@ -141,14 +127,14 @@ describe("fetchKiroUsage", () => {
 
     await fetchKiroUsage(creds);
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expectUsageRequest(fetchMock.mock.calls[0][0]);
-    expect(fetchMock.mock.calls[1][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
-    expect(fetchMock.mock.calls[1][1].headers["X-Amz-Target"]).toBeUndefined();
-    expectUsageRequest(fetchMock.mock.calls[2][0], profileArn);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+    expect(fetchMock.mock.calls[0][1].headers["X-Amz-Target"]).toBeUndefined();
+    expectUsageRequest(fetchMock.mock.calls[1][0], profileArn);
   });
 
-  it("surfaces non-authorization failures without profile lookup or retry", async () => {
+  it("surfaces profile resolution failures before requesting usage", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,
       status: 503,
@@ -157,8 +143,23 @@ describe("fetchKiroUsage", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(fetchKiroUsage(creds)).rejects.toThrow(
+      "Kiro management ListAvailableProfiles failed in us-east-1: 503 Service Unavailable",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces usage failures without another profile lookup", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchKiroUsage({ ...creds, profileArn })).rejects.toThrow(
       "Kiro management GetUsageLimits failed in us-east-1: 503 Service Unavailable",
     );
     expect(fetchMock).toHaveBeenCalledOnce();
+    expectUsageRequest(fetchMock.mock.calls[0][0], profileArn);
   });
 });


### PR DESCRIPTION
Kiro usage can disappear when the saved credentials don't include a profile ARN. The management API currently returns HTTP 400 for a profile-less `GetUsageLimits` request, but the provider only tried to discover the profile after HTTP 403, so the fallback never ran. I've discovered this because I have a extension to display kiro usage and it behaved flaky.

## What changed

 - Resolve the profile with `resolveKiroProfileArn()` before calling `GetUsageLimits`.
 - Always include the resolved profile ARN in the usage request.
 - Remove the status-code-dependent profile lookup and retry.
 - Preserve the direct path for credentials that already include a profile ARN; the resolver returns it without making a discovery request.
 - Continue using the existing cached and coalesced profile discovery for credentials without one.
 - Update tests to cover:
   - direct usage requests with a supplied profile;
   - profile discovery before usage;
   - profile-resolution failures before any usage request;
   - usage failures without an extra profile lookup.