### PR TITLE
feat: export KiroManagementHttpError and discriminate the auth plane

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,12 @@ export {
   validateKiroConversation,
   validateKiroToolStructure,
 } from "./history-validator.js";
-export type { KiroErrorPlane } from "./management.js";
-export { isKiroManagementHttpError, KiroManagementHttpError } from "./management.js";
+export type { KiroErrorPlane, KiroManagementErrorInfo } from "./management.js";
+export {
+  isKiroManagementHttpError,
+  KIRO_AUTH_PLANE_DIAGNOSTIC,
+  KiroManagementHttpError,
+} from "./management.js";
 export { KIRO_MODEL_IDS, kiroModels, resolveKiroModel } from "./models.js";
 export { streamKiro } from "./stream.js";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ export {
   validateKiroConversation,
   validateKiroToolStructure,
 } from "./history-validator.js";
+export type { KiroErrorPlane } from "./management.js";
+export { isKiroManagementHttpError, KiroManagementHttpError } from "./management.js";
 export { KIRO_MODEL_IDS, kiroModels, resolveKiroModel } from "./models.js";
 export { streamKiro } from "./stream.js";
 export {

--- a/src/management.ts
+++ b/src/management.ts
@@ -43,7 +43,38 @@ interface KiroListAvailableProfilesResponse {
 const profileArnCache = new Map<string, string>();
 const pendingProfileRequests = new Map<string, Promise<string>>();
 
+/**
+ * Which Kiro plane produced an error.
+ *
+ * The distinction is load-bearing for a consumer deciding whether to re-
+ * authenticate:
+ *
+ * - `management` resolves *who you are* — `ListAvailableProfiles`,
+ *   `ListAvailableModels`, `GetUsageLimits`. There is no per-model entitlement
+ *   layer here to deny, so a 401/403 is a credential problem.
+ * - `runtime` is `generateAssistantResponse`. It can legitimately 403 a caller
+ *   whose credential is perfectly valid but who lacks entitlement for the
+ *   requested model — a config problem that re-authentication cannot fix.
+ *
+ * Collapsing the two makes a config error look re-authenticable and sends the
+ * consumer into a pointless re-login loop.
+ */
+export type KiroErrorPlane = "management" | "runtime";
+
+/**
+ * A Kiro management control-plane HTTP failure.
+ *
+ * `message` is deliberately byte-identical to the string this class has always
+ * carried (`Kiro management <operation> failed in <region>: <status><statusText>`) —
+ * downstream consumers string-match it, so the text is an API contract. The
+ * typed fields are strictly additive: read them instead of parsing `message`.
+ */
 export class KiroManagementHttpError extends Error {
+  /** Discriminator so consumers need not parse `message` to tell the planes apart. */
+  readonly plane: KiroErrorPlane = "management";
+
+  #refreshAttempted = false;
+
   constructor(
     message: string,
     readonly status: number,
@@ -51,6 +82,50 @@ export class KiroManagementHttpError extends Error {
     super(message);
     this.name = "KiroManagementHttpError";
   }
+
+  /**
+   * True when this provider already refreshed credentials and retried before
+   * the error escaped. A consumer seeing `true` knows in-process re-auth was
+   * tried and lost, so prompting for another automatic retry is wasted work —
+   * the state needs a human to re-authenticate.
+   */
+  get refreshAttempted(): boolean {
+    return this.#refreshAttempted;
+  }
+
+  /**
+   * Record that a credential refresh was attempted, and return `this`.
+   *
+   * Returns the same instance rather than a copy because `stream.ts`
+   * deliberately rethrows the *original* error after a failed refresh; cloning
+   * would discard its stack and break `instanceof` identity for anything that
+   * captured the original.
+   */
+  markRefreshAttempted(): this {
+    this.#refreshAttempted = true;
+    return this;
+  }
+}
+
+/**
+ * True when `error` is a management-plane HTTP failure.
+ *
+ * For consumers of this package. Checks shape before `instanceof` so it still
+ * holds across duplicate copies of this package — a bundled consumer plus a
+ * `node_modules` copy produce two distinct classes, and `instanceof` alone
+ * would report `false` for a genuine management error from the other copy.
+ *
+ * Because a foreign copy's error is not this class, only the data fields
+ * (`status`, `plane`, `refreshAttempted`) are guaranteed present; do not call
+ * `markRefreshAttempted()` on a value narrowed by this guard.
+ */
+export function isKiroManagementHttpError(error: unknown): error is KiroManagementHttpError {
+  if (!(error instanceof Error)) return false;
+  const candidate = error as Partial<KiroManagementHttpError>;
+  return (
+    (candidate.plane === "management" && typeof candidate.status === "number") ||
+    error instanceof KiroManagementHttpError
+  );
 }
 
 async function requestManagement<TResponse>(

--- a/src/management.ts
+++ b/src/management.ts
@@ -62,6 +62,38 @@ const pendingProfileRequests = new Map<string, Promise<string>>();
 export type KiroErrorPlane = "management" | "runtime";
 
 /**
+ * `AssistantMessageDiagnostic.type` under which `streamKiro` reports the plane of
+ * a failure.
+ *
+ * `streamKiro` flattens every thrown error into `AssistantMessage.errorMessage`,
+ * a string, so a consumer of the stream never receives the error object itself.
+ * This diagnostic is the machine-readable channel that survives that
+ * flattening: its `details` carry `plane`, `status`, and `refreshAttempted`.
+ *
+ * Only management-plane failures are tagged. A runtime failure — and any local
+ * precondition failure, such as absent credentials — emits no diagnostic of
+ * this type, so a management error is identified by its presence and everything
+ * else by its absence, without parsing `errorMessage`.
+ */
+export const KIRO_AUTH_PLANE_DIAGNOSTIC = "kiro_auth_plane";
+
+/**
+ * The data an `isKiroManagementHttpError()` caller may rely on.
+ *
+ * Deliberately narrower than `KiroManagementHttpError`: the guard also accepts a
+ * structurally-identical error from a duplicate copy of this package, which is
+ * not this class and therefore carries no methods. Narrowing to the class would
+ * let `markRefreshAttempted()` typecheck on such a value and throw at runtime.
+ *
+ * `refreshAttempted` is optional because a foreign copy may predate that field.
+ */
+export interface KiroManagementErrorInfo extends Error {
+  readonly plane: "management";
+  readonly status: number;
+  readonly refreshAttempted?: boolean;
+}
+
+/**
  * A Kiro management control-plane HTTP failure.
  *
  * `message` is deliberately byte-identical to the string this class has always
@@ -70,8 +102,12 @@ export type KiroErrorPlane = "management" | "runtime";
  * typed fields are strictly additive: read them instead of parsing `message`.
  */
 export class KiroManagementHttpError extends Error {
-  /** Discriminator so consumers need not parse `message` to tell the planes apart. */
-  readonly plane: KiroErrorPlane = "management";
+  /**
+   * Discriminator so consumers need not parse `message` to tell the planes
+   * apart. Typed as the literal rather than `KiroErrorPlane` so a consumer
+   * comparing it against `"runtime"` is told that branch is unreachable.
+   */
+  readonly plane = "management" as const;
 
   #refreshAttempted = false;
 
@@ -88,6 +124,13 @@ export class KiroManagementHttpError extends Error {
    * the error escaped. A consumer seeing `true` knows in-process re-auth was
    * tried and lost, so prompting for another automatic retry is wasted work —
    * the state needs a human to re-authenticate.
+   *
+   * Only `streamKiro` sets this, and it never rethrows to its caller — it
+   * flattens the error into `AssistantMessage.errorMessage`. Read this field
+   * from the `KIRO_AUTH_PLANE_DIAGNOSTIC` diagnostic on that message rather
+   * than expecting to catch the error object. It is readable directly only when
+   * calling the management helpers in this module yourself, and is always
+   * `false` there, because nothing but `streamKiro` attempts a refresh.
    */
   get refreshAttempted(): boolean {
     return this.#refreshAttempted;
@@ -115,13 +158,13 @@ export class KiroManagementHttpError extends Error {
  * `node_modules` copy produce two distinct classes, and `instanceof` alone
  * would report `false` for a genuine management error from the other copy.
  *
- * Because a foreign copy's error is not this class, only the data fields
- * (`status`, `plane`, `refreshAttempted`) are guaranteed present; do not call
- * `markRefreshAttempted()` on a value narrowed by this guard.
+ * Narrows to `KiroManagementErrorInfo`, not to this class: a foreign copy's
+ * error carries the data fields but no methods, so the narrowed type omits
+ * `markRefreshAttempted()` rather than letting a call on it typecheck and throw.
  */
-export function isKiroManagementHttpError(error: unknown): error is KiroManagementHttpError {
+export function isKiroManagementHttpError(error: unknown): error is KiroManagementErrorInfo {
   if (!(error instanceof Error)) return false;
-  const candidate = error as Partial<KiroManagementHttpError>;
+  const candidate = error as Partial<KiroManagementErrorInfo>;
   return (
     (candidate.plane === "management" && typeof candidate.status === "number") ||
     error instanceof KiroManagementHttpError

--- a/src/management.ts
+++ b/src/management.ts
@@ -120,10 +120,12 @@ export class KiroManagementHttpError extends Error {
   }
 
   /**
-   * True when this provider already refreshed credentials and retried before
-   * the error escaped. A consumer seeing `true` knows in-process re-auth was
-   * tried and lost, so prompting for another automatic retry is wasted work —
-   * the state needs a human to re-authenticate.
+   * True when this provider already tried to obtain a working credential before
+   * the error escaped — either the refresh itself failed, or it produced a
+   * credential the management plane then rejected too. A consumer seeing `true`
+   * knows in-process re-auth was tried and lost, so prompting for another
+   * automatic retry is wasted work — the state needs a human to
+   * re-authenticate.
    *
    * Only `streamKiro` sets this, and it never rethrows to its caller — it
    * flattens the error into `AssistantMessage.errorMessage`. Read this field

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -40,6 +40,7 @@ import { isKiroToolStructureRule, kiroConversationEntries, repairKiroConversatio
 import { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, refreshViaKiroCli } from "./kiro-cli.js";
 import {
   invalidateKiroProfileArn,
+  KIRO_AUTH_PLANE_DIAGNOSTIC,
   type KiroManagementAuth,
   KiroManagementHttpError,
   resetKiroProfileArnCache,
@@ -1043,6 +1044,24 @@ export function streamKiro(
     } catch (error) {
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
       output.errorMessage = formatSafeError(error);
+      // `errorMessage` is a string, so the typed error object never reaches the
+      // consumer. Republish the management-plane discriminator through the
+      // diagnostics channel, which does survive on the AssistantMessage, so a
+      // consumer can classify the failure without matching error prose.
+      if (error instanceof KiroManagementHttpError) {
+        output.diagnostics = [
+          ...(output.diagnostics ?? []),
+          {
+            type: KIRO_AUTH_PLANE_DIAGNOSTIC,
+            timestamp: Date.now(),
+            details: {
+              plane: error.plane,
+              status: error.status,
+              refreshAttempted: error.refreshAttempted,
+            },
+          },
+        ];
+      }
       debugLog("response.caught", { stopReason: output.stopReason, error: output.errorMessage });
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -145,6 +145,25 @@ export function resetProfileArnCache(resolved = false): void {
   skipProfileResolutionForTests = resolved;
 }
 
+/**
+ * Resolve the profile ARN on a management call made *after* a credential
+ * refresh, flagging any management failure as refresh-already-attempted.
+ *
+ * A 401/403 here means the freshly-refreshed credential was itself rejected, so
+ * a consumer must not read it as a first-contact auth error it can recover from
+ * by refreshing again.
+ */
+async function resolveProfileArnAfterRefresh(auth: KiroManagementAuth): Promise<string> {
+  try {
+    return await resolveKiroProfileArn(auth);
+  } catch (error) {
+    // instanceof, not the structural guard: this error can only come from the
+    // module-local management.ts, so it is always the local class.
+    if (error instanceof KiroManagementHttpError) throw error.markRefreshAttempted();
+    throw error;
+  }
+}
+
 function emitToolCall(
   state: KiroToolCallState,
   output: AssistantMessage,
@@ -241,13 +260,15 @@ export function streamKiro(
         const storedCreds = getKiroCliCredentials();
         const freshCreds =
           storedCreds?.access && storedCreds.access !== accessToken ? storedCreds : refreshViaKiroCli();
-        if (!freshCreds?.access) throw error;
+        // Rethrow the ORIGINAL error, flagged so the consumer knows in-process
+        // re-auth was already tried and lost.
+        if (!freshCreds?.access) throw error.markRefreshAttempted();
 
         accessToken = freshCreds.access;
         managementAuth = { accessToken, region };
         profileArn =
           freshCreds.profileArn ||
-          (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveKiroProfileArn(managementAuth));
+          (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveProfileArnAfterRefresh(managementAuth));
       }
 
       // Trigger dynamic models cache update in the background if empty or stale
@@ -647,7 +668,9 @@ export function streamKiro(
               profileArn =
                 freshCreds?.profileArn ||
                 inheritedDesktopProfileArn ||
-                (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveKiroProfileArn(managementAuth));
+                (skipProfileResolutionForTests
+                  ? TEST_PROFILE_ARN
+                  : await resolveProfileArnAfterRefresh(managementAuth));
               const delayMs = exponentialBackoff(retryCount - 1, 500, MAX_RETRY_DELAY);
               await abortableDelay(delayMs, options?.signal);
               break; // break inner loop, continue outer loop

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -152,6 +152,19 @@ describe("management-plane error typing", () => {
     expect(isKiroManagementHttpError(foreign)).toBe(true);
   });
 
+  it("narrows to the data fields only, not to the class methods", async () => {
+    const error: unknown = await managementFailure(403, "Forbidden").catch((e: unknown) => e);
+
+    if (!isKiroManagementHttpError(error)) throw new Error("expected a management error");
+    expect(error.status).toBe(403);
+    expect(error.plane).toBe("management");
+    expect(error.refreshAttempted).toBe(false);
+    // A foreign copy's error passes the guard but carries no methods, so the
+    // narrowed type must not offer one — this would throw at runtime.
+    // @ts-expect-error markRefreshAttempted is absent from KiroManagementErrorInfo
+    expect(error.markRefreshAttempted).toBeTypeOf("function");
+  });
+
   it("rejects non-errors and unrelated errors", () => {
     expect(isKiroManagementHttpError(undefined)).toBe(false);
     expect(isKiroManagementHttpError({ plane: "management", status: 403 })).toBe(false);

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchKiroModelCatalog,
+  isKiroManagementHttpError,
+  KiroManagementHttpError,
   listAvailableModels,
   resetKiroProfileArnCache,
   resolveKiroProfileArn,
@@ -80,5 +82,101 @@ describe("Kiro management control plane", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(fetchMock.mock.calls[0][0]).toContain("https://management.us-east-1.kiro.dev/List-Available-Models?");
+  });
+});
+
+describe("management-plane error typing", () => {
+  const managementFailure = (status: number, statusText?: string) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status, statusText });
+    vi.stubGlobal("fetch", fetchMock);
+    return resolveKiroProfileArn(auth);
+  };
+
+  it("is reachable through the package entry point", async () => {
+    const entry = await import("../src/index.js");
+
+    expect(entry.KiroManagementHttpError).toBe(KiroManagementHttpError);
+    expect(typeof entry.isKiroManagementHttpError).toBe("function");
+
+    const error = await managementFailure(403, "Forbidden").catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(entry.KiroManagementHttpError);
+    expect(entry.isKiroManagementHttpError(error)).toBe(true);
+  });
+
+  it("carries status and the plane discriminator on 401 and 403", async () => {
+    for (const status of [401, 403]) {
+      const error = await managementFailure(status, "Forbidden").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(KiroManagementHttpError);
+      const typed = error as KiroManagementHttpError;
+      expect(typed.status).toBe(status);
+      expect(typed.plane).toBe("management");
+      expect(typed.name).toBe("KiroManagementHttpError");
+      expect(typed).toBeInstanceOf(Error);
+      resetKiroProfileArnCache();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("distinguishes a runtime 403 from a management 403 without reading .message", async () => {
+    const managementError = (await managementFailure(403, "Forbidden").catch((e: unknown) => e)) as Error;
+    // Exactly what src/stream.ts throws on the runtime plane today.
+    const runtimeError = new Error(
+      'Kiro API error: 403 Forbidden {"message":"The bearer token included in the request is invalid.","reason":null}',
+    );
+
+    expect(isKiroManagementHttpError(managementError)).toBe(true);
+    expect(isKiroManagementHttpError(runtimeError)).toBe(false);
+    expect((managementError as KiroManagementHttpError).plane).toBe("management");
+    expect((runtimeError as Partial<KiroManagementHttpError>).plane).toBeUndefined();
+  });
+
+  it("recognises a management error from a duplicate copy of this package", () => {
+    // A bundled consumer plus a node_modules copy yield two distinct classes;
+    // instanceof alone would reject a genuine management error from the other.
+    class ForeignKiroManagementHttpError extends Error {
+      readonly plane = "management" as const;
+      constructor(
+        message: string,
+        readonly status: number,
+      ) {
+        super(message);
+      }
+    }
+    const foreign = new ForeignKiroManagementHttpError(
+      "Kiro management ListAvailableProfiles failed in us-east-1: 403",
+      403,
+    );
+
+    expect(foreign).not.toBeInstanceOf(KiroManagementHttpError);
+    expect(isKiroManagementHttpError(foreign)).toBe(true);
+  });
+
+  it("rejects non-errors and unrelated errors", () => {
+    expect(isKiroManagementHttpError(undefined)).toBe(false);
+    expect(isKiroManagementHttpError({ plane: "management", status: 403 })).toBe(false);
+    expect(isKiroManagementHttpError(new Error("boom"))).toBe(false);
+  });
+
+  it("keeps the existing message text byte-identical", async () => {
+    const withStatusText = (await managementFailure(403, "Forbidden").catch((e: unknown) => e)) as Error;
+    expect(withStatusText.message).toBe("Kiro management ListAvailableProfiles failed in us-east-1: 403 Forbidden");
+    resetKiroProfileArnCache();
+    vi.unstubAllGlobals();
+
+    // Empty statusText contributes no trailing space — preserve that quirk.
+    const withoutStatusText = (await managementFailure(401, "").catch((e: unknown) => e)) as Error;
+    expect(withoutStatusText.message).toBe("Kiro management ListAvailableProfiles failed in us-east-1: 401");
+  });
+
+  it("reports refreshAttempted only after a refresh was tried", async () => {
+    const error = (await managementFailure(403, "Forbidden").catch((e: unknown) => e)) as KiroManagementHttpError;
+
+    expect(error.refreshAttempted).toBe(false);
+    expect(error.markRefreshAttempted()).toBe(error);
+    expect(error.refreshAttempted).toBe(true);
+    // Flagging must not disturb the message contract or the discriminator.
+    expect(error.message).toBe("Kiro management ListAvailableProfiles failed in us-east-1: 403 Forbidden");
+    expect(error.plane).toBe("management");
   });
 });

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -92,7 +92,15 @@ describe("management-plane error typing", () => {
     return resolveKiroProfileArn(auth);
   };
 
-  it("is reachable through the package entry point", async () => {
+  // Scope note: this asserts the symbols leave `src/index.ts`, the module
+  // esbuild bundles into `dist/index.js` — the file `package.json`'s
+  // `pi.extensions` tells the pi host to load. It is NOT proof that
+  // `import { KiroManagementHttpError } from "pi-provider-kiro"` resolves for an
+  // npm consumer: `package.json` declares no `main`, `types`, or `exports`, so a
+  // bare specifier cannot resolve and no `.d.ts` ships. Establishing that
+  // contract needs packed-tarball coverage and belongs to the packaging change,
+  // not here.
+  it("is re-exported from the extension entry module", async () => {
     const entry = await import("../src/index.js");
 
     expect(entry.KiroManagementHttpError).toBe(KiroManagementHttpError);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -12,6 +12,7 @@ import { isContextOverflow } from "@earendil-works/pi-ai/compat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { validateKiroConversation, validateKiroToolStructure } from "../src/history-validator.js";
+import { KIRO_AUTH_PLANE_DIAGNOSTIC } from "../src/management.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
@@ -3794,4 +3795,99 @@ describe("Feature 9: Streaming Integration", () => {
 
     vi.unstubAllGlobals();
   });
+});
+
+describe("auth-plane diagnostics on the flattened error", () => {
+  // streamKiro never rethrows: it flattens every error into
+  // AssistantMessage.errorMessage, a string. These tests assert the typed plane
+  // state still reaches a consumer, through the diagnostics channel, so nothing
+  // has to match the error prose.
+  const planeDiagnostic = (events: AssistantMessageEvent[]) => {
+    const error = events.find((event) => event.type === "error");
+    expect(error?.type).toBe("error");
+    const message = error?.type === "error" ? error.error : undefined;
+    return {
+      message,
+      diagnostic: message?.diagnostics?.find((entry) => entry.type === KIRO_AUTH_PLANE_DIAGNOSTIC),
+    };
+  };
+
+  it("tags a management failure with the plane, status and refreshAttempted", async () => {
+    resetProfileArnCache(false);
+    const mockFetch = vi
+      .fn()
+      // ListAvailableProfiles rejects the host's token.
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
+      // ListAvailableProfiles fails again on the refreshed credential.
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: "Service Unavailable" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const kiroCliModule = await import("../src/kiro-cli.js");
+    const getCredsSpy = vi.spyOn(kiroCliModule, "getKiroCliCredentials").mockReturnValue({
+      refresh: "fresh-refresh|client|secret|idc",
+      access: "fresh-access-token",
+      expires: Date.now() + 3_600_000,
+      clientId: "client",
+      clientSecret: "secret",
+      region: "us-east-1",
+      authMethod: "idc",
+    });
+
+    const { message, diagnostic } = planeDiagnostic(
+      await collect(streamKiro(makeModel(), makeContext(), { apiKey: "stale-token" })),
+    );
+
+    expect(diagnostic?.details).toEqual({ plane: "management", status: 503, refreshAttempted: true });
+    // The message contract downstream matchers rely on is untouched.
+    expect(message?.errorMessage).toContain("Kiro management ListAvailableProfiles failed in us-east-1: 503");
+
+    getCredsSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports refreshAttempted false when no refresh was possible", async () => {
+    resetProfileArnCache(false);
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 401, statusText: "Unauthorized" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    // A 401 is not the 403 that triggers the refresh branch, so the error
+    // escapes without any refresh attempt.
+    const { diagnostic } = planeDiagnostic(
+      await collect(streamKiro(makeModel(), makeContext(), { apiKey: "stale-token" })),
+    );
+
+    expect(diagnostic?.details).toEqual({ plane: "management", status: 401, refreshAttempted: false });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves a runtime 403 untagged, so the planes are distinguishable without .message", async () => {
+    // Profile already resolved: every call below is the runtime plane.
+    resetProfileArnCache(true);
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      // A valid credential lacking entitlement for the requested model — the
+      // case re-authentication cannot fix.
+      text: () => Promise.resolve('{"message":"You do not have access to the model."}'),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const kiroCliModule = await import("../src/kiro-cli.js");
+    const refreshSpy = vi.spyOn(kiroCliModule, "refreshViaKiroCli").mockReturnValue(undefined);
+    const getCredsSpy = vi.spyOn(kiroCliModule, "getKiroCliCredentials").mockReturnValue(undefined);
+
+    const { message, diagnostic } = planeDiagnostic(
+      await collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" })),
+    );
+
+    expect(message?.stopReason).toBe("error");
+    expect(diagnostic).toBeUndefined();
+    expect(message?.errorMessage).toContain("403");
+
+    getCredsSpy.mockRestore();
+    refreshSpy.mockRestore();
+    vi.unstubAllGlobals();
+  }, 20000);
 });


### PR DESCRIPTION
## Problem

`src/management.ts` already defines exactly the right shape:

```ts
export class KiroManagementHttpError extends Error {
  constructor(message: string, readonly status: number) { … }
}
```

It is **not re-exported from `src/index.ts`**, so no consumer can `instanceof` it. Downstream code is forced to regex the management-plane error prose instead. A consumer of this provider has an entire file whose only job is matching this provider's auth grammar:

```
/\bKiro management\b[^\n]*\bfailed\b[^\n]*[: ](?:401|403)\b/i
/\bKiro API error\b[^\n]*\b(?:401|403)\b/i
```

That file exists solely because the type is unreachable.

## Change

**1. Re-export `KiroManagementHttpError`** from `src/index.ts`, along with `KiroErrorPlane`, `KiroManagementErrorInfo`, `isKiroManagementHttpError()`, and `KIRO_AUTH_PLANE_DIAGNOSTIC`.

**2. Add a plane discriminator** — `plane: "management"` on the class, typed against `KiroErrorPlane = "management" | "runtime"`. The distinction is semantically load-bearing:

- A **management** 401/403 is identity/profile/catalog resolution (`ListAvailableProfiles`, `ListAvailableModels`, `GetUsageLimits`). That plane has no per-model entitlement layer to deny, so a 401/403 there is a credential problem.
- A **runtime** 403 may be a perfectly valid credential lacking entitlement for the requested model — something re-authentication cannot fix.

Collapsing them makes a config error look re-authenticable and sends the consumer into a pointless re-login loop.

**3. Surface the already-attempted refresh** — `refreshAttempted` plus `markRefreshAttempted()`. `streamKiro` already refreshes credentials and retries a management 403 before rethrowing the *original* error; a consumer had no way to know in-process re-auth was already tried and lost. Set at both rethrow points: when kiro-cli yields no fresh credential at all (the dominant path, no retry), and when profile resolution fails *again* on the refreshed credential.

`markRefreshAttempted()` returns the same instance rather than a copy, because `stream.ts` deliberately rethrows the original error; cloning would discard its stack and break `instanceof` identity for anything holding the original.

**4. Republish the plane state through `AssistantMessage.diagnostics`.** This is what makes the typed fields actually observable, and it is the crux of the change.

`streamKiro` is the only public API that can produce a `KiroManagementHttpError` — `index.ts` exports neither `resolveKiroProfileArn` nor `fetchKiroModelCatalog`. But `streamKiro` never rethrows: its outer catch sets `output.errorMessage = formatSafeError(error)` and pushes the `AssistantMessage`, destroying the error object at the boundary. Both `markRefreshAttempted()` call sites sit inside that try. So a typed field alone would be **write-only** — no consumer could ever read `refreshAttempted: true`, and `plane` would be reachable only by deep-importing an unexported module.

`diagnostics` is a modelled pi-ai field that survives the flattening:

- `KIRO_AUTH_PLANE_DIAGNOSTIC` (`"kiro_auth_plane"`), whose `details` carry `plane`, `status`, and `refreshAttempted`.
- Only management failures are tagged, so **a management 403 is identified by the diagnostic's presence and a runtime 403 by its absence** — the plane distinction, through the path an actual consumer uses.
- `errorMessage` is untouched.

**5. Narrow the guard to data, not to the class.** `isKiroManagementHttpError()` narrows to a new `KiroManagementErrorInfo` (an `Error` with `plane`, `status`, optional `refreshAttempted`). The guard checks shape before `instanceof` so it still holds across duplicate copies of this package — a bundled consumer plus a `node_modules` copy produce two distinct classes. But such a foreign error carries **no methods**, so narrowing to the class would let `markRefreshAttempted()` typecheck on it and throw at runtime. `refreshAttempted` is optional on the interface because a foreign copy may predate the field. Inside `stream.ts` the plain `instanceof` is kept, since an error there can only come from the module-local class.

`plane` is the literal `"management"` on the class, so comparing it against `"runtime"` is reported as unreachable rather than silently compiling.

## Compatibility

**Message text is unchanged.** Every existing downstream matcher keeps working; the typed fields and the diagnostic are strictly additive. A test asserts byte-exact equality for both the `403 Forbidden` form and the empty-`statusText` form (`… : 401`, no trailing space).

## Tests

`test/management.test.ts` — `management-plane error typing`:

- Symbols are re-exported from `src/index.ts`, and the entry-module class is identity-equal to the module's.
- Management 401 and 403 carry `status`, `plane: "management"`, `name`, and remain `instanceof Error`.
- A management error from a *duplicate copy* of this package is still recognised by the guard, though it is not `instanceof` the local class.
- A `@ts-expect-error` case pins the guard's narrowing, so widening it back to the class fails the typecheck rather than regressing silently.
- Negative controls: non-errors, plain objects with the right shape, unrelated `Error`s.
- Message text byte-identical, including the empty-`statusText` quirk.
- `refreshAttempted` defaults to `false`; `markRefreshAttempted()` returns the same instance and disturbs neither the message nor the discriminator.

`test/stream.test.ts` — three cases drive `streamKiro` itself and assert the diagnostic a consumer actually receives:

- Management 503 after a failed refresh → diagnostic with `refreshAttempted: true`.
- Management 401 with no refresh possible → `refreshAttempted: false`.
- Unentitled runtime 403 → **no diagnostic at all**, which is how a consumer tells it from a management 403 without reading `.message`.

## Scope note on the entry-point claim

The re-export test imports `../src/index.js`, which proves the symbols leave the module esbuild bundles into `dist/index.js` — the file `package.json`'s `pi.extensions` tells the pi host to load. It is **not** proof that `import { KiroManagementHttpError } from "pi-provider-kiro"` resolves for an npm consumer: `package.json` declares no `main`, `types`, or `exports`, so a bare specifier cannot resolve and no `.d.ts` ships. Establishing that contract needs packed-tarball coverage and belongs to a packaging change, not this one. The test is named for what it verifies so it is not misread as tarball coverage.

## Relationship to the sibling `KiroApiError` PR

The runtime throw sites are left alone here — they belong to the sibling `KiroApiError` PR. Runtime is identified by the *absence* of the management diagnostic. Once `KiroApiError` lands it can adopt `plane: "runtime"` from the exported `KiroErrorPlane` type, giving the positive form without changing any consumer.

## Verification

`npm run check` (src + test tsconfig), `npm test` — **327 passed / 18 files**, `npm run lint` (biome, clean), `npm run build` — all pass. No lockfile or `dist/` churn.
