### PR TITLE
feat: Add reasoning-effort support for Oh My Pi

### DIFF
--- a/src/effort.ts
+++ b/src/effort.ts
@@ -82,14 +82,9 @@ export function fallbackKiroEffort(kiroModelId: string): KiroEffortConfig | unde
   return undefined;
 }
 
-/** Prefer authoritative schema metadata; never replace a present schema with a known-model guess. */
-export function getKiroEffortConfig(
-  model: ModelWithKiroEffortMetadata,
-  kiroModelId: string,
-): KiroEffortConfig | undefined {
-  if (model.additionalModelRequestFieldsSchema !== undefined) {
-    return deriveKiroEffort(model.additionalModelRequestFieldsSchema);
-  }
+/** Prefer catalog schema; fall back only when it is absent. */
+export function getKiroEffortConfig(schema: unknown, kiroModelId: string): KiroEffortConfig | undefined {
+  if (schema !== undefined) return deriveKiroEffort(schema);
   return fallbackKiroEffort(kiroModelId);
 }
 
@@ -135,7 +130,7 @@ export function buildKiroAdditionalModelRequestFields(
 ): KiroAdditionalModelRequestFields | undefined {
   if (!level || !model.reasoning) return undefined;
 
-  const config = getKiroEffortConfig(model, kiroModelId);
+  const config = getKiroEffortConfig(model.additionalModelRequestFieldsSchema, kiroModelId);
   if (!config) return undefined;
   const effort = mapPiLevelToKiroEffort(model, level, config);
   if (!effort) return undefined;

--- a/src/models.ts
+++ b/src/models.ts
@@ -5,13 +5,13 @@ import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "nod
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Model, ThinkingLevelMap } from "@earendil-works/pi-ai";
-import { deriveKiroEffort } from "./effort.js";
+import { getKiroEffortConfig, type KiroEffortConfig } from "./effort.js";
 import { getKiroEndpoints } from "./endpoints.js";
 import { fetchKiroModelCatalog, type KiroCatalogModel } from "./management.js";
 
 export { resolveApiRegion } from "./endpoints.js";
 
-export const KIRO_MANAGEMENT_CACHE_VERSION = 1;
+export const KIRO_MANAGEMENT_CACHE_VERSION = 2;
 export const KIRO_MANAGEMENT_CACHE_SOURCE = "kiro-management";
 export const KIRO_MANAGEMENT_CACHE_PATH = join(homedir(), ".kiro-management-models-cache.json");
 
@@ -23,6 +23,18 @@ const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite:
 const REASONING_FAMILY_MARKERS = ["opus", "sonnet", "fable", "coder", "deepseek", "gpt", "glm", "qwen"];
 
 type KiroTokenLimits = NonNullable<KiroCatalogModel["tokenLimits"]>;
+
+/** Effort rungs omp's ThinkingConfig schema accepts. */
+const OMP_THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+export type KiroThinkingEffort = (typeof OMP_THINKING_EFFORTS)[number];
+
+export type KiroThinkingConfig = {
+  mode: "effort";
+  efforts: readonly KiroThinkingEffort[];
+  /** Kiro can return a summarized thinking block for this model. */
+  supportsDisplay?: boolean;
+};
 
 export interface KiroModel extends Model<"kiro-api"> {
   /** Exact model ID returned by the Kiro management catalog. */
@@ -36,6 +48,8 @@ export interface KiroModel extends Model<"kiro-api"> {
   kiroRegion?: string;
   /** Credential-scoped profile ARN attached only to the in-memory model projection. */
   kiroProfileArn?: string;
+  /** omp >=13.9.3 reads this; pi reads thinkingLevelMap. Emit both. */
+  thinking?: KiroThinkingConfig;
 }
 
 interface ManagementCacheRegion {
@@ -256,9 +270,23 @@ const bootstrapKiroModels: KiroModel[] = [
   },
 ];
 
-export const kiroModels: KiroModel[] = bootstrapKiroModels.map((model) =>
-  model.id.startsWith("claude-") ? { ...model, recoverTextToolCalls: false } : model,
-);
+/**
+ * Bootstrap models carry no catalog schema, so their ladder comes from the same
+ * `getKiroEffortConfig` fallback the request path uses. Deriving here instead of
+ * hardcoding per-model literals keeps one source of truth: `effort.ts` decides
+ * which model gets which rungs, and discovery overwrites this once it runs.
+ */
+export const kiroModels: KiroModel[] = bootstrapKiroModels.map((model) => {
+  const effortConfig = model.reasoning
+    ? getKiroEffortConfig(model.additionalModelRequestFieldsSchema, model.kiroModelId)
+    : undefined;
+  const thinking = deriveThinkingConfig(effortConfig);
+  return {
+    ...model,
+    ...(thinking ? { thinking } : {}),
+    ...(model.id.startsWith("claude-") ? { recoverTextToolCalls: false } : {}),
+  };
+});
 
 const BOOTSTRAP_KIRO_MODEL_IDS = kiroModels.map((model) => model.kiroModelId);
 
@@ -277,6 +305,17 @@ function isThinkingLevelMap(value: unknown): value is ThinkingLevelMap {
   return (
     isRecord(value) &&
     Object.values(value).every((mappedValue) => typeof mappedValue === "string" || mappedValue === null)
+  );
+}
+
+function isThinkingConfig(value: unknown): value is KiroThinkingConfig {
+  return (
+    isRecord(value) &&
+    value.mode === "effort" &&
+    Array.isArray(value.efforts) &&
+    value.efforts.length > 0 &&
+    value.efforts.every((effort) => (OMP_THINKING_EFFORTS as readonly unknown[]).includes(effort)) &&
+    (value.supportsDisplay === undefined || typeof value.supportsDisplay === "boolean")
   );
 }
 
@@ -309,6 +348,7 @@ function isCachedKiroModel(value: unknown): value is KiroModel {
     isPositiveNumber(value.contextWindow) &&
     isPositiveNumber(value.maxTokens) &&
     (value.thinkingLevelMap === undefined || isThinkingLevelMap(value.thinkingLevelMap)) &&
+    (value.thinking === undefined || isThinkingConfig(value.thinking)) &&
     (schema === undefined || isRecord(schema)) &&
     (tokenLimits === undefined || isRecord(tokenLimits)) &&
     (value.firstTokenTimeout === undefined || isPositiveNumber(value.firstTokenTimeout))
@@ -396,6 +436,19 @@ function deriveThinkingLevelMap(effortValues: readonly string[] | undefined): Th
   return Object.keys(thinkingLevelMap).length > 0 ? thinkingLevelMap : undefined;
 }
 
+/**
+ * omp >=13.9.3 reads `thinking`; pi reads `thinkingLevelMap`. Rungs are filtered
+ * through omp's own enum because Kiro may report a value outside it (`none`).
+ * `supportsDisplay` comes from the schema's `thinking.display` enum, which omp
+ * never infers for `kiro-api` — only for native anthropic/bedrock APIs.
+ */
+export function deriveThinkingConfig(config: KiroEffortConfig | undefined): KiroThinkingConfig | undefined {
+  if (!config || config.values.length === 0) return undefined;
+  const efforts = OMP_THINKING_EFFORTS.filter((effort) => config.values.includes(effort));
+  if (efforts.length === 0) return undefined;
+  return { mode: "effort", efforts, ...(config.summarizedThinking ? { supportsDisplay: true } : {}) };
+}
+
 function hasReasoningFamilyFallback(modelId: string): boolean {
   const normalizedId = modelId.toLowerCase();
   return normalizedId === "auto" || REASONING_FAMILY_MARKERS.some((marker) => normalizedId.includes(marker));
@@ -446,8 +499,12 @@ export function mapKiroCatalogModels(catalogModels: KiroCatalogModel[], region: 
 
     const existing = kiroModels.find((model) => model.id === id);
     const { schema, tokenLimits } = validateCatalogMetadata(catalogModel);
-    const effortValues = deriveKiroEffort(schema)?.values;
-    const thinkingLevelMap = deriveThinkingLevelMap(effortValues);
+    // Two-tier resolution, same as the request path: an authoritative schema wins,
+    // and a known-model guess fills in only when the catalog carried no schema. So a
+    // model that arrives schema-less still advertises the rungs its requests send.
+    const effortConfig = getKiroEffortConfig(schema, kiroModelId);
+    const thinkingLevelMap = deriveThinkingLevelMap(effortConfig?.values);
+    const thinking = deriveThinkingConfig(effortConfig);
     const catalogName =
       typeof catalogModel.displayName === "string" && catalogModel.displayName.length > 0
         ? catalogModel.displayName
@@ -461,8 +518,14 @@ export function mapKiroCatalogModels(catalogModels: KiroCatalogModel[], region: 
       api: "kiro-api",
       provider: "kiro",
       baseUrl: getKiroEndpoints(region).runtime,
-      reasoning: effortValues !== undefined || (schema === undefined && hasReasoningFamilyFallback(id)),
+      // Deliberately schema-only, matching pre-change behavior exactly: when a schema
+      // exists the resolver returns deriveKiroEffort(schema), and when it does not the
+      // family-marker guess decides. The fallback tier feeds the ladders, not this flag.
+      reasoning:
+        (schema !== undefined && effortConfig !== undefined) ||
+        (schema === undefined && hasReasoningFamilyFallback(id)),
       ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+      ...(thinking ? { thinking } : {}),
       input: existing ? [...existing.input] : isClaude ? ["text", "image"] : ["text"],
       recoverTextToolCalls: isClaude ? false : undefined,
       cost: ZERO_COST,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -259,7 +259,7 @@ export function streamKiro(
       }
 
       const kiroModelId = resolveKiroModel(model.id, modelMetadata.kiroModelId);
-      const effortConfig = getKiroEffortConfig(modelMetadata, kiroModelId);
+      const effortConfig = getKiroEffortConfig(modelMetadata.additionalModelRequestFieldsSchema, kiroModelId);
       const additionalModelRequestFields = buildKiroAdditionalModelRequestFields(
         modelMetadata,
         kiroModelId,

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -3,8 +3,10 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { getSupportedThinkingLevels, type ModelThinkingLevel } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deriveKiroEffort } from "../src/effort.js";
 import type { KiroCatalogModel } from "../src/management.js";
 import {
+  deriveThinkingConfig,
   getCachedModels,
   isCacheStale,
   KIRO_MANAGEMENT_CACHE_PATH,
@@ -22,7 +24,11 @@ const LEGACY_CACHE_PATH = join(homedir(), ".kiro-models-cache.json");
 const TEST_REGION = "test-region-1";
 const PROFILE_ARN = "arn:aws:codewhisperer:test-region-1:123456789012:profile/test";
 
-function effortSchema(field: "reasoning" | "output_config", values: string[]): Record<string, unknown> {
+function effortSchema(
+  field: "reasoning" | "output_config",
+  values: string[],
+  summarizedThinking = false,
+): Record<string, unknown> {
   return {
     type: "object",
     properties: {
@@ -31,6 +37,9 @@ function effortSchema(field: "reasoning" | "output_config", values: string[]): R
         properties: { effort: { type: "string", enum: values } },
         additionalProperties: false,
       },
+      ...(summarizedThinking
+        ? { thinking: { type: "object", properties: { display: { enum: ["summarized", "omitted"] } } } }
+        : {}),
     },
     additionalProperties: false,
   };
@@ -47,7 +56,7 @@ const catalogFixture: KiroCatalogModel[] = [
     modelId: "claude-opus-4.8",
     displayName: "Catalog Opus 4.8",
     tokenLimits: { maxInputTokens: 900_000, maxOutputTokens: 100_000 },
-    additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "xhigh", "max"]),
+    additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "xhigh", "max"], true),
   },
   {
     modelId: "claude-sonnet-4.6",
@@ -330,6 +339,115 @@ describe("Feature 2: Model Definitions", () => {
       for (const model of kiroModels.filter((candidate) => !candidate.reasoning)) {
         expect(getSupportedThinkingLevels(model), `${model.id} supported levels`).toEqual(["off"]);
       }
+    });
+  });
+
+  describe("omp thinking config", () => {
+    const OPUS_SCHEMA = effortSchema("output_config", ["low", "medium", "high", "xhigh", "max"], true);
+
+    function validCache(models: unknown[], version: number = KIRO_MANAGEMENT_CACHE_VERSION): string {
+      return JSON.stringify({
+        version,
+        source: KIRO_MANAGEMENT_CACHE_SOURCE,
+        regions: { [TEST_REGION]: { region: TEST_REGION, fetchedAt: Date.now(), models } },
+      });
+    }
+
+    it("returns the full ladder and display capability from a catalog schema", () => {
+      expect(deriveThinkingConfig(deriveKiroEffort(OPUS_SCHEMA))).toEqual({
+        mode: "effort",
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        supportsDisplay: true,
+      });
+    });
+
+    it("returns undefined when no supported effort enum is present", () => {
+      expect(deriveThinkingConfig(deriveKiroEffort({ type: "object", properties: {} }))).toBeUndefined();
+      expect(deriveThinkingConfig({ field: "reasoning", values: [], summarizedThinking: false })).toBeUndefined();
+    });
+
+    it("filters values outside omp's effort enum", () => {
+      expect(
+        deriveThinkingConfig({
+          field: "reasoning",
+          values: ["none", "low", "turbo", "max"],
+          summarizedThinking: false,
+        }),
+      ).toEqual({
+        mode: "effort",
+        efforts: ["low", "max"],
+      });
+    });
+
+    it("orders efforts lowest-first regardless of schema order", () => {
+      expect(
+        deriveThinkingConfig({
+          field: "reasoning",
+          values: ["max", "low", "high"],
+          summarizedThinking: false,
+        })?.efforts,
+      ).toEqual(["low", "high", "max"]);
+    });
+
+    it("emits both thinking and thinkingLevelMap for a schema-bearing catalog model", () => {
+      const opus = mapKiroCatalogModels(catalogFixture, TEST_REGION).find((model) => model.id === "claude-opus-4-8");
+
+      expect(opus?.thinking).toEqual({
+        mode: "effort",
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        supportsDisplay: true,
+      });
+      expect(opus?.thinkingLevelMap).toEqual({ xhigh: "xhigh", max: "max" });
+    });
+
+    it("declares a ladder for every bootstrap model that maps xhigh or max", () => {
+      const laddered = kiroModels.filter((model) => model.thinkingLevelMap !== undefined);
+
+      expect(laddered.length).toBeGreaterThan(0);
+      expect(laddered.every((model) => (model.thinking?.efforts.length ?? 0) > 0)).toBe(true);
+      expect(kiroModels.every((model) => model.reasoning || model.thinking === undefined)).toBe(true);
+    });
+
+    it("uses the request fallback only when catalog schema is absent", () => {
+      const [schemaLess] = mapKiroCatalogModels([{ modelId: "claude-opus-4.8" }], TEST_REGION);
+      const [schemaWithoutEffort] = mapKiroCatalogModels(
+        [{ modelId: "claude-opus-4.8", additionalModelRequestFieldsSchema: { type: "object", properties: {} } }],
+        TEST_REGION,
+      );
+
+      expect(schemaLess.thinking?.efforts).toEqual(["low", "medium", "high", "xhigh", "max"]);
+      expect(schemaWithoutEffort.thinking).toBeUndefined();
+    });
+
+    it("keeps a cached entry that carries a thinking config", () => {
+      const models = mapKiroCatalogModels(catalogFixture, TEST_REGION);
+      expect(models.some((model) => model.thinking !== undefined)).toBe(true);
+      writeFileSync(KIRO_MANAGEMENT_CACHE_PATH, validCache(models), "utf-8");
+
+      expect(getCachedModels(TEST_REGION).map((model) => model.id)).toEqual(models.map((model) => model.id));
+    });
+
+    it.each([
+      ["a non-effort mode", { mode: "budget", efforts: ["low"] }],
+      ["an empty effort list", { mode: "effort", efforts: [] }],
+      ["an effort outside the enum", { mode: "effort", efforts: ["turbo"] }],
+      ["a non-array effort list", { mode: "effort", efforts: "low" }],
+      ["a non-boolean display flag", { mode: "effort", efforts: ["low"], supportsDisplay: "yes" }],
+    ])("discards the whole cache when an entry has %s", (_label, thinking) => {
+      const [first, ...rest] = mapKiroCatalogModels(catalogFixture, TEST_REGION);
+      writeFileSync(KIRO_MANAGEMENT_CACHE_PATH, validCache([{ ...first, thinking }, ...rest]), "utf-8");
+
+      expect(getCachedModels(TEST_REGION)).toBe(kiroModels);
+    });
+
+    it("drops a v1 cache written before the thinking field existed", () => {
+      const models = mapKiroCatalogModels(catalogFixture, TEST_REGION).map(
+        ({ thinking: _thinking, ...model }) => model,
+      );
+      writeFileSync(KIRO_MANAGEMENT_CACHE_PATH, validCache(models, 1), "utf-8");
+
+      expect(getCachedModels(TEST_REGION)).toBe(kiroModels);
+      expect(isCacheStale(TEST_REGION)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Add reasoning-effort support for Oh My Pi (OMP) while keeping existing Pi behavior unchanged.

OMP 13.9.3 introduced native model-level thinking metadata. Pi and OMP now read these capabilities differently:

- Pi uses `thinkingLevelMap`.
- OMP 13.9.3+ uses a [`ThinkingConfig`](https://github.com/can1357/oh-my-pi/blob/main/packages/catalog/src/types.ts#L33-L55)
containing the supported effort levels and transport mode.

This change provides both formats from the same Kiro model metadata. OMP then processes the supplied configuration through its
existing
[`resolveModelThinking`](https://github.com/can1357/oh-my-pi/blob/main/packages/catalog/src/model-thinking.ts#L130-L158) path.

## Changes

- Read each model’s supported effort levels from Kiro’s authenticated model catalog.
- Generate Pi’s `thinkingLevelMap` and OMP’s `thinking` configuration from the same data.
- Reuse the same effort resolver when building Kiro requests, keeping displayed options aligned with what is sent.
- Keep `xhigh` and `max` as separate levels.
- Filter values OMP cannot represent, such as `none`.
- Detect whether a model supports summarized thinking output.
- Use the existing hardcoded mappings only when Kiro does not provide schema metadata.
- Update cached model validation and add coverage for both host formats.

This builds on the dynamic catalog and refresh behavior introduced in #91 and #93. It does not add another model list or
hardcode newly discovered models.

## Verification

- Typecheck and build passed.
- Full test suite passed: 330 tests.
- Replaced the installed Kiro extension in both Pi and OMP with a build from this fork and tested each host directly.
- Confirmed both hosts discover the authenticated Kiro catalog, including all current Opus and GPT-5.6 variants.
- Confirmed both Pi and OMP successfully send requests with the selected `max` effort.
- Confirmed the serialized Kiro request contains `output_config.effort: "max"`.
- Confirmed models can expose `max` without incorrectly adding `xhigh`.