### PR TITLE
fix(stream): route Kiro events by modeled event-type key, not field sniffing

### DIFF
--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -43,6 +43,13 @@ export type KiroUsageData = {
   cacheReadInputTokens?: number;
   cacheWriteInputTokens?: number;
   contextUsagePercentage?: number;
+  /**
+   * `TokenUsage.normalizedTokenUsage` — usage normalized by MPS from credit
+   * information. Distinct from `MeteringEvent.usage`, which is a raw credit
+   * count; surfaced so it is not dropped at the boundary like the rest of
+   * `MetadataEvent` was.
+   */
+  normalizedTokenUsage?: number;
   /** `MetadataEvent.stopReason`, passed through verbatim. */
   rawStopReason?: string;
   /** `MetadataEvent.stopDetails`, passed through verbatim. */
@@ -134,6 +141,7 @@ function parseMetadata(parsed: Record<string, unknown>): KiroStreamEvent | null 
     cacheReadInputTokens: num(tu.cacheReadInputTokens),
     cacheWriteInputTokens: num(tu.cacheWriteInputTokens),
     contextUsagePercentage: num(tu.contextUsagePercentage),
+    normalizedTokenUsage: num(tu.normalizedTokenUsage),
     rawStopReason: str(parsed.stopReason),
     stopDetails:
       parsed.stopDetails && typeof parsed.stopDetails === "object"

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -1,5 +1,67 @@
-// ABOUTME: Kiro stream event type definitions and JSON-to-typed-event mapping.
+// ABOUTME: Kiro stream event type definitions and modeled-key-to-typed-event mapping.
 // ABOUTME: Binary framing is handled by @smithy/core EventStreamMarshaller in stream.ts.
+
+/**
+ * Members of the `ChatResponseStream` tagged union emitted by
+ * `generateAssistantResponse` on `runtime.{region}.kiro.dev`.
+ *
+ * Source of truth: the generated Smithy client for the same service
+ * (`@amzn/kiro-runtime-service-typescript-client`, `ChatResponseStream`).
+ * The frame's `:event-type` header carries one of these keys, so routing is a
+ * switch on the key rather than a guess based on which fields happen to be set.
+ */
+export const KIRO_EVENT_KEYS = [
+  "assistantResponseEvent",
+  "codeReferenceEvent",
+  "contextUsageEvent",
+  "documentCitationEvent",
+  "error",
+  "metadataEvent",
+  "meteringEvent",
+  "reasoningContentEvent",
+  "serviceUnavailableError",
+  "throttlingError",
+  "toolResultEvent",
+  "toolUseEvent",
+  "validationError",
+] as const;
+
+export type KiroEventKey = (typeof KIRO_EVENT_KEYS)[number];
+
+const KIRO_EVENT_KEY_SET: ReadonlySet<string> = new Set(KIRO_EVENT_KEYS);
+
+export function isKiroEventKey(key: string): key is KiroEventKey {
+  return KIRO_EVENT_KEY_SET.has(key);
+}
+
+/** Token accounting from `MetadataEvent.tokenUsage`. */
+export type KiroUsageData = {
+  /** `TokenUsage.uncachedInputTokens` — input tokens billed at full rate. */
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  contextUsagePercentage?: number;
+  /** `MetadataEvent.stopReason`, passed through verbatim. */
+  rawStopReason?: string;
+  /** `MetadataEvent.stopDetails`, passed through verbatim. */
+  stopDetails?: Record<string, unknown>;
+};
+
+/** Which modeled union member produced an error event. */
+export type KiroErrorKind = "internalServer" | "throttling" | "validation" | "serviceUnavailable" | "unknown";
+
+export type KiroErrorData = {
+  /** Exception class name, or the legacy free-form `error` string. */
+  error: string;
+  message?: string;
+  kind: KiroErrorKind;
+  /** `ThrottlingException.reason` / `ValidationException.reason`, passed through. */
+  reason?: string;
+  /** `ThrottlingException.retryAfterMilliseconds`. */
+  retryAfterMilliseconds?: number;
+};
 
 export type KiroStreamEvent =
   | { type: "content"; data: string }
@@ -10,53 +72,169 @@ export type KiroStreamEvent =
   | { type: "toolUseStop"; data: { stop: boolean } }
   | { type: "contextUsage"; data: { contextUsagePercentage: number } }
   | { type: "followupPrompt"; data: string }
-  | { type: "usage"; data: { inputTokens?: number; outputTokens?: number } }
-  | { type: "error"; data: { error: string; message?: string } };
+  | { type: "usage"; data: KiroUsageData }
+  /** `MeteringEvent` — `usage` is a COUNT OF CREDITS, not tokens. */
+  | { type: "metering"; data: { credits?: number; unit?: string; unitPlural?: string } }
+  | { type: "error"; data: KiroErrorData }
+  /** A known union member with no consumer yet. Kept distinct from unparseable. */
+  | { type: "ignored"; data: { key: string } };
 
-export function parseKiroEvent(parsed: Record<string, unknown>): KiroStreamEvent | null {
-  if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };
-  if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
-  if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
+const num = (v: unknown): number | undefined => (typeof v === "number" ? v : undefined);
+const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+
+/** Serialize a toolUse `input` field, collapsing the empty-object placeholder to "". */
+function toolInput(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object" && Object.keys(raw as Record<string, unknown>).length > 0) {
+    return JSON.stringify(raw);
+  }
+  return "";
+}
+
+function parseToolUse(parsed: Record<string, unknown>): KiroStreamEvent | null {
+  // Kiro splits one logical tool call across frames: the first carries
+  // name+toolUseId, continuations carry only `input`, the last only `stop`.
   if (parsed.name && parsed.toolUseId) {
-    const input =
-      typeof parsed.input === "string"
-        ? parsed.input
-        : parsed.input &&
-            typeof parsed.input === "object" &&
-            Object.keys(parsed.input as Record<string, unknown>).length > 0
-          ? JSON.stringify(parsed.input)
-          : "";
     return {
       type: "toolUse",
       data: {
         name: parsed.name as string,
         toolUseId: parsed.toolUseId as string,
-        input,
+        input: toolInput(parsed.input),
         stop: parsed.stop as boolean | undefined,
       },
     };
   }
+  if (parsed.input !== undefined) {
+    return { type: "toolUseInput", data: { input: toolInput(parsed.input) } };
+  }
+  if (parsed.stop !== undefined) return { type: "toolUseStop", data: { stop: parsed.stop as boolean } };
+  return null;
+}
+
+function parseMetadata(parsed: Record<string, unknown>): KiroStreamEvent | null {
+  const tu = (parsed.tokenUsage ?? {}) as Record<string, unknown>;
+  const data: KiroUsageData = {
+    inputTokens: num(tu.uncachedInputTokens),
+    outputTokens: num(tu.outputTokens),
+    totalTokens: num(tu.totalTokens),
+    cacheReadInputTokens: num(tu.cacheReadInputTokens),
+    cacheWriteInputTokens: num(tu.cacheWriteInputTokens),
+    contextUsagePercentage: num(tu.contextUsagePercentage),
+    rawStopReason: str(parsed.stopReason),
+    stopDetails:
+      parsed.stopDetails && typeof parsed.stopDetails === "object"
+        ? (parsed.stopDetails as Record<string, unknown>)
+        : undefined,
+  };
+  for (const k of Object.keys(data) as (keyof KiroUsageData)[]) {
+    if (data[k] === undefined) delete data[k];
+  }
+  return Object.keys(data).length > 0 ? { type: "usage", data } : null;
+}
+
+function parseError(parsed: Record<string, unknown>, kind: KiroErrorKind, fallbackName: string): KiroStreamEvent {
+  // Modeled exceptions carry {message, reason?, retryAfterMilliseconds?}; older
+  // free-form frames carry {error, message}. Accept both.
+  const rawError = parsed.error ?? parsed.Error;
+  const error =
+    typeof rawError === "string"
+      ? rawError
+      : rawError !== undefined
+        ? JSON.stringify(rawError)
+        : (str(parsed.name) ?? fallbackName);
+  const message = (parsed.message ?? parsed.Message ?? parsed.reason) as string | undefined;
+  const data: KiroErrorData = { error, kind };
+  if (typeof message === "string") data.message = message;
+  const reason = str(parsed.reason);
+  if (reason !== undefined) data.reason = reason;
+  const retryAfterMilliseconds = num(parsed.retryAfterMilliseconds);
+  if (retryAfterMilliseconds !== undefined) data.retryAfterMilliseconds = retryAfterMilliseconds;
+  return { type: "error", data };
+}
+
+/**
+ * Route a decoded stream frame by its modeled `:event-type` key.
+ *
+ * `key` is the `ChatResponseStream` union member name from the frame header.
+ * Unknown or missing keys fall back to {@link parseKiroEventByShape} so new
+ * server-side members degrade instead of breaking the stream.
+ */
+export function parseKiroEvent(key: string, parsed: Record<string, unknown>): KiroStreamEvent | null {
+  switch (key) {
+    case "assistantResponseEvent": {
+      const content = str(parsed.content);
+      return content !== undefined ? { type: "content", data: content } : null;
+    }
+    case "reasoningContentEvent": {
+      // ReasoningContentEvent = {text?, redactedContent?, signature?}
+      const text = str(parsed.text);
+      if (text !== undefined) return { type: "thinkingText", data: text };
+      const signature = str(parsed.signature);
+      if (signature !== undefined) return { type: "thinkingSignature", data: signature };
+      return { type: "ignored", data: { key } };
+    }
+    case "toolUseEvent":
+      return parseToolUse(parsed);
+    case "contextUsageEvent": {
+      const pct = num(parsed.contextUsagePercentage);
+      return pct !== undefined ? { type: "contextUsage", data: { contextUsagePercentage: pct } } : null;
+    }
+    case "metadataEvent":
+      return parseMetadata(parsed);
+    case "meteringEvent":
+      // MeteringEvent.usage is a NUMBER of credits — never token counts.
+      return {
+        type: "metering",
+        data: { credits: num(parsed.usage), unit: str(parsed.unit), unitPlural: str(parsed.unitPlural) },
+      };
+    case "error":
+      return parseError(parsed, "internalServer", "InternalServerException");
+    case "throttlingError":
+      return parseError(parsed, "throttling", "ThrottlingException");
+    case "validationError":
+      return parseError(parsed, "validation", "ValidationException");
+    case "serviceUnavailableError":
+      return parseError(parsed, "serviceUnavailable", "ServiceUnavailableException");
+    // Known members with no consumer yet: explicitly ignored, not unparseable.
+    case "codeReferenceEvent":
+    case "documentCitationEvent":
+    case "toolResultEvent":
+      return { type: "ignored", data: { key } };
+    default:
+      return parseKiroEventByShape(parsed);
+  }
+}
+
+/**
+ * Fail-open fallback for `$unknown` / unkeyed frames.
+ *
+ * Order-dependent field sniffing. Only reachable when the frame carries no
+ * recognizable `:event-type`; modeled frames never reach here.
+ */
+export function parseKiroEventByShape(parsed: Record<string, unknown>): KiroStreamEvent | null {
+  if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };
+  if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
+  if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
+  if (parsed.name && parsed.toolUseId) return parseToolUse(parsed);
   if (parsed.input !== undefined && !parsed.name) {
-    return {
-      type: "toolUseInput",
-      data: { input: typeof parsed.input === "string" ? parsed.input : JSON.stringify(parsed.input) },
-    };
+    return { type: "toolUseInput", data: { input: toolInput(parsed.input) } };
   }
   if (parsed.stop !== undefined && parsed.contextUsagePercentage === undefined)
     return { type: "toolUseStop", data: { stop: parsed.stop as boolean } };
   if (parsed.contextUsagePercentage !== undefined)
     return { type: "contextUsage", data: { contextUsagePercentage: parsed.contextUsagePercentage as number } };
   if (parsed.followupPrompt !== undefined) return { type: "followupPrompt", data: parsed.followupPrompt as string };
-  if (parsed.error !== undefined || parsed.Error !== undefined) {
-    const error = (parsed.error || parsed.Error || "unknown") as string;
-    const message = (parsed.message || parsed.Message || parsed.reason) as string | undefined;
-    return { type: "error", data: { error: typeof error === "string" ? error : JSON.stringify(error), message } };
+  if (parsed.tokenUsage !== undefined || parsed.stopReason !== undefined || parsed.stopDetails !== undefined) {
+    return parseMetadata(parsed);
   }
-  if (parsed.usage !== undefined) {
-    const u = parsed.usage as Record<string, unknown>;
+  if (parsed.error !== undefined || parsed.Error !== undefined) {
+    return parseError(parsed, "unknown", "unknown");
+  }
+  if (typeof parsed.usage === "number") {
     return {
-      type: "usage",
-      data: { inputTokens: u.inputTokens as number | undefined, outputTokens: u.outputTokens as number | undefined },
+      type: "metering",
+      data: { credits: parsed.usage, unit: str(parsed.unit), unitPlural: str(parsed.unitPlural) },
     };
   }
   return null;

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -73,16 +73,37 @@ export const KIRO_ERROR_MEMBERS: Readonly<Record<string, { kind: KiroErrorKind; 
 };
 
 /**
- * Look up an error member by a key the SERVICE chose.
+ * The token the service puts in `:exception-type` is not guaranteed to be the
+ * union member name. The hand-written event-stream bridge in the generated
+ * client for THIS service (`sse-middleware.ts`, `buildStreamException`) accepts
+ * either form for every one of the four members — `throttlingError` OR
+ * `ThrottlingException` — and does so on both its exception-frame and its
+ * defensive event-frame path. That is the same service, so both tokens are
+ * observed vocabulary, not speculation.
  *
- * `KIRO_ERROR_MEMBERS` is an ordinary object literal, so a bare index would
+ * Keyed separately from `KIRO_EVENT_MEMBERS` because a class name is NOT a
+ * `ChatResponseStream` member: `KIRO_EVENT_KEYS` stays the union's enumeration
+ * and keeps guarding fixture encoding.
+ */
+const KIRO_ERROR_TOKENS: Readonly<Record<string, { kind: KiroErrorKind; exception: string }>> = {
+  ...KIRO_ERROR_MEMBERS,
+  InternalServerException: KIRO_ERROR_MEMBERS.error,
+  ThrottlingException: KIRO_ERROR_MEMBERS.throttlingError,
+  ValidationException: KIRO_ERROR_MEMBERS.validationError,
+  ServiceUnavailableException: KIRO_ERROR_MEMBERS.serviceUnavailableError,
+};
+
+/**
+ * Look up an error member by a token the SERVICE chose.
+ *
+ * `KIRO_ERROR_TOKENS` is an ordinary object literal, so a bare index would
  * also resolve inherited `Object.prototype` members: an `:exception-type` of
  * `toString` or `constructor` returns a truthy value whose `kind` and
  * `exception` are both undefined, silently discarding the member name this
  * routing exists to preserve. Only own properties count as modeled members.
  */
-function lookupErrorMember(key: string): { kind: KiroErrorKind; exception: string } | undefined {
-  return Object.hasOwn(KIRO_ERROR_MEMBERS, key) ? KIRO_ERROR_MEMBERS[key] : undefined;
+export function lookupKiroErrorMember(key: string): { kind: KiroErrorKind; exception: string } | undefined {
+  return Object.hasOwn(KIRO_ERROR_TOKENS, key) ? KIRO_ERROR_TOKENS[key] : undefined;
 }
 
 export type KiroErrorData = {
@@ -240,7 +261,7 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
     case "validationError":
     case "serviceUnavailableError": {
       // Literal case labels, so the own-property lookup always resolves.
-      const member = lookupErrorMember(key) as { kind: KiroErrorKind; exception: string };
+      const member = lookupKiroErrorMember(key) as { kind: KiroErrorKind; exception: string };
       return parseError(parsed, member.kind, member.exception);
     }
     // Known members with no consumer yet: explicitly ignored, not unparseable.
@@ -248,24 +269,33 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
     case "documentCitationEvent":
     case "toolResultEvent":
       return { type: "ignored", data: { key } };
-    default:
+    default: {
+      // An error member delivered under its exception CLASS name rather than its
+      // union member name (see KIRO_ERROR_TOKENS). Classify before shape
+      // sniffing: an exception payload is `{message, reason?}`, which the
+      // fallback ladder matches on nothing and drops — losing the class exactly
+      // the way the old field ladder did.
+      const member = lookupKiroErrorMember(key);
+      if (member) return parseError(parsed, member.kind, member.exception);
       return parseKiroEventByShape(parsed);
+    }
   }
 }
 
 /**
- * Route an `:message-type: exception` frame by its `:exception-type` key.
+ * Route an `:message-type: exception` frame by its `:exception-type` token.
  *
  * The Smithy marshaller throws whatever the deserializer returns for that key,
  * so this is the only place the modeled exception class, `reason`, and
- * `retryAfterMilliseconds` are still structured. Returns `null` for a member
- * that is not one of the four modeled errors; the caller is responsible for
- * still preserving that member's name (see `src/stream.ts`), because Smithy's
- * own raw-body fallback only fires for a `$unknown` result this deserializer
- * never produces.
+ * `retryAfterMilliseconds` are still structured. Accepts either token form the
+ * service uses (union member name or exception class name). Returns `null` for
+ * a token that is not one of the four modeled errors; the caller is responsible
+ * for still preserving that name (see `src/stream.ts`), because Smithy's own
+ * raw-body fallback only fires for a `$unknown` result this deserializer never
+ * produces.
  */
 export function parseKiroExceptionFrame(key: string, parsed: Record<string, unknown>): KiroErrorData | null {
-  const member = lookupErrorMember(key);
+  const member = lookupKiroErrorMember(key);
   if (!member) return null;
   const event = parseError(parsed, member.kind, member.exception);
   return event.data;

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -52,6 +52,19 @@ export type KiroUsageData = {
 /** Which modeled union member produced an error event. */
 export type KiroErrorKind = "internalServer" | "throttling" | "validation" | "serviceUnavailable" | "unknown";
 
+/**
+ * The four error members of `ChatResponseStream` target `@error` shapes, so the
+ * service frames them as `:message-type: exception` with the union member name
+ * in `:exception-type` — not as ordinary `event` frames. Mapping the member to
+ * its exception class here keeps both framings on one table.
+ */
+export const KIRO_ERROR_MEMBERS: Readonly<Record<string, { kind: KiroErrorKind; exception: string }>> = {
+  error: { kind: "internalServer", exception: "InternalServerException" },
+  throttlingError: { kind: "throttling", exception: "ThrottlingException" },
+  validationError: { kind: "validation", exception: "ValidationException" },
+  serviceUnavailableError: { kind: "serviceUnavailable", exception: "ServiceUnavailableException" },
+};
+
 export type KiroErrorData = {
   /** Exception class name, or the legacy free-form `error` string. */
   error: string;
@@ -133,7 +146,11 @@ function parseMetadata(parsed: Record<string, unknown>): KiroStreamEvent | null 
   return Object.keys(data).length > 0 ? { type: "usage", data } : null;
 }
 
-function parseError(parsed: Record<string, unknown>, kind: KiroErrorKind, fallbackName: string): KiroStreamEvent {
+function parseError(
+  parsed: Record<string, unknown>,
+  kind: KiroErrorKind,
+  fallbackName: string,
+): { type: "error"; data: KiroErrorData } {
   // Modeled exceptions carry {message, reason?, retryAfterMilliseconds?}; older
   // free-form frames carry {error, message}. Accept both.
   const rawError = parsed.error ?? parsed.Error;
@@ -188,14 +205,16 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
         type: "metering",
         data: { credits: num(parsed.usage), unit: str(parsed.unit), unitPlural: str(parsed.unitPlural) },
       };
+    // Reachable when a member that models an exception is delivered as an
+    // ordinary event frame. The real wire uses exception framing, handled by
+    // parseKiroExceptionFrame, but both routes must agree.
     case "error":
-      return parseError(parsed, "internalServer", "InternalServerException");
     case "throttlingError":
-      return parseError(parsed, "throttling", "ThrottlingException");
     case "validationError":
-      return parseError(parsed, "validation", "ValidationException");
-    case "serviceUnavailableError":
-      return parseError(parsed, "serviceUnavailable", "ServiceUnavailableException");
+    case "serviceUnavailableError": {
+      const member = KIRO_ERROR_MEMBERS[key];
+      return parseError(parsed, member.kind, member.exception);
+    }
     // Known members with no consumer yet: explicitly ignored, not unparseable.
     case "codeReferenceEvent":
     case "documentCitationEvent":
@@ -204,6 +223,21 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
     default:
       return parseKiroEventByShape(parsed);
   }
+}
+
+/**
+ * Route an `:message-type: exception` frame by its `:exception-type` key.
+ *
+ * The Smithy marshaller throws whatever the deserializer returns for that key,
+ * so this is the only place the modeled exception class, `reason`, and
+ * `retryAfterMilliseconds` are still structured. Unknown keys yield `null` so
+ * the caller can fall back to the raw body.
+ */
+export function parseKiroExceptionFrame(key: string, parsed: Record<string, unknown>): KiroErrorData | null {
+  const member = KIRO_ERROR_MEMBERS[key];
+  if (!member) return null;
+  const event = parseError(parsed, member.kind, member.exception);
+  return event.data;
 }
 
 /**

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -182,8 +182,14 @@ function parseError(
  * Route a decoded stream frame by its modeled `:event-type` key.
  *
  * `key` is the `ChatResponseStream` union member name from the frame header.
- * Unknown or missing keys fall back to {@link parseKiroEventByShape} so new
- * server-side members degrade instead of breaking the stream.
+ * An unrecognized key falls back to {@link parseKiroEventByShape} so a member
+ * added server-side degrades instead of breaking the stream.
+ *
+ * Note: a frame whose `:event-type` is the literal `$unknown` never reaches
+ * here. The Smithy marshaller drops any event frame for which the deserializer
+ * returns a `$unknown` property, and the deserializer keys its result by the
+ * header value, so `$unknown` is discarded one layer up. The fallback below is
+ * therefore reached only by a real, unrecognized member name.
  */
 export function parseKiroEvent(key: string, parsed: Record<string, unknown>): KiroStreamEvent | null {
   switch (key) {
@@ -238,8 +244,11 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
  *
  * The Smithy marshaller throws whatever the deserializer returns for that key,
  * so this is the only place the modeled exception class, `reason`, and
- * `retryAfterMilliseconds` are still structured. Unknown keys yield `null` so
- * the caller can fall back to the raw body.
+ * `retryAfterMilliseconds` are still structured. Returns `null` for a member
+ * that is not one of the four modeled errors; the caller is responsible for
+ * still preserving that member's name (see `src/stream.ts`), because Smithy's
+ * own raw-body fallback only fires for a `$unknown` result this deserializer
+ * never produces.
  */
 export function parseKiroExceptionFrame(key: string, parsed: Record<string, unknown>): KiroErrorData | null {
   const member = KIRO_ERROR_MEMBERS[key];
@@ -249,10 +258,10 @@ export function parseKiroExceptionFrame(key: string, parsed: Record<string, unkn
 }
 
 /**
- * Fail-open fallback for `$unknown` / unkeyed frames.
+ * Fail-open fallback for frames carrying an unrecognized `:event-type`.
  *
- * Order-dependent field sniffing. Only reachable when the frame carries no
- * recognizable `:event-type`; modeled frames never reach here.
+ * Order-dependent field sniffing. Only reachable when the frame's key is not a
+ * known `ChatResponseStream` member; modeled frames never reach here.
  */
 export function parseKiroEventByShape(parsed: Record<string, unknown>): KiroStreamEvent | null {
   if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -72,6 +72,19 @@ export const KIRO_ERROR_MEMBERS: Readonly<Record<string, { kind: KiroErrorKind; 
   serviceUnavailableError: { kind: "serviceUnavailable", exception: "ServiceUnavailableException" },
 };
 
+/**
+ * Look up an error member by a key the SERVICE chose.
+ *
+ * `KIRO_ERROR_MEMBERS` is an ordinary object literal, so a bare index would
+ * also resolve inherited `Object.prototype` members: an `:exception-type` of
+ * `toString` or `constructor` returns a truthy value whose `kind` and
+ * `exception` are both undefined, silently discarding the member name this
+ * routing exists to preserve. Only own properties count as modeled members.
+ */
+function lookupErrorMember(key: string): { kind: KiroErrorKind; exception: string } | undefined {
+  return Object.hasOwn(KIRO_ERROR_MEMBERS, key) ? KIRO_ERROR_MEMBERS[key] : undefined;
+}
+
 export type KiroErrorData = {
   /** Exception class name, or the legacy free-form `error` string. */
   error: string;
@@ -226,7 +239,8 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
     case "throttlingError":
     case "validationError":
     case "serviceUnavailableError": {
-      const member = KIRO_ERROR_MEMBERS[key];
+      // Literal case labels, so the own-property lookup always resolves.
+      const member = lookupErrorMember(key) as { kind: KiroErrorKind; exception: string };
       return parseError(parsed, member.kind, member.exception);
     }
     // Known members with no consumer yet: explicitly ignored, not unparseable.
@@ -251,7 +265,7 @@ export function parseKiroEvent(key: string, parsed: Record<string, unknown>): Ki
  * never produces.
  */
 export function parseKiroExceptionFrame(key: string, parsed: Record<string, unknown>): KiroErrorData | null {
-  const member = KIRO_ERROR_MEMBERS[key];
+  const member = lookupErrorMember(key);
   if (!member) return null;
   const event = parseError(parsed, member.kind, member.exception);
   return event.data;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -857,7 +857,13 @@ export function streamKiro(
         if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
         if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
+        // `TokenUsage.totalTokens` is required on the wire while the cache counts
+        // are optional, so the service's own total is the authoritative figure —
+        // recomputing from components silently under-reports whenever a component
+        // is omitted. Prefer it and fall back to the sum, matching how pi's
+        // bedrock adapter treats the one other wire that supplies a total.
         output.usage.totalTokens =
+          usageEvent?.totalTokens ??
           output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,7 +28,7 @@ import {
   type KiroAdditionalModelRequestFields,
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
-import { parseKiroEvent } from "./event-parser.js";
+import { type KiroUsageData, parseKiroEvent } from "./event-parser.js";
 import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
@@ -561,7 +561,7 @@ export function streamKiro(
         const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
         let totalContent = "";
         let lastContentData = "";
-        let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
+        let usageEvent: KiroUsageData | null = null;
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -671,9 +671,18 @@ export function streamKiro(
           const { done, value } = iterResult;
           if (done) break;
           resetIdle();
-          const eventPayload = Object.values(value as Record<string, unknown>)[0] as Record<string, unknown>;
-          const event = parseKiroEvent(eventPayload);
+          // The marshaller keys each frame by its modeled `ChatResponseStream`
+          // union member (from the `:event-type` header). Route on that key
+          // instead of guessing the member from which fields are populated.
+          const frameEntry = Object.entries(value as Record<string, unknown>)[0];
+          if (!frameEntry) continue;
+          const [frameKey, framePayload] = frameEntry;
+          const event = parseKiroEvent(frameKey, (framePayload ?? {}) as Record<string, unknown>);
           if (!event) continue;
+          if (event.type === "ignored") {
+            if (debugEnabled()) debugLog("stream.events.ignored", [event.data.key]);
+            continue;
+          }
           if (debugEnabled()) debugLog("stream.events", [event]);
           switch (event.type) {
             case "contextUsage": {
@@ -744,6 +753,12 @@ export function streamKiro(
             }
             case "usage": {
               usageEvent = event.data;
+              break;
+            }
+            case "metering": {
+              // MeteringEvent.usage counts credits, not tokens. Recorded for
+              // observability only; never folded into token accounting.
+              if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
             case "error": {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -752,7 +752,11 @@ export function streamKiro(
               break;
             }
             case "usage": {
-              usageEvent = event.data;
+              // Every MetadataEvent field is optional, so the service may split
+              // tokenUsage and stopReason/stopDetails across frames. Merge so a
+              // later partial frame cannot erase counts already received.
+              const prev: KiroUsageData = usageEvent ?? {};
+              usageEvent = { ...prev, ...event.data };
               break;
             }
             case "metering": {
@@ -842,9 +846,19 @@ export function streamKiro(
         // (accumulated into `totalContent` above). Otherwise tool-call-only
         // turns report 0 output tokens and break consumers like the TPS
         // extension that watch `usage.output`.
+        //
+        // `KiroUsageData.inputTokens` is `TokenUsage.uncachedInputTokens` — the
+        // input billed at full rate, NOT total input. pi's `usage.input` is the
+        // same uncached slot, with `cacheRead`/`cacheWrite` as siblings, and
+        // `calculateCost` prices all three separately. So the cache counts must
+        // land whenever `input` is taken from the wire; otherwise a cached turn
+        // reports a fraction of its real input and is priced far too low.
         if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
+        if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
+        if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
-        output.usage.totalTokens = output.usage.input + output.usage.output;
+        output.usage.totalTokens =
+          output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);
         } catch {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -657,13 +657,27 @@ export function streamKiro(
           const entry = Object.entries(event)[0];
           if (!entry) throw new Error("Received an empty event stream message");
           const [key, msg] = entry;
-          const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
           // The four error members of ChatResponseStream target `@error` shapes,
           // so the service frames them as `:message-type: exception`. The
           // marshaller keys those by `:exception-type` and throws whatever this
           // callback returns, so returning the bare payload would discard the
           // modeled class. Return an Error carrying the parsed detail instead.
           if (msg.headers[":message-type"]?.value === "exception") {
+            // Parsed defensively, and BEFORE the shared parse below: an exception
+            // body that is empty or not JSON would otherwise throw a SyntaxError
+            // out of this deserializer, and the caller would report
+            // "Unexpected end of JSON input" with the modeled class gone — the
+            // exact loss this routing removes. The class lives in the header, so
+            // it survives a body we cannot read. The same-service client's own
+            // bridge takes this position too (sse-middleware.ts: "Non-JSON body:
+            // still throw a typed exception with a fallback message").
+            let parsedException: Record<string, unknown> = {};
+            try {
+              const decoded = JSON.parse(utf8Decoder.decode(msg.body)) as unknown;
+              if (decoded && typeof decoded === "object") parsedException = decoded as Record<string, unknown>;
+            } catch {
+              // Header-only classification below.
+            }
             // An unmodeled member (a fifth error added server-side, or `$unknown`)
             // still arrives keyed by `:exception-type`. Smithy's own fail-open path
             // is unreachable here — it only triggers when the deserializer returns
@@ -671,13 +685,13 @@ export function streamKiro(
             // fallback the marshaller would throw the bare parsed body and the
             // member name would be lost in exactly the way this routing exists to
             // prevent. Synthesize the same typed shape with `kind: "unknown"`.
-            const data: KiroErrorData = parseKiroExceptionFrame(key, parsed) ?? {
+            const data: KiroErrorData = parseKiroExceptionFrame(key, parsedException) ?? {
               error: key,
               kind: "unknown",
-              ...(typeof parsed.message === "string" ? { message: parsed.message } : {}),
-              ...(typeof parsed.reason === "string" ? { reason: parsed.reason } : {}),
-              ...(typeof parsed.retryAfterMilliseconds === "number"
-                ? { retryAfterMilliseconds: parsed.retryAfterMilliseconds }
+              ...(typeof parsedException.message === "string" ? { message: parsedException.message } : {}),
+              ...(typeof parsedException.reason === "string" ? { reason: parsedException.reason } : {}),
+              ...(typeof parsedException.retryAfterMilliseconds === "number"
+                ? { retryAfterMilliseconds: parsedException.retryAfterMilliseconds }
                 : {}),
             };
             const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
@@ -685,6 +699,7 @@ export function streamKiro(
             (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
             return { [key]: error } as Record<string, unknown>;
           }
+          const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
           return { [key]: parsed } as Record<string, unknown>;
         });
         const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -836,6 +836,12 @@ export function streamKiro(
             // retry below resets for the same reason. `textBlockIndex` and the
             // tool-call state are per-iteration and need no reset here; the
             // usage block is cleared by `resetAttemptUsage` at the loop top.
+            //
+            // pi's event protocol has no retraction event, so deltas already
+            // pushed for the abandoned attempt cannot be withdrawn. The signals
+            // a consumer does get are the fresh `start` emitted for the retried
+            // attempt and the `partial` carried on every event, which is this
+            // same `output` object and so reflects the clear.
             output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,7 +28,7 @@ import {
   type KiroAdditionalModelRequestFields,
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
-import { type KiroUsageData, parseKiroEvent } from "./event-parser.js";
+import { type KiroErrorData, type KiroUsageData, parseKiroEvent, parseKiroExceptionFrame } from "./event-parser.js";
 import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
@@ -610,6 +610,11 @@ export function streamKiro(
         let gotFirstToken = false;
         let firstTokenTimedOut = false;
         let streamError: string | null = null;
+        // Structured detail for the last modeled exception frame. The message
+        // string stays the retry/throw contract; this keeps `kind`, `reason`,
+        // and `retryAfterMilliseconds` addressable instead of only readable as
+        // prose inside that string.
+        let streamErrorData: KiroErrorData | null = null;
         const FIRST_TOKEN_SENTINEL = Symbol("firstTokenTimeout");
 
         // Smithy EventStreamMarshaller handles: chunk reassembly, CRC validation,
@@ -633,6 +638,20 @@ export function streamKiro(
           if (!entry) throw new Error("Received an empty event stream message");
           const [key, msg] = entry;
           const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
+          // The four error members of ChatResponseStream target `@error` shapes,
+          // so the service frames them as `:message-type: exception`. The
+          // marshaller keys those by `:exception-type` and throws whatever this
+          // callback returns, so returning the bare payload would discard the
+          // modeled class. Return an Error carrying the parsed detail instead.
+          if (msg.headers[":message-type"]?.value === "exception") {
+            const data = parseKiroExceptionFrame(key, parsed);
+            if (data) {
+              const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
+              error.name = data.error;
+              (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
+              return { [key]: error } as Record<string, unknown>;
+            }
+          }
           return { [key]: parsed } as Record<string, unknown>;
         });
         const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;
@@ -661,7 +680,11 @@ export function streamKiro(
               iterResult = await iterator.next();
             }
           } catch (e) {
-            // Smithy throws on :message-type error/exception headers
+            // Smithy throws on :message-type error/exception headers. A modeled
+            // exception frame arrives here as the Error built in the
+            // deserializer above, with its parsed detail attached.
+            const kiroError = (e as { kiroError?: KiroErrorData } | null)?.kiroError;
+            if (kiroError) streamErrorData = kiroError;
             streamError =
               e instanceof Error
                 ? e.message
@@ -768,6 +791,7 @@ export function streamKiro(
             case "error": {
               const errMsg = event.data.message ? `${event.data.error}: ${event.data.message}` : event.data.error;
               streamError = errMsg;
+              streamErrorData = event.data;
               void bodyReader.cancel().catch(() => {});
               break;
             }
@@ -781,6 +805,9 @@ export function streamKiro(
           if (retryCount < maxRetries) {
             retryCount++;
             const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            if (streamErrorData && debugEnabled()) {
+              debugLog("stream.error.typed", [streamErrorData]);
+            }
             // `output` is created once outside the retry loop, so anything the
             // aborted attempt already appended survives into the next one. A
             // typed error frame (throttling/validation/serviceUnavailable) can

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -298,8 +298,28 @@ export function streamKiro(
       let retryCount = 0;
       const maxRetries = 3;
       const conversationId = options?.sessionId ?? crypto.randomUUID();
+      // Every wire-derived usage figure is written straight onto `output`, which
+      // outlives the retry loop, so an abandoned attempt's accounting would
+      // otherwise be billed to the turn that replaced it. Two live paths:
+      // `contextUsageEvent` sets `usage.input`/`contextPercent` mid-stream, and
+      // the post-stream metadataEvent writes land *before* the empty-response /
+      // echo-loop retry check. Clearing at the attempt boundary keeps the whole
+      // usage block sourced from one attempt, matching how `usageEvent` itself
+      // is scoped per attempt.
+      const resetAttemptUsage = () => {
+        output.usage.input = 0;
+        output.usage.output = 0;
+        output.usage.cacheRead = 0;
+        output.usage.cacheWrite = 0;
+        output.usage.totalTokens = 0;
+        output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+        // Not part of pi's Usage shape; only present once a contextUsageEvent
+        // has been seen, so a retried turn must not report the old gauge.
+        delete (output.usage as unknown as Record<string, unknown>).contextPercent;
+      };
       while (retryCount <= maxRetries) {
         if (options?.signal?.aborted) throw options.signal.reason;
+        resetAttemptUsage();
         const effectiveSystemPrompt = systemPrompt;
         const normalized = normalizeMessages(context.messages);
         const {
@@ -814,7 +834,8 @@ export function streamKiro(
             // arrive after partial text, which would otherwise concatenate the
             // abandoned prefix onto the retried response. The empty-response
             // retry below resets for the same reason. `textBlockIndex` and the
-            // tool-call state are per-iteration and need no reset here.
+            // tool-call state are per-iteration and need no reset here; the
+            // usage block is cleared by `resetAttemptUsage` at the loop top.
             output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -781,6 +781,14 @@ export function streamKiro(
           if (retryCount < maxRetries) {
             retryCount++;
             const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            // `output` is created once outside the retry loop, so anything the
+            // aborted attempt already appended survives into the next one. A
+            // typed error frame (throttling/validation/serviceUnavailable) can
+            // arrive after partial text, which would otherwise concatenate the
+            // abandoned prefix onto the retried response. The empty-response
+            // retry below resets for the same reason. `textBlockIndex` and the
+            // tool-call state are per-iteration and need no reset here.
+            output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;
           }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -664,13 +664,26 @@ export function streamKiro(
           // callback returns, so returning the bare payload would discard the
           // modeled class. Return an Error carrying the parsed detail instead.
           if (msg.headers[":message-type"]?.value === "exception") {
-            const data = parseKiroExceptionFrame(key, parsed);
-            if (data) {
-              const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
-              error.name = data.error;
-              (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
-              return { [key]: error } as Record<string, unknown>;
-            }
+            // An unmodeled member (a fifth error added server-side, or `$unknown`)
+            // still arrives keyed by `:exception-type`. Smithy's own fail-open path
+            // is unreachable here — it only triggers when the deserializer returns
+            // a `$unknown` property, which this one never does — so without a
+            // fallback the marshaller would throw the bare parsed body and the
+            // member name would be lost in exactly the way this routing exists to
+            // prevent. Synthesize the same typed shape with `kind: "unknown"`.
+            const data: KiroErrorData = parseKiroExceptionFrame(key, parsed) ?? {
+              error: key,
+              kind: "unknown",
+              ...(typeof parsed.message === "string" ? { message: parsed.message } : {}),
+              ...(typeof parsed.reason === "string" ? { reason: parsed.reason } : {}),
+              ...(typeof parsed.retryAfterMilliseconds === "number"
+                ? { retryAfterMilliseconds: parsed.retryAfterMilliseconds }
+                : {}),
+            };
+            const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
+            error.name = data.error;
+            (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
+            return { [key]: error } as Record<string, unknown>;
           }
           return { [key]: parsed } as Record<string, unknown>;
         });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -877,13 +877,26 @@ export function streamKiro(
           // callback returns, so returning the bare payload would discard the
           // modeled class. Return an Error carrying the parsed detail instead.
           if (msg.headers[":message-type"]?.value === "exception") {
-            const data = parseKiroExceptionFrame(key, parsed);
-            if (data) {
-              const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
-              error.name = data.error;
-              (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
-              return { [key]: error } as Record<string, unknown>;
-            }
+            // An unmodeled member (a fifth error added server-side, or `$unknown`)
+            // still arrives keyed by `:exception-type`. Smithy's own fail-open path
+            // is unreachable here — it only triggers when the deserializer returns
+            // a `$unknown` property, which this one never does — so without a
+            // fallback the marshaller would throw the bare parsed body and the
+            // member name would be lost in exactly the way this routing exists to
+            // prevent. Synthesize the same typed shape with `kind: "unknown"`.
+            const data: KiroErrorData = parseKiroExceptionFrame(key, parsed) ?? {
+              error: key,
+              kind: "unknown",
+              ...(typeof parsed.message === "string" ? { message: parsed.message } : {}),
+              ...(typeof parsed.reason === "string" ? { reason: parsed.reason } : {}),
+              ...(typeof parsed.retryAfterMilliseconds === "number"
+                ? { retryAfterMilliseconds: parsed.retryAfterMilliseconds }
+                : {}),
+            };
+            const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
+            error.name = data.error;
+            (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
+            return { [key]: error } as Record<string, unknown>;
           }
           return { [key]: parsed } as Record<string, unknown>;
         });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -994,6 +994,14 @@ export function streamKiro(
           if (retryCount < maxRetries) {
             retryCount++;
             const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            // `output` is created once outside the retry loop, so anything the
+            // aborted attempt already appended survives into the next one. A
+            // typed error frame (throttling/validation/serviceUnavailable) can
+            // arrive after partial text, which would otherwise concatenate the
+            // abandoned prefix onto the retried response. The empty-response
+            // retry below resets for the same reason. `textBlockIndex` and the
+            // tool-call state are per-iteration and need no reset here.
+            output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;
           }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -347,8 +347,28 @@ export function streamKiro(
       let retryCount = 0;
       const maxRetries = 3;
       const conversationId = options?.sessionId ?? crypto.randomUUID();
+      // Every wire-derived usage figure is written straight onto `output`, which
+      // outlives the retry loop, so an abandoned attempt's accounting would
+      // otherwise be billed to the turn that replaced it. Two live paths:
+      // `contextUsageEvent` sets `usage.input`/`contextPercent` mid-stream, and
+      // the post-stream metadataEvent writes land *before* the empty-response /
+      // echo-loop retry check. Clearing at the attempt boundary keeps the whole
+      // usage block sourced from one attempt, matching how `usageEvent` itself
+      // is scoped per attempt.
+      const resetAttemptUsage = () => {
+        output.usage.input = 0;
+        output.usage.output = 0;
+        output.usage.cacheRead = 0;
+        output.usage.cacheWrite = 0;
+        output.usage.totalTokens = 0;
+        output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+        // Not part of pi's Usage shape; only present once a contextUsageEvent
+        // has been seen, so a retried turn must not report the old gauge.
+        delete (output.usage as unknown as Record<string, unknown>).contextPercent;
+      };
       requestLoop: while (retryCount <= maxRetries) {
         if (options?.signal?.aborted) throw options.signal.reason;
+        resetAttemptUsage();
         const effectiveSystemPrompt = systemPrompt;
         // Relocate a tool result that arrived behind a later assistant turn than
         // the one that called it, before anything positional runs. Interleaved
@@ -1027,7 +1047,8 @@ export function streamKiro(
             // arrive after partial text, which would otherwise concatenate the
             // abandoned prefix onto the retried response. The empty-response
             // retry below resets for the same reason. `textBlockIndex` and the
-            // tool-call state are per-iteration and need no reset here.
+            // tool-call state are per-iteration and need no reset here; the
+            // usage block is cleared by `resetAttemptUsage` at the loop top.
             output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1086,7 +1086,13 @@ export function streamKiro(
         if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
         if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
+        // `TokenUsage.totalTokens` is required on the wire while the cache counts
+        // are optional, so the service's own total is the authoritative figure —
+        // recomputing from components silently under-reports whenever a component
+        // is omitted. Prefer it and fall back to the sum, matching how pi's
+        // bedrock adapter treats the one other wire that supplies a total.
         output.usage.totalTokens =
+          usageEvent?.totalTokens ??
           output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,7 +28,7 @@ import {
   type KiroAdditionalModelRequestFields,
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
-import { parseKiroEvent } from "./event-parser.js";
+import { type KiroUsageData, parseKiroEvent } from "./event-parser.js";
 import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
@@ -774,7 +774,7 @@ export function streamKiro(
         const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
         let totalContent = "";
         let lastContentData = "";
-        let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
+        let usageEvent: KiroUsageData | null = null;
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -884,9 +884,18 @@ export function streamKiro(
           const { done, value } = iterResult;
           if (done) break;
           resetIdle();
-          const eventPayload = Object.values(value as Record<string, unknown>)[0] as Record<string, unknown>;
-          const event = parseKiroEvent(eventPayload);
+          // The marshaller keys each frame by its modeled `ChatResponseStream`
+          // union member (from the `:event-type` header). Route on that key
+          // instead of guessing the member from which fields are populated.
+          const frameEntry = Object.entries(value as Record<string, unknown>)[0];
+          if (!frameEntry) continue;
+          const [frameKey, framePayload] = frameEntry;
+          const event = parseKiroEvent(frameKey, (framePayload ?? {}) as Record<string, unknown>);
           if (!event) continue;
+          if (event.type === "ignored") {
+            if (debugEnabled()) debugLog("stream.events.ignored", [event.data.key]);
+            continue;
+          }
           if (debugEnabled()) debugLog("stream.events", [event]);
           switch (event.type) {
             case "contextUsage": {
@@ -957,6 +966,12 @@ export function streamKiro(
             }
             case "usage": {
               usageEvent = event.data;
+              break;
+            }
+            case "metering": {
+              // MeteringEvent.usage counts credits, not tokens. Recorded for
+              // observability only; never folded into token accounting.
+              if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
             case "error": {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -965,7 +965,11 @@ export function streamKiro(
               break;
             }
             case "usage": {
-              usageEvent = event.data;
+              // Every MetadataEvent field is optional, so the service may split
+              // tokenUsage and stopReason/stopDetails across frames. Merge so a
+              // later partial frame cannot erase counts already received.
+              const prev: KiroUsageData = usageEvent ?? {};
+              usageEvent = { ...prev, ...event.data };
               break;
             }
             case "metering": {
@@ -1071,9 +1075,19 @@ export function streamKiro(
         // (accumulated into `totalContent` above). Otherwise tool-call-only
         // turns report 0 output tokens and break consumers like the TPS
         // extension that watch `usage.output`.
+        //
+        // `KiroUsageData.inputTokens` is `TokenUsage.uncachedInputTokens` — the
+        // input billed at full rate, NOT total input. pi's `usage.input` is the
+        // same uncached slot, with `cacheRead`/`cacheWrite` as siblings, and
+        // `calculateCost` prices all three separately. So the cache counts must
+        // land whenever `input` is taken from the wire; otherwise a cached turn
+        // reports a fraction of its real input and is priced far too low.
         if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
+        if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
+        if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
-        output.usage.totalTokens = output.usage.input + output.usage.output;
+        output.usage.totalTokens =
+          output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);
         } catch {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -870,13 +870,27 @@ export function streamKiro(
           const entry = Object.entries(event)[0];
           if (!entry) throw new Error("Received an empty event stream message");
           const [key, msg] = entry;
-          const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
           // The four error members of ChatResponseStream target `@error` shapes,
           // so the service frames them as `:message-type: exception`. The
           // marshaller keys those by `:exception-type` and throws whatever this
           // callback returns, so returning the bare payload would discard the
           // modeled class. Return an Error carrying the parsed detail instead.
           if (msg.headers[":message-type"]?.value === "exception") {
+            // Parsed defensively, and BEFORE the shared parse below: an exception
+            // body that is empty or not JSON would otherwise throw a SyntaxError
+            // out of this deserializer, and the caller would report
+            // "Unexpected end of JSON input" with the modeled class gone — the
+            // exact loss this routing removes. The class lives in the header, so
+            // it survives a body we cannot read. The same-service client's own
+            // bridge takes this position too (sse-middleware.ts: "Non-JSON body:
+            // still throw a typed exception with a fallback message").
+            let parsedException: Record<string, unknown> = {};
+            try {
+              const decoded = JSON.parse(utf8Decoder.decode(msg.body)) as unknown;
+              if (decoded && typeof decoded === "object") parsedException = decoded as Record<string, unknown>;
+            } catch {
+              // Header-only classification below.
+            }
             // An unmodeled member (a fifth error added server-side, or `$unknown`)
             // still arrives keyed by `:exception-type`. Smithy's own fail-open path
             // is unreachable here — it only triggers when the deserializer returns
@@ -884,13 +898,13 @@ export function streamKiro(
             // fallback the marshaller would throw the bare parsed body and the
             // member name would be lost in exactly the way this routing exists to
             // prevent. Synthesize the same typed shape with `kind: "unknown"`.
-            const data: KiroErrorData = parseKiroExceptionFrame(key, parsed) ?? {
+            const data: KiroErrorData = parseKiroExceptionFrame(key, parsedException) ?? {
               error: key,
               kind: "unknown",
-              ...(typeof parsed.message === "string" ? { message: parsed.message } : {}),
-              ...(typeof parsed.reason === "string" ? { reason: parsed.reason } : {}),
-              ...(typeof parsed.retryAfterMilliseconds === "number"
-                ? { retryAfterMilliseconds: parsed.retryAfterMilliseconds }
+              ...(typeof parsedException.message === "string" ? { message: parsedException.message } : {}),
+              ...(typeof parsedException.reason === "string" ? { reason: parsedException.reason } : {}),
+              ...(typeof parsedException.retryAfterMilliseconds === "number"
+                ? { retryAfterMilliseconds: parsedException.retryAfterMilliseconds }
                 : {}),
             };
             const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
@@ -898,6 +912,7 @@ export function streamKiro(
             (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
             return { [key]: error } as Record<string, unknown>;
           }
+          const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
           return { [key]: parsed } as Record<string, unknown>;
         });
         const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,7 +28,7 @@ import {
   type KiroAdditionalModelRequestFields,
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
-import { type KiroUsageData, parseKiroEvent } from "./event-parser.js";
+import { type KiroErrorData, type KiroUsageData, parseKiroEvent, parseKiroExceptionFrame } from "./event-parser.js";
 import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
@@ -823,6 +823,11 @@ export function streamKiro(
         let gotFirstToken = false;
         let firstTokenTimedOut = false;
         let streamError: string | null = null;
+        // Structured detail for the last modeled exception frame. The message
+        // string stays the retry/throw contract; this keeps `kind`, `reason`,
+        // and `retryAfterMilliseconds` addressable instead of only readable as
+        // prose inside that string.
+        let streamErrorData: KiroErrorData | null = null;
         const FIRST_TOKEN_SENTINEL = Symbol("firstTokenTimeout");
 
         // Smithy EventStreamMarshaller handles: chunk reassembly, CRC validation,
@@ -846,6 +851,20 @@ export function streamKiro(
           if (!entry) throw new Error("Received an empty event stream message");
           const [key, msg] = entry;
           const parsed = JSON.parse(utf8Decoder.decode(msg.body)) as Record<string, unknown>;
+          // The four error members of ChatResponseStream target `@error` shapes,
+          // so the service frames them as `:message-type: exception`. The
+          // marshaller keys those by `:exception-type` and throws whatever this
+          // callback returns, so returning the bare payload would discard the
+          // modeled class. Return an Error carrying the parsed detail instead.
+          if (msg.headers[":message-type"]?.value === "exception") {
+            const data = parseKiroExceptionFrame(key, parsed);
+            if (data) {
+              const error = new Error(data.message ? `${data.error}: ${data.message}` : data.error);
+              error.name = data.error;
+              (error as Error & { kiroError?: KiroErrorData }).kiroError = data;
+              return { [key]: error } as Record<string, unknown>;
+            }
+          }
           return { [key]: parsed } as Record<string, unknown>;
         });
         const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;
@@ -874,7 +893,11 @@ export function streamKiro(
               iterResult = await iterator.next();
             }
           } catch (e) {
-            // Smithy throws on :message-type error/exception headers
+            // Smithy throws on :message-type error/exception headers. A modeled
+            // exception frame arrives here as the Error built in the
+            // deserializer above, with its parsed detail attached.
+            const kiroError = (e as { kiroError?: KiroErrorData } | null)?.kiroError;
+            if (kiroError) streamErrorData = kiroError;
             streamError =
               e instanceof Error
                 ? e.message
@@ -981,6 +1004,7 @@ export function streamKiro(
             case "error": {
               const errMsg = event.data.message ? `${event.data.error}: ${event.data.message}` : event.data.error;
               streamError = errMsg;
+              streamErrorData = event.data;
               void bodyReader.cancel().catch(() => {});
               break;
             }
@@ -994,6 +1018,9 @@ export function streamKiro(
           if (retryCount < maxRetries) {
             retryCount++;
             const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            if (streamErrorData && debugEnabled()) {
+              debugLog("stream.error.typed", [streamErrorData]);
+            }
             // `output` is created once outside the retry loop, so anything the
             // aborted attempt already appended survives into the next one. A
             // typed error frame (throttling/validation/serviceUnavailable) can

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1049,6 +1049,12 @@ export function streamKiro(
             // retry below resets for the same reason. `textBlockIndex` and the
             // tool-call state are per-iteration and need no reset here; the
             // usage block is cleared by `resetAttemptUsage` at the loop top.
+            //
+            // pi's event protocol has no retraction event, so deltas already
+            // pushed for the abandoned attempt cannot be withdrawn. The signals
+            // a consumer does get are the fresh `start` emitted for the retried
+            // attempt and the `partial` carried on every event, which is this
+            // same `output` object and so reflects the clear.
             output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -260,8 +260,13 @@ describe("Feature 8: Stream Event Parsing", () => {
   });
 
   describe("parseKiroEventByShape — fail-open fallback", () => {
-    it("is used for unkeyed frames so unknown members degrade gracefully", () => {
-      expect(parseKiroEvent("$unknown", { content: "hi" })).toEqual({ type: "content", data: "hi" });
+    it("is used for a member name this client does not know yet", () => {
+      // The reachable case: the service adds a member, so the frame carries a
+      // real `:event-type` this build has never seen. A literal `$unknown`
+      // event frame does NOT reach the parser — the Smithy marshaller drops any
+      // event frame whose deserialized result has a `$unknown` property, and the
+      // deserializer keys its result by the header value.
+      expect(parseKiroEvent("brandNewEvent", { content: "hi" })).toEqual({ type: "content", data: "hi" });
     });
 
     it("recognizes followupPrompt, which has no modeled union member", () => {

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
-import { parseKiroEvent, parseKiroEventByShape } from "../src/event-parser.js";
+import { parseKiroEvent, parseKiroEventByShape, parseKiroExceptionFrame } from "../src/event-parser.js";
 
 describe("Feature 8: Stream Event Parsing", () => {
   describe("findJsonEnd", () => {
@@ -165,6 +165,10 @@ describe("Feature 8: Stream Event Parsing", () => {
   });
 
   describe("parseKiroEvent — error members keep their modeled class", () => {
+    // These four members target @error shapes, so the service frames them as
+    // `:message-type: exception` (see parseKiroExceptionFrame). The event-frame
+    // branches below exist so a non-conforming server that sends them as
+    // ordinary events is classified identically rather than dropped.
     it("classifies the error member as internalServer", () => {
       expect(parseKiroEvent("error", { message: "boom" })).toEqual({
         type: "error",
@@ -205,6 +209,39 @@ describe("Feature 8: Stream Event Parsing", () => {
         type: "error",
         data: { error: "ThrottlingException", message: "slow down", kind: "internalServer" },
       });
+    });
+  });
+
+  describe("parseKiroExceptionFrame — the real wire framing for error members", () => {
+    it("maps every error member to its modeled exception class", () => {
+      expect(parseKiroExceptionFrame("error", { message: "boom" })).toEqual({
+        error: "InternalServerException",
+        message: "boom",
+        kind: "internalServer",
+      });
+      expect(parseKiroExceptionFrame("validationError", { message: "bad" })?.kind).toBe("validation");
+      expect(parseKiroExceptionFrame("serviceUnavailableError", { message: "down" })?.kind).toBe("serviceUnavailable");
+    });
+
+    it("preserves reason and retryAfterMilliseconds for throttlingError", () => {
+      expect(
+        parseKiroExceptionFrame("throttlingError", {
+          message: "Too many requests",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        }),
+      ).toEqual({
+        error: "ThrottlingException",
+        message: "Too many requests",
+        kind: "throttling",
+        reason: "INSUFFICIENT_MODEL_CAPACITY",
+        retryAfterMilliseconds: 4500,
+      });
+    });
+
+    it("returns null for a non-error member so the caller keeps the raw body", () => {
+      expect(parseKiroExceptionFrame("metadataEvent", { tokenUsage: {} })).toBeNull();
+      expect(parseKiroExceptionFrame("SomeFutureException", { message: "x" })).toBeNull();
     });
   });
 

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -257,6 +257,17 @@ describe("Feature 8: Stream Event Parsing", () => {
       expect(parseKiroExceptionFrame("metadataEvent", { tokenUsage: {} })).toBeNull();
       expect(parseKiroExceptionFrame("SomeFutureException", { message: "x" })).toBeNull();
     });
+
+    it("does not treat an Object.prototype key as a modeled member", () => {
+      // `:exception-type` is chosen by the service, so the member table must be
+      // read by own property. A bare index resolves inherited members, and the
+      // resulting truthy hit yields kind/error undefined — the caller then skips
+      // its unmodeled-member fallback and loses the name entirely, which is the
+      // exact class loss this routing removes.
+      for (const key of ["toString", "constructor", "hasOwnProperty", "valueOf", "__proto__"]) {
+        expect(parseKiroExceptionFrame(key, { message: "x" })).toBeNull();
+      }
+    });
   });
 
   describe("parseKiroEventByShape — fail-open fallback", () => {

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
-import { parseKiroEvent } from "../src/event-parser.js";
+import { parseKiroEvent, parseKiroEventByShape } from "../src/event-parser.js";
 
 describe("Feature 8: Stream Event Parsing", () => {
   describe("findJsonEnd", () => {
@@ -25,78 +25,214 @@ describe("Feature 8: Stream Event Parsing", () => {
     });
   });
 
-  describe("parseKiroEvent", () => {
-    it("parses content event", () => {
-      expect(parseKiroEvent({ content: "Hello " })).toEqual({ type: "content", data: "Hello " });
+  describe("parseKiroEvent — modeled key routing", () => {
+    it("routes assistantResponseEvent to content", () => {
+      expect(parseKiroEvent("assistantResponseEvent", { content: "Hello " })).toEqual({
+        type: "content",
+        data: "Hello ",
+      });
     });
 
-    it("parses summarized thinking text", () => {
-      expect(parseKiroEvent({ text: "Considering options" })).toEqual({
+    it("routes reasoningContentEvent text to thinkingText", () => {
+      expect(parseKiroEvent("reasoningContentEvent", { text: "Considering options" })).toEqual({
         type: "thinkingText",
         data: "Considering options",
       });
     });
 
-    it("parses summarized thinking signature", () => {
-      expect(parseKiroEvent({ signature: "opaque-signature" })).toEqual({
+    it("routes reasoningContentEvent signature to thinkingSignature", () => {
+      expect(parseKiroEvent("reasoningContentEvent", { signature: "opaque-signature" })).toEqual({
         type: "thinkingSignature",
         data: "opaque-signature",
       });
     });
 
-    it("parses toolUse event", () => {
-      const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: '{"cmd":"ls"}' });
+    it("ignores a reasoningContentEvent carrying only redactedContent", () => {
+      expect(parseKiroEvent("reasoningContentEvent", { redactedContent: "encrypted" })).toEqual({
+        type: "ignored",
+        data: { key: "reasoningContentEvent" },
+      });
+    });
+
+    it("routes toolUseEvent with name+toolUseId to toolUse", () => {
+      const e = parseKiroEvent("toolUseEvent", { name: "bash", toolUseId: "tc1", input: '{"cmd":"ls"}' });
       expect(e?.type).toBe("toolUse");
       expect(e?.type === "toolUse" && e.data.name).toBe("bash");
     });
 
-    it("parses toolUse with stop", () => {
-      const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: "", stop: true });
-      expect(e?.type === "toolUse" && e.data.stop).toBe(true);
+    it("routes toolUseEvent continuation frames to toolUseInput", () => {
+      expect(parseKiroEvent("toolUseEvent", { input: '"ls"}' })).toEqual({
+        type: "toolUseInput",
+        data: { input: '"ls"}' },
+      });
     });
 
-    it("parses toolUseInput", () => {
-      expect(parseKiroEvent({ input: '"ls"}' })).toEqual({ type: "toolUseInput", data: { input: '"ls"}' } });
+    it("routes toolUseEvent stop frame to toolUseStop", () => {
+      expect(parseKiroEvent("toolUseEvent", { stop: true })).toEqual({ type: "toolUseStop", data: { stop: true } });
     });
 
-    it("parses toolUseStop", () => {
-      expect(parseKiroEvent({ stop: true })).toEqual({ type: "toolUseStop", data: { stop: true } });
-    });
-
-    it("parses contextUsage", () => {
-      expect(parseKiroEvent({ contextUsagePercentage: 42.5 })).toEqual({
+    it("routes contextUsageEvent to contextUsage", () => {
+      expect(parseKiroEvent("contextUsageEvent", { contextUsagePercentage: 42.5 })).toEqual({
         type: "contextUsage",
         data: { contextUsagePercentage: 42.5 },
       });
     });
 
-    it("parses followupPrompt event", () => {
-      const e = parseKiroEvent({ followupPrompt: "What would you like to do next?" });
-      expect(e).toEqual({ type: "followupPrompt", data: "What would you like to do next?" });
-    });
-
-    it("parses usage event", () => {
-      const e = parseKiroEvent({ usage: { inputTokens: 100, outputTokens: 50 } });
-      expect(e?.type).toBe("usage");
-      expect(e?.type === "usage" && e.data.inputTokens).toBe(100);
-      expect(e?.type === "usage" && e.data.outputTokens).toBe(50);
-    });
-
-    it("returns null for unrecognized shape", () => {
-      expect(parseKiroEvent({ unknown: true })).toBeNull();
-    });
-
     it("treats empty object input as empty string for toolUse placeholder", () => {
-      const e = parseKiroEvent({ name: "write", toolUseId: "tc1", input: {} });
+      const e = parseKiroEvent("toolUseEvent", { name: "write", toolUseId: "tc1", input: {} });
       expect(e?.type).toBe("toolUse");
       // Empty object placeholder must become "" so toolUseInput concatenation works
       expect(e?.type === "toolUse" && e.data.input).toBe("");
     });
 
     it("preserves non-empty object input as JSON string", () => {
-      const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: { cmd: "ls" } });
+      const e = parseKiroEvent("toolUseEvent", { name: "bash", toolUseId: "tc1", input: { cmd: "ls" } });
       expect(e?.type).toBe("toolUse");
       expect(e?.type === "toolUse" && e.data.input).toBe('{"cmd":"ls"}');
+    });
+
+    it("explicitly ignores known members with no consumer", () => {
+      for (const key of ["codeReferenceEvent", "documentCitationEvent", "toolResultEvent"]) {
+        expect(parseKiroEvent(key, {})).toEqual({ type: "ignored", data: { key } });
+      }
+    });
+
+    it("returns null for an unrecognized key with an unrecognized payload", () => {
+      expect(parseKiroEvent("brandNewEvent", { unknown: true })).toBeNull();
+    });
+  });
+
+  describe("parseKiroEvent — metadataEvent token usage", () => {
+    // MetadataEvent = {tokenUsage?, stopReason?, stopDetails?}; TokenUsage =
+    // {uncachedInputTokens, outputTokens, totalTokens, cacheRead..., cacheWrite...,
+    // contextUsagePercentage?}. Previously no branch matched this shape at all.
+    it("produces a usage event from a modeled metadataEvent frame", () => {
+      const e = parseKiroEvent("metadataEvent", {
+        tokenUsage: {
+          uncachedInputTokens: 500,
+          outputTokens: 200,
+          totalTokens: 700,
+          cacheReadInputTokens: 120,
+          cacheWriteInputTokens: 30,
+          contextUsagePercentage: 12.5,
+        },
+        stopReason: "END_TURN",
+      });
+      expect(e).toEqual({
+        type: "usage",
+        data: {
+          inputTokens: 500,
+          outputTokens: 200,
+          totalTokens: 700,
+          cacheReadInputTokens: 120,
+          cacheWriteInputTokens: 30,
+          contextUsagePercentage: 12.5,
+          rawStopReason: "END_TURN",
+        },
+      });
+    });
+
+    it("omits absent token fields rather than emitting undefined", () => {
+      const e = parseKiroEvent("metadataEvent", { stopReason: "MAX_TOKENS" });
+      expect(e).toEqual({ type: "usage", data: { rawStopReason: "MAX_TOKENS" } });
+      expect(e?.type === "usage" && Object.keys(e.data)).toEqual(["rawStopReason"]);
+    });
+
+    it("passes stopDetails through verbatim", () => {
+      const e = parseKiroEvent("metadataEvent", { stopDetails: { refusal: { reason: "POLICY" } } });
+      expect(e?.type === "usage" && e.data.stopDetails).toEqual({ refusal: { reason: "POLICY" } });
+    });
+
+    it("returns null for an empty metadataEvent", () => {
+      expect(parseKiroEvent("metadataEvent", {})).toBeNull();
+    });
+  });
+
+  describe("parseKiroEvent — meteringEvent is credits, not tokens", () => {
+    // MeteringEvent = {usage?: number; unit?: string; unitPlural?: string}.
+    it("surfaces meteringEvent as a credit count", () => {
+      expect(parseKiroEvent("meteringEvent", { usage: 3, unit: "credit", unitPlural: "credits" })).toEqual({
+        type: "metering",
+        data: { credits: 3, unit: "credit", unitPlural: "credits" },
+      });
+    });
+
+    it("never reads token fields off the numeric usage value", () => {
+      const e = parseKiroEvent("meteringEvent", { usage: 7 });
+      expect(e?.type).toBe("metering");
+      expect(e?.type === "usage").toBe(false);
+    });
+  });
+
+  describe("parseKiroEvent — error members keep their modeled class", () => {
+    it("classifies the error member as internalServer", () => {
+      expect(parseKiroEvent("error", { message: "boom" })).toEqual({
+        type: "error",
+        data: { error: "InternalServerException", message: "boom", kind: "internalServer" },
+      });
+    });
+
+    it("classifies throttlingError and preserves retryAfterMilliseconds", () => {
+      expect(
+        parseKiroEvent("throttlingError", {
+          message: "Too many requests",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        }),
+      ).toEqual({
+        type: "error",
+        data: {
+          error: "ThrottlingException",
+          message: "Too many requests",
+          kind: "throttling",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        },
+      });
+    });
+
+    it("classifies validationError and serviceUnavailableError distinctly", () => {
+      expect(parseKiroEvent("validationError", { message: "bad input" })?.type === "error").toBe(true);
+      const v = parseKiroEvent("validationError", { message: "bad input" });
+      expect(v?.type === "error" && v.data.kind).toBe("validation");
+      const s = parseKiroEvent("serviceUnavailableError", { message: "down" });
+      expect(s?.type === "error" && s.data.kind).toBe("serviceUnavailable");
+    });
+
+    it("still accepts the legacy free-form error field", () => {
+      const e = parseKiroEvent("error", { error: "ThrottlingException", message: "slow down" });
+      expect(e).toEqual({
+        type: "error",
+        data: { error: "ThrottlingException", message: "slow down", kind: "internalServer" },
+      });
+    });
+  });
+
+  describe("parseKiroEventByShape — fail-open fallback", () => {
+    it("is used for unkeyed frames so unknown members degrade gracefully", () => {
+      expect(parseKiroEvent("$unknown", { content: "hi" })).toEqual({ type: "content", data: "hi" });
+    });
+
+    it("recognizes followupPrompt, which has no modeled union member", () => {
+      expect(parseKiroEventByShape({ followupPrompt: "What next?" })).toEqual({
+        type: "followupPrompt",
+        data: "What next?",
+      });
+    });
+
+    it("recognizes a metadata-shaped payload", () => {
+      expect(parseKiroEventByShape({ tokenUsage: { outputTokens: 12 } })).toEqual({
+        type: "usage",
+        data: { outputTokens: 12 },
+      });
+    });
+
+    it("treats a numeric usage as metering", () => {
+      expect(parseKiroEventByShape({ usage: 2 })).toEqual({ type: "metering", data: { credits: 2 } });
+    });
+
+    it("returns null for an unrecognized shape", () => {
+      expect(parseKiroEventByShape({ unknown: true })).toBeNull();
     });
   });
 });

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -143,6 +143,20 @@ describe("Feature 8: Stream Event Parsing", () => {
       expect(e?.type === "usage" && e.data.stopDetails).toEqual({ refusal: { reason: "POLICY" } });
     });
 
+    it("surfaces normalizedTokenUsage, which is not a raw credit count", () => {
+      // TokenUsage.normalizedTokenUsage is MPS-normalized usage derived from
+      // credit information. It is modeled alongside the token counts, so it must
+      // not be dropped at the boundary, and it must not be confused with
+      // MeteringEvent.usage (raw credits).
+      const e = parseKiroEvent("metadataEvent", {
+        tokenUsage: { uncachedInputTokens: 10, outputTokens: 2, totalTokens: 12, normalizedTokenUsage: 3.5 },
+      });
+      expect(e).toEqual({
+        type: "usage",
+        data: { inputTokens: 10, outputTokens: 2, totalTokens: 12, normalizedTokenUsage: 3.5 },
+      });
+    });
+
     it("returns null for an empty metadataEvent", () => {
       expect(parseKiroEvent("metadataEvent", {})).toBeNull();
     });

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -100,6 +100,30 @@ describe("Feature 8: Stream Event Parsing", () => {
     it("returns null for an unrecognized key with an unrecognized payload", () => {
       expect(parseKiroEvent("brandNewEvent", { unknown: true })).toBeNull();
     });
+
+    it("routes an error member delivered under its exception class name", () => {
+      // Same dual vocabulary as `:exception-type` (see parseKiroExceptionFrame).
+      // On the event-frame path there is no literal case label for the class
+      // name, so without the token lookup in `default:` the payload
+      // `{message, reason}` matches nothing in the shape ladder and the frame is
+      // dropped — the original class loss, one layer over.
+      const e = parseKiroEvent("ThrottlingException", {
+        message: "Too many requests",
+        reason: "INSUFFICIENT_MODEL_CAPACITY",
+        retryAfterMilliseconds: 4500,
+      });
+      expect(e).toEqual({
+        type: "error",
+        data: {
+          error: "ThrottlingException",
+          message: "Too many requests",
+          kind: "throttling",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        },
+      });
+      expect(parseKiroEvent("ServiceUnavailableException", { message: "down" })?.type).toBe("error");
+    });
   });
 
   describe("parseKiroEvent — metadataEvent token usage", () => {
@@ -256,6 +280,43 @@ describe("Feature 8: Stream Event Parsing", () => {
     it("returns null for a non-error member so the caller keeps the raw body", () => {
       expect(parseKiroExceptionFrame("metadataEvent", { tokenUsage: {} })).toBeNull();
       expect(parseKiroExceptionFrame("SomeFutureException", { message: "x" })).toBeNull();
+    });
+
+    it("accepts the exception CLASS name as the :exception-type token", () => {
+      // The service is not required to put the union member name in
+      // `:exception-type`. The hand-written bridge in the generated client for
+      // this same service accepts either form for all four members
+      // (sse-middleware.ts `buildStreamException`), so both are observed
+      // vocabulary. Keying only on the member name would classify
+      // `ThrottlingException` as `kind: "unknown"` and drop the throttle
+      // classification that retry policy depends on.
+      expect(
+        parseKiroExceptionFrame("ThrottlingException", {
+          message: "Too many requests",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        }),
+      ).toEqual({
+        error: "ThrottlingException",
+        message: "Too many requests",
+        kind: "throttling",
+        reason: "INSUFFICIENT_MODEL_CAPACITY",
+        retryAfterMilliseconds: 4500,
+      });
+      expect(parseKiroExceptionFrame("InternalServerException", { message: "boom" })?.kind).toBe("internalServer");
+      expect(parseKiroExceptionFrame("ValidationException", { message: "bad" })?.kind).toBe("validation");
+      expect(parseKiroExceptionFrame("ServiceUnavailableException", { message: "down" })?.kind).toBe(
+        "serviceUnavailable",
+      );
+    });
+
+    it("classifies a header-only exception frame from its token alone", () => {
+      // An unreadable body leaves an empty payload; the class still comes from
+      // the header, so the member must not degrade to unknown.
+      expect(parseKiroExceptionFrame("throttlingError", {})).toEqual({
+        error: "ThrottlingException",
+        kind: "throttling",
+      });
     });
 
     it("does not treat an Object.prototype key as a modeled member", () => {

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -82,13 +82,28 @@ export function encodeExceptionMessage(exceptionType: KiroEventKey, payload: obj
  * still surface its `:exception-type` name rather than a bare JSON body.
  */
 export function encodeRawExceptionMessage(exceptionType: string, payload: object): Uint8Array {
+  return encodeExceptionFrame(exceptionType, JSON.stringify(payload));
+}
+
+/**
+ * Encode an exception frame whose body is NOT parseable JSON.
+ *
+ * The modeled class lives in the `:exception-type` header, so it must survive a
+ * body this client cannot read — otherwise the JSON parse failure replaces the
+ * modeled error with a `SyntaxError` message and the class is lost.
+ */
+export function encodeExceptionMessageWithRawBody(exceptionType: string, body: string): Uint8Array {
+  return encodeExceptionFrame(exceptionType, body);
+}
+
+function encodeExceptionFrame(exceptionType: string, body: string): Uint8Array {
   return codec.encode({
     headers: {
       ":exception-type": { type: "string", value: exceptionType },
       ":message-type": { type: "string", value: "exception" },
       ":content-type": { type: "string", value: "application/json" },
     },
-    body: new TextEncoder().encode(JSON.stringify(payload)),
+    body: new TextEncoder().encode(body),
   });
 }
 

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -1,14 +1,46 @@
 import { EventStreamCodec } from "@smithy/core/event-streams";
+import { isKiroEventKey, type KiroEventKey } from "../../src/event-parser.js";
 
 const codec = new EventStreamCodec(
   (input: Uint8Array) => new TextDecoder().decode(input),
   (input: string) => new TextEncoder().encode(input),
 );
 
-export function encodeEventMessage(payload: object): Uint8Array {
+/**
+ * Infer the `ChatResponseStream` union member a payload belongs to.
+ *
+ * Real frames carry the member name in the `:event-type` header; fixtures are
+ * written as bare payloads, so derive the key from the payload shape to keep
+ * the encoded frame faithful to the wire contract.
+ */
+export function inferEventKey(payload: Record<string, unknown>): KiroEventKey | "$unknown" {
+  if (payload.content !== undefined) return "assistantResponseEvent";
+  if (typeof payload.text === "string" || typeof payload.signature === "string") return "reasoningContentEvent";
+  if (payload.toolUseId !== undefined || payload.input !== undefined || payload.stop !== undefined)
+    return "toolUseEvent";
+  if (payload.contextUsagePercentage !== undefined) return "contextUsageEvent";
+  if (payload.tokenUsage !== undefined || payload.stopReason !== undefined || payload.stopDetails !== undefined)
+    return "metadataEvent";
+  if (typeof payload.usage === "number") return "meteringEvent";
+  if (payload.error !== undefined || payload.Error !== undefined) return "error";
+  return "$unknown";
+}
+
+/**
+ * Encode a payload as one binary event-stream frame.
+ *
+ * `eventType` defaults to the member inferred from the payload shape; pass it
+ * explicitly to exercise a specific union member (including error members,
+ * which share field names with each other).
+ */
+export function encodeEventMessage(payload: object, eventType?: KiroEventKey | "$unknown"): Uint8Array {
+  const key = eventType ?? inferEventKey(payload as Record<string, unknown>);
+  if (key !== "$unknown" && !isKiroEventKey(key)) {
+    throw new Error(`Not a ChatResponseStream member: ${key}`);
+  }
   return codec.encode({
     headers: {
-      ":event-type": { type: "string", value: "assistantResponseEvent" },
+      ":event-type": { type: "string", value: key },
       ":message-type": { type: "string", value: "event" },
     },
     body: new TextEncoder().encode(JSON.stringify(payload)),

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -35,6 +35,10 @@ export function inferEventKey(payload: Record<string, unknown>): KiroEventKey | 
  * `eventType` defaults to the member inferred from the payload shape; pass it
  * explicitly to exercise a specific union member (including error members,
  * which share field names with each other).
+ *
+ * Note: the four error members target `@error` shapes, so the service frames
+ * them as `:message-type: exception`. Use {@link encodeExceptionMessage} for
+ * those; this function is for ordinary `event` frames.
  */
 export function encodeEventMessage(payload: object, eventType?: KiroEventKey | "$unknown"): Uint8Array {
   const key = eventType ?? inferEventKey(payload as Record<string, unknown>);
@@ -45,6 +49,28 @@ export function encodeEventMessage(payload: object, eventType?: KiroEventKey | "
     headers: {
       ":event-type": { type: "string", value: key },
       ":message-type": { type: "string", value: "event" },
+    },
+    body: new TextEncoder().encode(JSON.stringify(payload)),
+  });
+}
+
+/**
+ * Encode a modeled error member the way the service actually frames it.
+ *
+ * `ChatResponseStream`'s `error` / `throttlingError` / `validationError` /
+ * `serviceUnavailableError` members target `@error` shapes, so they arrive as
+ * `:message-type: exception` with the member name in `:exception-type` — the
+ * Smithy marshaller routes those through a different path than event frames.
+ */
+export function encodeExceptionMessage(exceptionType: KiroEventKey, payload: object): Uint8Array {
+  if (!isKiroEventKey(exceptionType)) {
+    throw new Error(`Not a ChatResponseStream member: ${exceptionType}`);
+  }
+  return codec.encode({
+    headers: {
+      ":exception-type": { type: "string", value: exceptionType },
+      ":message-type": { type: "string", value: "exception" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new TextEncoder().encode(JSON.stringify(payload)),
   });

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -16,9 +16,12 @@ const codec = new EventStreamCodec(
 export function inferEventKey(payload: Record<string, unknown>): KiroEventKey | "$unknown" {
   if (payload.content !== undefined) return "assistantResponseEvent";
   if (typeof payload.text === "string" || typeof payload.signature === "string") return "reasoningContentEvent";
+  // contextUsagePercentage is checked before the toolUse `stop` branch for the
+  // same reason parseKiroEventByShape guards it: a contextUsageEvent payload can
+  // also carry `stop`, and inferring toolUseEvent there would frame it wrongly.
+  if (payload.contextUsagePercentage !== undefined) return "contextUsageEvent";
   if (payload.toolUseId !== undefined || payload.input !== undefined || payload.stop !== undefined)
     return "toolUseEvent";
-  if (payload.contextUsagePercentage !== undefined) return "contextUsageEvent";
   if (payload.tokenUsage !== undefined || payload.stopReason !== undefined || payload.stopDetails !== undefined)
     return "metadataEvent";
   if (typeof payload.usage === "number") return "meteringEvent";

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -36,6 +36,11 @@ export function inferEventKey(payload: Record<string, unknown>): KiroEventKey | 
  * explicitly to exercise a specific union member (including error members,
  * which share field names with each other).
  *
+ * Passing `"$unknown"` produces a frame the Smithy marshaller DROPS: it skips
+ * any event frame whose deserialized result carries a `$unknown` property, and
+ * the deserializer in `src/stream.ts` keys its result by this header value. Use
+ * a real member name for anything that must reach the parser.
+ *
  * Note: the four error members target `@error` shapes, so the service frames
  * them as `:message-type: exception`. Use {@link encodeExceptionMessage} for
  * those; this function is for ordinary `event` frames.
@@ -66,6 +71,17 @@ export function encodeExceptionMessage(exceptionType: KiroEventKey, payload: obj
   if (!isKiroEventKey(exceptionType)) {
     throw new Error(`Not a ChatResponseStream member: ${exceptionType}`);
   }
+  return encodeRawExceptionMessage(exceptionType, payload);
+}
+
+/**
+ * Encode an exception frame for a member name this client does not model.
+ *
+ * Deliberately skips the `KIRO_EVENT_KEYS` guard so tests can exercise the
+ * unmodeled-member path — a fifth error member added server-side, which must
+ * still surface its `:exception-type` name rather than a bare JSON body.
+ */
+export function encodeRawExceptionMessage(exceptionType: string, payload: object): Uint8Array {
   return codec.encode({
     headers: {
       ":exception-type": { type: "string", value: exceptionType },

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2950,6 +2950,16 @@ describe("Feature 9: Streaming Integration", () => {
     // post-loop, so an aborted attempt must contribute nothing to billing.
     // cacheRead is priced as its own line in calculateCost, so inheriting a
     // prior attempt's value would over-bill a turn that never read that cache.
+    //
+    // Priced deliberately: `makeModel()` defaults every rate to 0, so a
+    // `cost.*` assertion against the default model passes no matter what leaked
+    // across the retry boundary. Real per-million rates make these assertions
+    // able to fail at all. What actually holds this invariant is `usageEvent`'s
+    // loop scope, not the attempt-boundary reset — dropping the cache lines
+    // from `resetAttemptUsage` leaves this test green, because the aborted
+    // attempt errors before the post-stream cache writes ever run. The
+    // terminal-failure test below is what pins the reset itself.
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
     let callCount = 0;
     const mockFetch = vi.fn().mockImplementation(async () => {
       callCount++;
@@ -3002,7 +3012,7 @@ describe("Feature 9: Streaming Integration", () => {
     });
     vi.stubGlobal("fetch", mockFetch);
 
-    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
     const events = await collect(stream);
     const done = events.find((e) => e.type === "done");
     const msg = done?.type === "done" ? done.message : undefined;
@@ -3015,9 +3025,94 @@ describe("Feature 9: Streaming Integration", () => {
     expect(msg.usage.cacheRead).toBe(0);
     expect(msg.usage.cacheWrite).toBe(0);
     expect(msg.usage.cost.cacheRead).toBe(0);
+    expect(msg.usage.cost.cacheWrite).toBe(0);
 
     vi.unstubAllGlobals();
   });
+
+  it("reports zero tokens and zero cost when a priced attempt is replaced by a terminally failing retry", async () => {
+    // The post-stream usage writes and `calculateCost` both run BEFORE the
+    // empty-response retry check, so a degenerate attempt that reported
+    // metadataEvent counts leaves a real priced charge on `output.usage.cost`.
+    // `output` outlives the retry loop. If the attempt-boundary reset cleared
+    // only the token counts and left `cost` alone, the terminal error would be
+    // emitted with totalTokens 0 and a stale non-zero charge — an invented bill
+    // for a turn that produced nothing.
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Degenerate but expensive: large counts, no text, no tool calls. Gets
+        // priced, then triggers the empty-response retry.
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: encodeEventMessage({
+                    tokenUsage: {
+                      uncachedInputTokens: 90000,
+                      outputTokens: 4000,
+                      totalTokens: 194000,
+                      cacheReadInputTokens: 100000,
+                      cacheWriteInputTokens: 0,
+                    },
+                  }),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Every later attempt fails with a modeled exception frame, so the retry
+      // budget is exhausted and the turn ends in a terminal error.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeExceptionMessage("serviceUnavailableError", { message: "unavailable" }),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type).toBe("error");
+    if (error?.type !== "error") throw new Error("Expected a terminal error event");
+    expect(error.error.errorMessage).toContain("ServiceUnavailableException");
+
+    const usage = error.error.usage;
+    expect(usage.input).toBe(0);
+    expect(usage.output).toBe(0);
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.totalTokens).toBe(0);
+    // The charge the abandoned attempt earned must be gone with its counts.
+    expect(usage.cost.input).toBe(0);
+    expect(usage.cost.output).toBe(0);
+    expect(usage.cost.cacheRead).toBe(0);
+    expect(usage.cost.cacheWrite).toBe(0);
+    expect(usage.cost.total).toBe(0);
+
+    vi.unstubAllGlobals();
+  }, 30000);
 
   it("does not inherit the failed attempt's contextUsage input when retrying", async () => {
     // `contextUsageEvent` writes `output.usage.input` and `contextPercent`

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -14,7 +14,7 @@ import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
-import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
+import { concatMessages, encodeEventMessage, encodeExceptionMessage } from "./helpers/event-stream.js";
 
 const ts = Date.now();
 const zeroUsage = {
@@ -2695,9 +2695,9 @@ describe("Feature 9: Streaming Integration", () => {
 
   it("surfaces a mid-stream throttlingError frame and retries", async () => {
     // throttlingError / validationError / serviceUnavailableError are distinct
-    // ChatResponseStream members. Before key routing they matched no branch and
-    // were dropped, so the turn looked like an empty response. Now they abort
-    // the read and enter the retry path with the modeled class in the message.
+    // ChatResponseStream members targeting @error shapes, so the service frames
+    // them as `:message-type: exception`. Before key routing they reached the
+    // caller only as an opaque JSON blob with the modeled class discarded.
     let callCount = 0;
     const mockFetch = vi.fn().mockImplementation(async () => {
       callCount++;
@@ -2712,14 +2712,11 @@ describe("Feature 9: Streaming Integration", () => {
                   done: false,
                   value: concatMessages(
                     encodeEventMessage({ content: "partial" }),
-                    encodeEventMessage(
-                      {
-                        message: "Too many requests",
-                        reason: "INSUFFICIENT_MODEL_CAPACITY",
-                        retryAfterMilliseconds: 10,
-                      },
-                      "throttlingError",
-                    ),
+                    encodeExceptionMessage("throttlingError", {
+                      message: "Too many requests",
+                      reason: "INSUFFICIENT_MODEL_CAPACITY",
+                      retryAfterMilliseconds: 10,
+                    }),
                   ),
                 })
                 .mockResolvedValueOnce({ done: true, value: undefined }),
@@ -2759,6 +2756,10 @@ describe("Feature 9: Streaming Integration", () => {
   });
 
   it("reports the modeled exception class when a typed error frame outlives every retry", async () => {
+    // Exception-framed member: the marshaller throws whatever the deserializer
+    // returns for the `:exception-type` key, so the class name only survives if
+    // that callback recognizes the member. Returning the bare payload would
+    // surface `{"message":"capacity exhausted"}` with no class at all.
     const mockFetch = vi.fn().mockImplementation(async () => ({
       ok: true,
       body: {
@@ -2767,7 +2768,7 @@ describe("Feature 9: Streaming Integration", () => {
             .fn()
             .mockResolvedValueOnce({
               done: false,
-              value: encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError"),
+              value: encodeExceptionMessage("serviceUnavailableError", { message: "capacity exhausted" }),
             })
             .mockResolvedValueOnce({ done: true, value: undefined }),
           cancel: vi.fn().mockResolvedValue(undefined),
@@ -2814,7 +2815,7 @@ describe("Feature 9: Streaming Integration", () => {
                         cacheWriteInputTokens: 7,
                       },
                     }),
-                    encodeEventMessage({ message: "throttled" }, "throttlingError"),
+                    encodeExceptionMessage("throttlingError", { message: "throttled" }),
                   ),
                 })
                 .mockResolvedValueOnce({ done: true, value: undefined }),

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2862,6 +2862,142 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not inherit the failed attempt's contextUsage input when retrying", async () => {
+    // `contextUsageEvent` writes `output.usage.input` and `contextPercent`
+    // straight onto the shared message, which outlives the retry loop. Routing
+    // typed error members made a mid-stream throttle a live retry trigger, so
+    // without an attempt-boundary reset the retried turn is billed for the
+    // abandoned attempt's input and reports its context gauge.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({ content: "partial" }),
+                    encodeEventMessage({ contextUsagePercentage: 90 }),
+                    encodeExceptionMessage("throttlingError", { message: "slow down" }),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Retry succeeds reporting NO contextUsage and NO metadataEvent.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: encodeEventMessage({ content: "clean" }) })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    // 90% of a 200000-token window is 180000 input tokens the retried turn
+    // never used.
+    expect(msg.usage.input).toBe(0);
+    expect((msg.usage as unknown as Record<string, unknown>).contextPercent).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not inherit the failed attempt's token counts across an empty-response retry", async () => {
+    // The post-stream usage writes run BEFORE the empty-response retry check, so
+    // this path leaks differently from the mid-stream error path above. Routing
+    // metadataEvent made it reachable: previously the frame was dropped, so
+    // there were no wire counts to inherit.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // A metadataEvent with large counts and no text or tool calls at all.
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: encodeEventMessage({
+                    tokenUsage: {
+                      uncachedInputTokens: 999,
+                      outputTokens: 111,
+                      totalTokens: 41110,
+                      cacheReadInputTokens: 40000,
+                      cacheWriteInputTokens: 7,
+                    },
+                  }),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: encodeEventMessage({ content: "clean" }) })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    expect(msg.usage.input).toBe(0);
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.cacheWrite).toBe(0);
+    // Output falls back to counting the recovered text, never the 111 reported
+    // by the abandoned attempt.
+    expect(msg.usage.output).toBeLessThan(111);
+    expect(msg.usage.totalTokens).toBe(msg.usage.output);
+
+    vi.unstubAllGlobals();
+  });
+
   it("falls back to summing components when a non-conforming frame omits totalTokens", async () => {
     // TokenUsage.totalTokens is required on the wire, so this branch only guards
     // a non-conforming server. The sum must match how the service itself defines

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -14,7 +14,12 @@ import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
-import { concatMessages, encodeEventMessage, encodeExceptionMessage } from "./helpers/event-stream.js";
+import {
+  concatMessages,
+  encodeEventMessage,
+  encodeExceptionMessage,
+  encodeRawExceptionMessage,
+} from "./helpers/event-stream.js";
 
 const ts = Date.now();
 const zeroUsage = {
@@ -2784,6 +2789,40 @@ describe("Feature 9: Streaming Integration", () => {
     const error = events.find((e) => e.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
     expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
+  it("keeps the exception-type name when the member is not one this client models", async () => {
+    // Smithy's own raw-body fallback only fires when the deserializer returns a
+    // `$unknown` property, which this one never does, so an unmodeled member
+    // would otherwise be thrown as the bare parsed object and reach the caller
+    // as `{"message":"..."}` with the member name gone — the same class loss
+    // this card removes for the four modeled members.
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeRawExceptionMessage("quotaExceededError", { message: "monthly quota gone" }),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("quotaExceededError");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("monthly quota gone");
 
     vi.unstubAllGlobals();
   }, 30000);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2693,6 +2693,100 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("surfaces a mid-stream throttlingError frame and retries", async () => {
+    // throttlingError / validationError / serviceUnavailableError are distinct
+    // ChatResponseStream members. Before key routing they matched no branch and
+    // were dropped, so the turn looked like an empty response. Now they abort
+    // the read and enter the retry path with the modeled class in the message.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({ content: "partial" }),
+                    encodeEventMessage(
+                      {
+                        message: "Too many requests",
+                        reason: "INSUFFICIENT_MODEL_CAPACITY",
+                        retryAfterMilliseconds: 10,
+                      },
+                      "throttlingError",
+                    ),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"recovered"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const done = events.find((e) => e.type === "done");
+    expect(done?.type === "done" && (done.message.content[0] as TextContent).text).toBe("recovered");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports the modeled exception class when a typed error frame outlives every retry", async () => {
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError"),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2617,6 +2617,57 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("records cacheRead/cacheWrite so a cached turn is not priced as uncached input", async () => {
+    // TokenUsage.uncachedInputTokens excludes cache reads. Taking `input` from
+    // it while leaving cacheRead at 0 would report ~200 input tokens for a turn
+    // that actually read 50k cached tokens, and price it accordingly.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+      '{"contextUsagePercentage":5}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(50000);
+    expect(msg.usage.cacheWrite).toBe(0);
+    // input + cacheRead + cacheWrite + output, matching the wire totalTokens.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
+    // Every MetadataEvent field is optional; tokenUsage and stopReason may
+    // arrive in separate frames.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
+      '{"stopReason":"END_TURN"}',
+      '{"contextUsagePercentage":10}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(500);
+    expect(msg.usage.output).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2787,6 +2787,103 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   }, 30000);
 
+  it("does not inherit the failed attempt's cache counts when retrying", async () => {
+    // `usageEvent` is declared inside the retry loop, and the cache writes are
+    // post-loop, so an aborted attempt must contribute nothing to billing.
+    // cacheRead is priced as its own line in calculateCost, so inheriting a
+    // prior attempt's value would over-bill a turn that never read that cache.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({
+                      tokenUsage: {
+                        uncachedInputTokens: 999,
+                        outputTokens: 111,
+                        totalTokens: 41110,
+                        cacheReadInputTokens: 40000,
+                        cacheWriteInputTokens: 7,
+                      },
+                    }),
+                    encodeEventMessage({ message: "throttled" }, "throttlingError"),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Retry succeeds and reports NO metadataEvent at all.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"clean"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    // The abandoned attempt's counts must not appear anywhere in billing.
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.cacheWrite).toBe(0);
+    expect(msg.usage.cost.cacheRead).toBe(0);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to summing components when a non-conforming frame omits totalTokens", async () => {
+    // TokenUsage.totalTokens is required on the wire, so this branch only guards
+    // a non-conforming server. The sum must match how the service itself defines
+    // the total: uncachedInput + cacheRead + cacheWrite + output.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    // Same components as the wire-total test above, which reports 50250.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2644,6 +2644,31 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps the wire totalTokens when the service omits an optional cache count", async () => {
+    // TokenUsage.totalTokens is required on the wire; cacheReadInputTokens and
+    // cacheWriteInputTokens are optional. Recomputing the total from components
+    // would report 250 for a turn the service says cost 50250 context tokens,
+    // and calculateContextTokens drives the context gauge from that total.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
     // Every MetadataEvent field is optional; tokenUsage and stopReason may
     // arrive in separate frames.

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2588,10 +2588,12 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers usage event values over tiktoken when available", async () => {
+  it("prefers metadataEvent token usage over tiktoken when available", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',
-      '{"usage":{"inputTokens":500,"outputTokens":200}}',
+      // MetadataEvent shape from ChatResponseStream: token counts live under
+      // tokenUsage.uncachedInputTokens/outputTokens, not a top-level `usage`.
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
       '{"contextUsagePercentage":10}',
     ]);
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2674,6 +2674,50 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps metadataEvent token counts when a meteringEvent credit frame follows", async () => {
+    // MeteringEvent.usage is a NUMBER of credits. It is the only top-level
+    // `usage` the service emits, and the pre-routing field ladder consumed it as
+    // a token object, reading .inputTokens/.outputTokens off a number. Framed
+    // with an explicit `:event-type` because a units-only or count-only metering
+    // payload cannot be reliably inferred from its shape.
+    const frames = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage(
+        { tokenUsage: { uncachedInputTokens: 500, outputTokens: 200, totalTokens: 700 } },
+        "metadataEvent",
+      ),
+      encodeEventMessage({ usage: 3, unit: "credit", unitPlural: "credits" }, "meteringEvent"),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    // The credit count must not land in, or erase, token accounting.
+    expect(msg.usage.input).toBe(500);
+    expect(msg.usage.output).toBe(200);
+    expect(msg.usage.totalTokens).toBe(700);
+
+    vi.unstubAllGlobals();
+  });
+
   it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
     // Every MetadataEvent field is optional; tokenUsage and stopReason may
     // arrive in separate frames.

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -18,6 +18,7 @@ import {
   concatMessages,
   encodeEventMessage,
   encodeExceptionMessage,
+  encodeExceptionMessageWithRawBody,
   encodeRawExceptionMessage,
 } from "./helpers/event-stream.js";
 
@@ -2867,6 +2868,79 @@ describe("Feature 9: Streaming Integration", () => {
     const error = events.find((e) => e.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("quotaExceededError");
     expect(error?.type === "error" && error.error.errorMessage).toContain("monthly quota gone");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
+  it("classifies an exception frame that names the exception class instead of the union member", async () => {
+    // `:exception-type` is chosen by the service and is not guaranteed to be the
+    // union member name: the hand-written event-stream bridge in the generated
+    // client for this same service accepts `throttlingError` OR
+    // `ThrottlingException` for every one of the four members.
+    //
+    // This is an end-to-end pin that a class-name token survives Smithy's
+    // exception framing intact. The classification itself (`kind: "throttling"`
+    // vs `"unknown"`) is asserted in test/event-parser.test.ts, because
+    // `KiroErrorData.kind` is not yet surfaced on the emitted AssistantMessage —
+    // the diagnostics card owns that.
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeRawExceptionMessage("ServiceUnavailableException", { message: "capacity exhausted" }),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
+  it("keeps the modeled class when an exception frame body is not parseable JSON", async () => {
+    // The class is a header, so it survives a body this client cannot read.
+    // Parsing before the exception branch threw a SyntaxError out of the
+    // deserializer, and the caller reported "Unexpected end of JSON input" with
+    // the modeled class gone — the same class loss, reintroduced by a truncated
+    // or non-JSON body.
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeExceptionMessageWithRawBody("throttlingError", ""),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ThrottlingException");
+    expect(error?.type === "error" && error.error.errorMessage).not.toContain("JSON");
 
     vi.unstubAllGlobals();
   }, 30000);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3612,10 +3612,12 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers usage event values over tiktoken when available", async () => {
+  it("prefers metadataEvent token usage over tiktoken when available", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',
-      '{"usage":{"inputTokens":500,"outputTokens":200}}',
+      // MetadataEvent shape from ChatResponseStream: token counts live under
+      // tokenUsage.uncachedInputTokens/outputTokens, not a top-level `usage`.
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
       '{"contextUsagePercentage":10}',
     ]);
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3974,6 +3974,16 @@ describe("Feature 9: Streaming Integration", () => {
     // post-loop, so an aborted attempt must contribute nothing to billing.
     // cacheRead is priced as its own line in calculateCost, so inheriting a
     // prior attempt's value would over-bill a turn that never read that cache.
+    //
+    // Priced deliberately: `makeModel()` defaults every rate to 0, so a
+    // `cost.*` assertion against the default model passes no matter what leaked
+    // across the retry boundary. Real per-million rates make these assertions
+    // able to fail at all. What actually holds this invariant is `usageEvent`'s
+    // loop scope, not the attempt-boundary reset — dropping the cache lines
+    // from `resetAttemptUsage` leaves this test green, because the aborted
+    // attempt errors before the post-stream cache writes ever run. The
+    // terminal-failure test below is what pins the reset itself.
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
     let callCount = 0;
     const mockFetch = vi.fn().mockImplementation(async () => {
       callCount++;
@@ -4026,7 +4036,7 @@ describe("Feature 9: Streaming Integration", () => {
     });
     vi.stubGlobal("fetch", mockFetch);
 
-    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
     const events = await collect(stream);
     const done = events.find((e) => e.type === "done");
     const msg = done?.type === "done" ? done.message : undefined;
@@ -4039,9 +4049,94 @@ describe("Feature 9: Streaming Integration", () => {
     expect(msg.usage.cacheRead).toBe(0);
     expect(msg.usage.cacheWrite).toBe(0);
     expect(msg.usage.cost.cacheRead).toBe(0);
+    expect(msg.usage.cost.cacheWrite).toBe(0);
 
     vi.unstubAllGlobals();
   });
+
+  it("reports zero tokens and zero cost when a priced attempt is replaced by a terminally failing retry", async () => {
+    // The post-stream usage writes and `calculateCost` both run BEFORE the
+    // empty-response retry check, so a degenerate attempt that reported
+    // metadataEvent counts leaves a real priced charge on `output.usage.cost`.
+    // `output` outlives the retry loop. If the attempt-boundary reset cleared
+    // only the token counts and left `cost` alone, the terminal error would be
+    // emitted with totalTokens 0 and a stale non-zero charge — an invented bill
+    // for a turn that produced nothing.
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Degenerate but expensive: large counts, no text, no tool calls. Gets
+        // priced, then triggers the empty-response retry.
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: encodeEventMessage({
+                    tokenUsage: {
+                      uncachedInputTokens: 90000,
+                      outputTokens: 4000,
+                      totalTokens: 194000,
+                      cacheReadInputTokens: 100000,
+                      cacheWriteInputTokens: 0,
+                    },
+                  }),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Every later attempt fails with a modeled exception frame, so the retry
+      // budget is exhausted and the turn ends in a terminal error.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeExceptionMessage("serviceUnavailableError", { message: "unavailable" }),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type).toBe("error");
+    if (error?.type !== "error") throw new Error("Expected a terminal error event");
+    expect(error.error.errorMessage).toContain("ServiceUnavailableException");
+
+    const usage = error.error.usage;
+    expect(usage.input).toBe(0);
+    expect(usage.output).toBe(0);
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.totalTokens).toBe(0);
+    // The charge the abandoned attempt earned must be gone with its counts.
+    expect(usage.cost.input).toBe(0);
+    expect(usage.cost.output).toBe(0);
+    expect(usage.cost.cacheRead).toBe(0);
+    expect(usage.cost.cacheWrite).toBe(0);
+    expect(usage.cost.total).toBe(0);
+
+    vi.unstubAllGlobals();
+  }, 30000);
 
   it("does not inherit the failed attempt's contextUsage input when retrying", async () => {
     // `contextUsageEvent` writes `output.usage.input` and `contextPercent`

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -15,7 +15,12 @@ import { validateKiroConversation, validateKiroToolStructure } from "../src/hist
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
-import { concatMessages, encodeEventMessage, encodeExceptionMessage } from "./helpers/event-stream.js";
+import {
+  concatMessages,
+  encodeEventMessage,
+  encodeExceptionMessage,
+  encodeRawExceptionMessage,
+} from "./helpers/event-stream.js";
 import { RECORD_279_COMMAND, RECORD_279_SUMMARY, RECORD_279_TEXT } from "./helpers/invoke-fixture.js";
 
 const ts = Date.now();
@@ -3808,6 +3813,40 @@ describe("Feature 9: Streaming Integration", () => {
     const error = events.find((e) => e.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
     expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
+  it("keeps the exception-type name when the member is not one this client models", async () => {
+    // Smithy's own raw-body fallback only fires when the deserializer returns a
+    // `$unknown` property, which this one never does, so an unmodeled member
+    // would otherwise be thrown as the bare parsed object and reach the caller
+    // as `{"message":"..."}` with the member name gone — the same class loss
+    // this card removes for the four modeled members.
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeRawExceptionMessage("quotaExceededError", { message: "monthly quota gone" }),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("quotaExceededError");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("monthly quota gone");
 
     vi.unstubAllGlobals();
   }, 30000);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3717,6 +3717,100 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("surfaces a mid-stream throttlingError frame and retries", async () => {
+    // throttlingError / validationError / serviceUnavailableError are distinct
+    // ChatResponseStream members. Before key routing they matched no branch and
+    // were dropped, so the turn looked like an empty response. Now they abort
+    // the read and enter the retry path with the modeled class in the message.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({ content: "partial" }),
+                    encodeEventMessage(
+                      {
+                        message: "Too many requests",
+                        reason: "INSUFFICIENT_MODEL_CAPACITY",
+                        retryAfterMilliseconds: 10,
+                      },
+                      "throttlingError",
+                    ),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"recovered"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const done = events.find((e) => e.type === "done");
+    expect(done?.type === "done" && (done.message.content[0] as TextContent).text).toBe("recovered");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports the modeled exception class when a typed error frame outlives every retry", async () => {
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError"),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3811,6 +3811,103 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   }, 30000);
 
+  it("does not inherit the failed attempt's cache counts when retrying", async () => {
+    // `usageEvent` is declared inside the retry loop, and the cache writes are
+    // post-loop, so an aborted attempt must contribute nothing to billing.
+    // cacheRead is priced as its own line in calculateCost, so inheriting a
+    // prior attempt's value would over-bill a turn that never read that cache.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({
+                      tokenUsage: {
+                        uncachedInputTokens: 999,
+                        outputTokens: 111,
+                        totalTokens: 41110,
+                        cacheReadInputTokens: 40000,
+                        cacheWriteInputTokens: 7,
+                      },
+                    }),
+                    encodeEventMessage({ message: "throttled" }, "throttlingError"),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Retry succeeds and reports NO metadataEvent at all.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"clean"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    // The abandoned attempt's counts must not appear anywhere in billing.
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.cacheWrite).toBe(0);
+    expect(msg.usage.cost.cacheRead).toBe(0);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to summing components when a non-conforming frame omits totalTokens", async () => {
+    // TokenUsage.totalTokens is required on the wire, so this branch only guards
+    // a non-conforming server. The sum must match how the service itself defines
+    // the total: uncachedInput + cacheRead + cacheWrite + output.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    // Same components as the wire-total test above, which reports 50250.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3886,6 +3886,142 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not inherit the failed attempt's contextUsage input when retrying", async () => {
+    // `contextUsageEvent` writes `output.usage.input` and `contextPercent`
+    // straight onto the shared message, which outlives the retry loop. Routing
+    // typed error members made a mid-stream throttle a live retry trigger, so
+    // without an attempt-boundary reset the retried turn is billed for the
+    // abandoned attempt's input and reports its context gauge.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({ content: "partial" }),
+                    encodeEventMessage({ contextUsagePercentage: 90 }),
+                    encodeExceptionMessage("throttlingError", { message: "slow down" }),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Retry succeeds reporting NO contextUsage and NO metadataEvent.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: encodeEventMessage({ content: "clean" }) })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    // 90% of a 200000-token window is 180000 input tokens the retried turn
+    // never used.
+    expect(msg.usage.input).toBe(0);
+    expect((msg.usage as unknown as Record<string, unknown>).contextPercent).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not inherit the failed attempt's token counts across an empty-response retry", async () => {
+    // The post-stream usage writes run BEFORE the empty-response retry check, so
+    // this path leaks differently from the mid-stream error path above. Routing
+    // metadataEvent made it reachable: previously the frame was dropped, so
+    // there were no wire counts to inherit.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // A metadataEvent with large counts and no text or tool calls at all.
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: encodeEventMessage({
+                    tokenUsage: {
+                      uncachedInputTokens: 999,
+                      outputTokens: 111,
+                      totalTokens: 41110,
+                      cacheReadInputTokens: 40000,
+                      cacheWriteInputTokens: 7,
+                    },
+                  }),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({ done: false, value: encodeEventMessage({ content: "clean" }) })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    expect(msg.usage.input).toBe(0);
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.cacheWrite).toBe(0);
+    // Output falls back to counting the recovered text, never the 111 reported
+    // by the abandoned attempt.
+    expect(msg.usage.output).toBeLessThan(111);
+    expect(msg.usage.totalTokens).toBe(msg.usage.output);
+
+    vi.unstubAllGlobals();
+  });
+
   it("falls back to summing components when a non-conforming frame omits totalTokens", async () => {
     // TokenUsage.totalTokens is required on the wire, so this branch only guards
     // a non-conforming server. The sum must match how the service itself defines

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3698,6 +3698,50 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps metadataEvent token counts when a meteringEvent credit frame follows", async () => {
+    // MeteringEvent.usage is a NUMBER of credits. It is the only top-level
+    // `usage` the service emits, and the pre-routing field ladder consumed it as
+    // a token object, reading .inputTokens/.outputTokens off a number. Framed
+    // with an explicit `:event-type` because a units-only or count-only metering
+    // payload cannot be reliably inferred from its shape.
+    const frames = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage(
+        { tokenUsage: { uncachedInputTokens: 500, outputTokens: 200, totalTokens: 700 } },
+        "metadataEvent",
+      ),
+      encodeEventMessage({ usage: 3, unit: "credit", unitPlural: "credits" }, "meteringEvent"),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    // The credit count must not land in, or erase, token accounting.
+    expect(msg.usage.input).toBe(500);
+    expect(msg.usage.output).toBe(200);
+    expect(msg.usage.totalTokens).toBe(700);
+
+    vi.unstubAllGlobals();
+  });
+
   it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
     // Every MetadataEvent field is optional; tokenUsage and stopReason may
     // arrive in separate frames.

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -15,7 +15,7 @@ import { validateKiroConversation, validateKiroToolStructure } from "../src/hist
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
-import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
+import { concatMessages, encodeEventMessage, encodeExceptionMessage } from "./helpers/event-stream.js";
 import { RECORD_279_COMMAND, RECORD_279_SUMMARY, RECORD_279_TEXT } from "./helpers/invoke-fixture.js";
 
 const ts = Date.now();
@@ -3719,9 +3719,9 @@ describe("Feature 9: Streaming Integration", () => {
 
   it("surfaces a mid-stream throttlingError frame and retries", async () => {
     // throttlingError / validationError / serviceUnavailableError are distinct
-    // ChatResponseStream members. Before key routing they matched no branch and
-    // were dropped, so the turn looked like an empty response. Now they abort
-    // the read and enter the retry path with the modeled class in the message.
+    // ChatResponseStream members targeting @error shapes, so the service frames
+    // them as `:message-type: exception`. Before key routing they reached the
+    // caller only as an opaque JSON blob with the modeled class discarded.
     let callCount = 0;
     const mockFetch = vi.fn().mockImplementation(async () => {
       callCount++;
@@ -3736,14 +3736,11 @@ describe("Feature 9: Streaming Integration", () => {
                   done: false,
                   value: concatMessages(
                     encodeEventMessage({ content: "partial" }),
-                    encodeEventMessage(
-                      {
-                        message: "Too many requests",
-                        reason: "INSUFFICIENT_MODEL_CAPACITY",
-                        retryAfterMilliseconds: 10,
-                      },
-                      "throttlingError",
-                    ),
+                    encodeExceptionMessage("throttlingError", {
+                      message: "Too many requests",
+                      reason: "INSUFFICIENT_MODEL_CAPACITY",
+                      retryAfterMilliseconds: 10,
+                    }),
                   ),
                 })
                 .mockResolvedValueOnce({ done: true, value: undefined }),
@@ -3783,6 +3780,10 @@ describe("Feature 9: Streaming Integration", () => {
   });
 
   it("reports the modeled exception class when a typed error frame outlives every retry", async () => {
+    // Exception-framed member: the marshaller throws whatever the deserializer
+    // returns for the `:exception-type` key, so the class name only survives if
+    // that callback recognizes the member. Returning the bare payload would
+    // surface `{"message":"capacity exhausted"}` with no class at all.
     const mockFetch = vi.fn().mockImplementation(async () => ({
       ok: true,
       body: {
@@ -3791,7 +3792,7 @@ describe("Feature 9: Streaming Integration", () => {
             .fn()
             .mockResolvedValueOnce({
               done: false,
-              value: encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError"),
+              value: encodeExceptionMessage("serviceUnavailableError", { message: "capacity exhausted" }),
             })
             .mockResolvedValueOnce({ done: true, value: undefined }),
           cancel: vi.fn().mockResolvedValue(undefined),
@@ -3838,7 +3839,7 @@ describe("Feature 9: Streaming Integration", () => {
                         cacheWriteInputTokens: 7,
                       },
                     }),
-                    encodeEventMessage({ message: "throttled" }, "throttlingError"),
+                    encodeExceptionMessage("throttlingError", { message: "throttled" }),
                   ),
                 })
                 .mockResolvedValueOnce({ done: true, value: undefined }),

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3641,6 +3641,57 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("records cacheRead/cacheWrite so a cached turn is not priced as uncached input", async () => {
+    // TokenUsage.uncachedInputTokens excludes cache reads. Taking `input` from
+    // it while leaving cacheRead at 0 would report ~200 input tokens for a turn
+    // that actually read 50k cached tokens, and price it accordingly.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+      '{"contextUsagePercentage":5}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(50000);
+    expect(msg.usage.cacheWrite).toBe(0);
+    // input + cacheRead + cacheWrite + output, matching the wire totalTokens.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
+    // Every MetadataEvent field is optional; tokenUsage and stopReason may
+    // arrive in separate frames.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
+      '{"stopReason":"END_TURN"}',
+      '{"contextUsagePercentage":10}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(500);
+    expect(msg.usage.output).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3668,6 +3668,31 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps the wire totalTokens when the service omits an optional cache count", async () => {
+    // TokenUsage.totalTokens is required on the wire; cacheReadInputTokens and
+    // cacheWriteInputTokens are optional. Recomputing the total from components
+    // would report 250 for a turn the service says cost 50250 context tokens,
+    // and calculateContextTokens drives the context gauge from that total.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
     // Every MetadataEvent field is optional; tokenUsage and stopReason may
     // arrive in separate frames.

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -19,6 +19,7 @@ import {
   concatMessages,
   encodeEventMessage,
   encodeExceptionMessage,
+  encodeExceptionMessageWithRawBody,
   encodeRawExceptionMessage,
 } from "./helpers/event-stream.js";
 import { RECORD_279_COMMAND, RECORD_279_SUMMARY, RECORD_279_TEXT } from "./helpers/invoke-fixture.js";
@@ -3891,6 +3892,79 @@ describe("Feature 9: Streaming Integration", () => {
     const error = events.find((e) => e.type === "error");
     expect(error?.type === "error" && error.error.errorMessage).toContain("quotaExceededError");
     expect(error?.type === "error" && error.error.errorMessage).toContain("monthly quota gone");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
+  it("classifies an exception frame that names the exception class instead of the union member", async () => {
+    // `:exception-type` is chosen by the service and is not guaranteed to be the
+    // union member name: the hand-written event-stream bridge in the generated
+    // client for this same service accepts `throttlingError` OR
+    // `ThrottlingException` for every one of the four members.
+    //
+    // This is an end-to-end pin that a class-name token survives Smithy's
+    // exception framing intact. The classification itself (`kind: "throttling"`
+    // vs `"unknown"`) is asserted in test/event-parser.test.ts, because
+    // `KiroErrorData.kind` is not yet surfaced on the emitted AssistantMessage —
+    // the diagnostics card owns that.
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeRawExceptionMessage("ServiceUnavailableException", { message: "capacity exhausted" }),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
+  it("keeps the modeled class when an exception frame body is not parseable JSON", async () => {
+    // The class is a header, so it survives a body this client cannot read.
+    // Parsing before the exception branch threw a SyntaxError out of the
+    // deserializer, and the caller reported "Unexpected end of JSON input" with
+    // the modeled class gone — the same class loss, reintroduced by a truncated
+    // or non-JSON body.
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeExceptionMessageWithRawBody("throttlingError", ""),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ThrottlingException");
+    expect(error?.type === "error" && error.error.errorMessage).not.toContain("JSON");
 
     vi.unstubAllGlobals();
   }, 30000);


### PR DESCRIPTION
## Problem

`parseKiroEvent` guessed each stream event's type from an order-dependent `if` ladder over field names, even though the frame's modeled union key was already decoded and then discarded:

```ts
// stream.ts (before)
const eventPayload = Object.values(value)[0];   // key thrown away
const event = parseKiroEvent(eventPayload);     // type re-guessed from fields
```

The authoritative wire model is `ChatResponseStream` in the generated Smithy client for the same service (`generateAssistantResponse` on `runtime.{region}.kiro.dev`) — a tagged union of 13 members. Diffing the ladder's field tests against those members shows three concrete defects:

1. **`metadataEvent` matched no branch and was silently dropped.** Its payload is `{tokenUsage?, stopReason?, stopDetails?}`. The ladder tested `parsed.stop` (wire: `stopReason`), `parsed.usage` (wire: `tokenUsage`), and top-level `parsed.contextUsagePercentage` (wire: nested in `tokenUsage`). No branch hit, so `parseKiroEvent` returned `null` and token usage never arrived.
2. **`meteringEvent` hit the `parsed.usage` branch and was mis-typed.** `MeteringEvent.usage` is a **number of credits**. The branch cast it to an object and read `.inputTokens`/`.outputTokens` off a number, yielding `undefined` — while the credit figure that drives billing was dropped.
3. **Error frames lost their modeled class.** `error`, `throttlingError`, `validationError` and `serviceUnavailableError` are four distinct union keys; the ladder only tested `parsed.error`/`parsed.Error`, which are absent on modeled exceptions. Throttle/validation/unavailable frames fell through to `null` and their class was later re-derived by prose regex.

## Change

- `parseKiroEvent(key, payload)` now switches on the modeled `:event-type` key. All 13 `ChatResponseStream` members are enumerated in `KIRO_EVENT_KEYS`.
- Known members with no consumer yet (`codeReferenceEvent`, `documentCitationEvent`, `toolResultEvent`, redacted reasoning content) return a distinct `ignored` event, so "known but unused" is no longer indistinguishable from "unparseable".
- The field-sniffing ladder is retained as `parseKiroEventByShape`, reachable only from the `default:` branch, so `$unknown`/unkeyed frames still degrade rather than break the stream.
- `metadataEvent` maps to a typed `KiroUsageData` carrying `uncachedInputTokens`, `outputTokens`, `totalTokens`, `cacheReadInputTokens`, `cacheWriteInputTokens`, `contextUsagePercentage`, plus verbatim `rawStopReason`/`stopDetails`.
- `meteringEvent` gets its own `metering` event exposing `credits`/`unit`/`unitPlural`. Token fields are never read off it.
- Error frames route to `parseError` with a modeled `kind` (`internalServer` / `throttling` / `validation` / `serviceUnavailable` / `unknown`) and pass through `reason` and `retryAfterMilliseconds`.

Consumer-side, in `stream.ts`:

- Cache counts now reach `output.usage.cacheRead`/`cacheWrite`. They were initialized to `0` and never written, so every turn reported a fabricated 0% cache hit rate — and since `usage.input` is the *uncached* slot that `calculateCost` prices separately from the cache slots, a cached turn was priced far too low.
- `usage.totalTokens` prefers the wire's `TokenUsage.totalTokens` (required on the wire, unlike the optional cache components) and falls back to the component sum.
- `metadataEvent` frames are merged rather than replaced, because every field is optional and the service may split `tokenUsage` from `stopReason`/`stopDetails` across frames.
- `output.content` is reset before a retry. `output` is created once outside the retry loop, so a typed error frame arriving after partial text would otherwise concatenate the abandoned prefix onto the retried response.

## Tests

`test/event-parser.test.ts` previously asserted on `{"usage":{"inputTokens":500,"outputTokens":200}}` — a shape the service never emits. That fixture (introduced in 7eb6103 alongside the retry/truncation work) was speculative, not observed, and locked in the wrong contract. Fixtures are rebuilt from the `ChatResponseStream` members, including:

- a `metadataEvent` frame producing a usage event (previously impossible);
- `meteringEvent` credits not being read as token counts;
- each typed error member keeping its modeled class and `retryAfterMilliseconds`;
- split `metadataEvent` frames merging instead of clobbering;
- retry-boundary isolation: a retried attempt inherits neither the failed attempt's text nor its cache counts.

## Validation

`npm run build` clean; `npm test` → 18 files, 337 tests, all passing.

## Follow-ups unblocked by this

Typed `KiroApiError` consumption, real `retryAfterMilliseconds`-driven backoff, and surfacing `rawStopReason` all depended on the modeled key surviving the boundary. They are separate changes.
