### PR TITLE
feat(usage): populate token and prompt-cache counts from modeled metadataEvent.tokenUsage

### DIFF
--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -1,5 +1,67 @@
-// ABOUTME: Kiro stream event type definitions and JSON-to-typed-event mapping.
+// ABOUTME: Kiro stream event type definitions and modeled-key-to-typed-event mapping.
 // ABOUTME: Binary framing is handled by @smithy/core EventStreamMarshaller in stream.ts.
+
+/**
+ * Members of the `ChatResponseStream` tagged union emitted by
+ * `generateAssistantResponse` on `runtime.{region}.kiro.dev`.
+ *
+ * Source of truth: the generated Smithy client for the same service
+ * (`@amzn/kiro-runtime-service-typescript-client`, `ChatResponseStream`).
+ * The frame's `:event-type` header carries one of these keys, so routing is a
+ * switch on the key rather than a guess based on which fields happen to be set.
+ */
+export const KIRO_EVENT_KEYS = [
+  "assistantResponseEvent",
+  "codeReferenceEvent",
+  "contextUsageEvent",
+  "documentCitationEvent",
+  "error",
+  "metadataEvent",
+  "meteringEvent",
+  "reasoningContentEvent",
+  "serviceUnavailableError",
+  "throttlingError",
+  "toolResultEvent",
+  "toolUseEvent",
+  "validationError",
+] as const;
+
+export type KiroEventKey = (typeof KIRO_EVENT_KEYS)[number];
+
+const KIRO_EVENT_KEY_SET: ReadonlySet<string> = new Set(KIRO_EVENT_KEYS);
+
+export function isKiroEventKey(key: string): key is KiroEventKey {
+  return KIRO_EVENT_KEY_SET.has(key);
+}
+
+/** Token accounting from `MetadataEvent.tokenUsage`. */
+export type KiroUsageData = {
+  /** `TokenUsage.uncachedInputTokens` — input tokens billed at full rate. */
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  contextUsagePercentage?: number;
+  /** `MetadataEvent.stopReason`, passed through verbatim. */
+  rawStopReason?: string;
+  /** `MetadataEvent.stopDetails`, passed through verbatim. */
+  stopDetails?: Record<string, unknown>;
+};
+
+/** Which modeled union member produced an error event. */
+export type KiroErrorKind = "internalServer" | "throttling" | "validation" | "serviceUnavailable" | "unknown";
+
+export type KiroErrorData = {
+  /** Exception class name, or the legacy free-form `error` string. */
+  error: string;
+  message?: string;
+  kind: KiroErrorKind;
+  /** `ThrottlingException.reason` / `ValidationException.reason`, passed through. */
+  reason?: string;
+  /** `ThrottlingException.retryAfterMilliseconds`. */
+  retryAfterMilliseconds?: number;
+};
 
 export type KiroStreamEvent =
   | { type: "content"; data: string }
@@ -10,53 +72,169 @@ export type KiroStreamEvent =
   | { type: "toolUseStop"; data: { stop: boolean } }
   | { type: "contextUsage"; data: { contextUsagePercentage: number } }
   | { type: "followupPrompt"; data: string }
-  | { type: "usage"; data: { inputTokens?: number; outputTokens?: number } }
-  | { type: "error"; data: { error: string; message?: string } };
+  | { type: "usage"; data: KiroUsageData }
+  /** `MeteringEvent` — `usage` is a COUNT OF CREDITS, not tokens. */
+  | { type: "metering"; data: { credits?: number; unit?: string; unitPlural?: string } }
+  | { type: "error"; data: KiroErrorData }
+  /** A known union member with no consumer yet. Kept distinct from unparseable. */
+  | { type: "ignored"; data: { key: string } };
 
-export function parseKiroEvent(parsed: Record<string, unknown>): KiroStreamEvent | null {
-  if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };
-  if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
-  if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
+const num = (v: unknown): number | undefined => (typeof v === "number" ? v : undefined);
+const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+
+/** Serialize a toolUse `input` field, collapsing the empty-object placeholder to "". */
+function toolInput(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object" && Object.keys(raw as Record<string, unknown>).length > 0) {
+    return JSON.stringify(raw);
+  }
+  return "";
+}
+
+function parseToolUse(parsed: Record<string, unknown>): KiroStreamEvent | null {
+  // Kiro splits one logical tool call across frames: the first carries
+  // name+toolUseId, continuations carry only `input`, the last only `stop`.
   if (parsed.name && parsed.toolUseId) {
-    const input =
-      typeof parsed.input === "string"
-        ? parsed.input
-        : parsed.input &&
-            typeof parsed.input === "object" &&
-            Object.keys(parsed.input as Record<string, unknown>).length > 0
-          ? JSON.stringify(parsed.input)
-          : "";
     return {
       type: "toolUse",
       data: {
         name: parsed.name as string,
         toolUseId: parsed.toolUseId as string,
-        input,
+        input: toolInput(parsed.input),
         stop: parsed.stop as boolean | undefined,
       },
     };
   }
+  if (parsed.input !== undefined) {
+    return { type: "toolUseInput", data: { input: toolInput(parsed.input) } };
+  }
+  if (parsed.stop !== undefined) return { type: "toolUseStop", data: { stop: parsed.stop as boolean } };
+  return null;
+}
+
+function parseMetadata(parsed: Record<string, unknown>): KiroStreamEvent | null {
+  const tu = (parsed.tokenUsage ?? {}) as Record<string, unknown>;
+  const data: KiroUsageData = {
+    inputTokens: num(tu.uncachedInputTokens),
+    outputTokens: num(tu.outputTokens),
+    totalTokens: num(tu.totalTokens),
+    cacheReadInputTokens: num(tu.cacheReadInputTokens),
+    cacheWriteInputTokens: num(tu.cacheWriteInputTokens),
+    contextUsagePercentage: num(tu.contextUsagePercentage),
+    rawStopReason: str(parsed.stopReason),
+    stopDetails:
+      parsed.stopDetails && typeof parsed.stopDetails === "object"
+        ? (parsed.stopDetails as Record<string, unknown>)
+        : undefined,
+  };
+  for (const k of Object.keys(data) as (keyof KiroUsageData)[]) {
+    if (data[k] === undefined) delete data[k];
+  }
+  return Object.keys(data).length > 0 ? { type: "usage", data } : null;
+}
+
+function parseError(parsed: Record<string, unknown>, kind: KiroErrorKind, fallbackName: string): KiroStreamEvent {
+  // Modeled exceptions carry {message, reason?, retryAfterMilliseconds?}; older
+  // free-form frames carry {error, message}. Accept both.
+  const rawError = parsed.error ?? parsed.Error;
+  const error =
+    typeof rawError === "string"
+      ? rawError
+      : rawError !== undefined
+        ? JSON.stringify(rawError)
+        : (str(parsed.name) ?? fallbackName);
+  const message = (parsed.message ?? parsed.Message ?? parsed.reason) as string | undefined;
+  const data: KiroErrorData = { error, kind };
+  if (typeof message === "string") data.message = message;
+  const reason = str(parsed.reason);
+  if (reason !== undefined) data.reason = reason;
+  const retryAfterMilliseconds = num(parsed.retryAfterMilliseconds);
+  if (retryAfterMilliseconds !== undefined) data.retryAfterMilliseconds = retryAfterMilliseconds;
+  return { type: "error", data };
+}
+
+/**
+ * Route a decoded stream frame by its modeled `:event-type` key.
+ *
+ * `key` is the `ChatResponseStream` union member name from the frame header.
+ * Unknown or missing keys fall back to {@link parseKiroEventByShape} so new
+ * server-side members degrade instead of breaking the stream.
+ */
+export function parseKiroEvent(key: string, parsed: Record<string, unknown>): KiroStreamEvent | null {
+  switch (key) {
+    case "assistantResponseEvent": {
+      const content = str(parsed.content);
+      return content !== undefined ? { type: "content", data: content } : null;
+    }
+    case "reasoningContentEvent": {
+      // ReasoningContentEvent = {text?, redactedContent?, signature?}
+      const text = str(parsed.text);
+      if (text !== undefined) return { type: "thinkingText", data: text };
+      const signature = str(parsed.signature);
+      if (signature !== undefined) return { type: "thinkingSignature", data: signature };
+      return { type: "ignored", data: { key } };
+    }
+    case "toolUseEvent":
+      return parseToolUse(parsed);
+    case "contextUsageEvent": {
+      const pct = num(parsed.contextUsagePercentage);
+      return pct !== undefined ? { type: "contextUsage", data: { contextUsagePercentage: pct } } : null;
+    }
+    case "metadataEvent":
+      return parseMetadata(parsed);
+    case "meteringEvent":
+      // MeteringEvent.usage is a NUMBER of credits — never token counts.
+      return {
+        type: "metering",
+        data: { credits: num(parsed.usage), unit: str(parsed.unit), unitPlural: str(parsed.unitPlural) },
+      };
+    case "error":
+      return parseError(parsed, "internalServer", "InternalServerException");
+    case "throttlingError":
+      return parseError(parsed, "throttling", "ThrottlingException");
+    case "validationError":
+      return parseError(parsed, "validation", "ValidationException");
+    case "serviceUnavailableError":
+      return parseError(parsed, "serviceUnavailable", "ServiceUnavailableException");
+    // Known members with no consumer yet: explicitly ignored, not unparseable.
+    case "codeReferenceEvent":
+    case "documentCitationEvent":
+    case "toolResultEvent":
+      return { type: "ignored", data: { key } };
+    default:
+      return parseKiroEventByShape(parsed);
+  }
+}
+
+/**
+ * Fail-open fallback for `$unknown` / unkeyed frames.
+ *
+ * Order-dependent field sniffing. Only reachable when the frame carries no
+ * recognizable `:event-type`; modeled frames never reach here.
+ */
+export function parseKiroEventByShape(parsed: Record<string, unknown>): KiroStreamEvent | null {
+  if (parsed.content !== undefined) return { type: "content", data: parsed.content as string };
+  if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
+  if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
+  if (parsed.name && parsed.toolUseId) return parseToolUse(parsed);
   if (parsed.input !== undefined && !parsed.name) {
-    return {
-      type: "toolUseInput",
-      data: { input: typeof parsed.input === "string" ? parsed.input : JSON.stringify(parsed.input) },
-    };
+    return { type: "toolUseInput", data: { input: toolInput(parsed.input) } };
   }
   if (parsed.stop !== undefined && parsed.contextUsagePercentage === undefined)
     return { type: "toolUseStop", data: { stop: parsed.stop as boolean } };
   if (parsed.contextUsagePercentage !== undefined)
     return { type: "contextUsage", data: { contextUsagePercentage: parsed.contextUsagePercentage as number } };
   if (parsed.followupPrompt !== undefined) return { type: "followupPrompt", data: parsed.followupPrompt as string };
-  if (parsed.error !== undefined || parsed.Error !== undefined) {
-    const error = (parsed.error || parsed.Error || "unknown") as string;
-    const message = (parsed.message || parsed.Message || parsed.reason) as string | undefined;
-    return { type: "error", data: { error: typeof error === "string" ? error : JSON.stringify(error), message } };
+  if (parsed.tokenUsage !== undefined || parsed.stopReason !== undefined || parsed.stopDetails !== undefined) {
+    return parseMetadata(parsed);
   }
-  if (parsed.usage !== undefined) {
-    const u = parsed.usage as Record<string, unknown>;
+  if (parsed.error !== undefined || parsed.Error !== undefined) {
+    return parseError(parsed, "unknown", "unknown");
+  }
+  if (typeof parsed.usage === "number") {
     return {
-      type: "usage",
-      data: { inputTokens: u.inputTokens as number | undefined, outputTokens: u.outputTokens as number | undefined },
+      type: "metering",
+      data: { credits: parsed.usage, unit: str(parsed.unit), unitPlural: str(parsed.unitPlural) },
     };
   }
   return null;

--- a/src/event-parser.ts
+++ b/src/event-parser.ts
@@ -43,6 +43,8 @@ export type KiroUsageData = {
   cacheReadInputTokens?: number;
   cacheWriteInputTokens?: number;
   contextUsagePercentage?: number;
+  /** `TokenUsage.normalizedTokenUsage` — the MPS credit basis, not a token count. */
+  normalizedTokenUsage?: number;
   /** `MetadataEvent.stopReason`, passed through verbatim. */
   rawStopReason?: string;
   /** `MetadataEvent.stopDetails`, passed through verbatim. */
@@ -121,6 +123,7 @@ function parseMetadata(parsed: Record<string, unknown>): KiroStreamEvent | null 
     cacheReadInputTokens: num(tu.cacheReadInputTokens),
     cacheWriteInputTokens: num(tu.cacheWriteInputTokens),
     contextUsagePercentage: num(tu.contextUsagePercentage),
+    normalizedTokenUsage: num(tu.normalizedTokenUsage),
     rawStopReason: str(parsed.stopReason),
     stopDetails:
       parsed.stopDetails && typeof parsed.stopDetails === "object"

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -857,7 +857,13 @@ export function streamKiro(
         if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
         if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
+        // `TokenUsage.totalTokens` is required on the wire while the cache counts
+        // are optional, so the service's own total is the authoritative figure —
+        // recomputing from components silently under-reports whenever a component
+        // is omitted. Prefer it and fall back to the sum, matching how pi's
+        // bedrock adapter treats the one other wire that supplies a total.
         output.usage.totalTokens =
+          usageEvent?.totalTokens ??
           output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,7 +28,7 @@ import {
   type KiroAdditionalModelRequestFields,
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
-import { parseKiroEvent } from "./event-parser.js";
+import { type KiroUsageData, parseKiroEvent } from "./event-parser.js";
 import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
@@ -561,7 +561,7 @@ export function streamKiro(
         const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
         let totalContent = "";
         let lastContentData = "";
-        let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
+        let usageEvent: KiroUsageData | null = null;
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -671,9 +671,18 @@ export function streamKiro(
           const { done, value } = iterResult;
           if (done) break;
           resetIdle();
-          const eventPayload = Object.values(value as Record<string, unknown>)[0] as Record<string, unknown>;
-          const event = parseKiroEvent(eventPayload);
+          // The marshaller keys each frame by its modeled `ChatResponseStream`
+          // union member (from the `:event-type` header). Route on that key
+          // instead of guessing the member from which fields are populated.
+          const frameEntry = Object.entries(value as Record<string, unknown>)[0];
+          if (!frameEntry) continue;
+          const [frameKey, framePayload] = frameEntry;
+          const event = parseKiroEvent(frameKey, (framePayload ?? {}) as Record<string, unknown>);
           if (!event) continue;
+          if (event.type === "ignored") {
+            if (debugEnabled()) debugLog("stream.events.ignored", [event.data.key]);
+            continue;
+          }
           if (debugEnabled()) debugLog("stream.events", [event]);
           switch (event.type) {
             case "contextUsage": {
@@ -744,6 +753,12 @@ export function streamKiro(
             }
             case "usage": {
               usageEvent = event.data;
+              break;
+            }
+            case "metering": {
+              // MeteringEvent.usage counts credits, not tokens. Recorded for
+              // observability only; never folded into token accounting.
+              if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
             case "error": {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -752,7 +752,11 @@ export function streamKiro(
               break;
             }
             case "usage": {
-              usageEvent = event.data;
+              // Every MetadataEvent field is optional, so the service may split
+              // tokenUsage and stopReason/stopDetails across frames. Merge so a
+              // later partial frame cannot erase counts already received.
+              const prev: KiroUsageData = usageEvent ?? {};
+              usageEvent = { ...prev, ...event.data };
               break;
             }
             case "metering": {
@@ -842,9 +846,19 @@ export function streamKiro(
         // (accumulated into `totalContent` above). Otherwise tool-call-only
         // turns report 0 output tokens and break consumers like the TPS
         // extension that watch `usage.output`.
+        //
+        // `KiroUsageData.inputTokens` is `TokenUsage.uncachedInputTokens` — the
+        // input billed at full rate, NOT total input. pi's `usage.input` is the
+        // same uncached slot, with `cacheRead`/`cacheWrite` as siblings, and
+        // `calculateCost` prices all three separately. So the cache counts must
+        // land whenever `input` is taken from the wire; otherwise a cached turn
+        // reports a fraction of its real input and is priced far too low.
         if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
+        if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
+        if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
-        output.usage.totalTokens = output.usage.input + output.usage.output;
+        output.usage.totalTokens =
+          output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);
         } catch {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -782,8 +782,9 @@ export function streamKiro(
             case "metering": {
               // MeteringEvent.usage counts credits, not tokens. Recorded as its
               // own field so the actual billing unit is observable; never folded
-              // into token accounting or into Usage.cost.
-              applyMeteringCredits(usage, event.data.credits, event.data.unitPlural ?? event.data.unit);
+              // into token accounting or into Usage.cost. Both grammatical forms
+              // are passed through so the count picks the right one.
+              applyMeteringCredits(usage, event.data.credits, event.data.unit, event.data.unitPlural);
               if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -781,6 +781,14 @@ export function streamKiro(
           if (retryCount < maxRetries) {
             retryCount++;
             const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            // `output` is created once outside the retry loop, so anything the
+            // aborted attempt already appended survives into the next one. A
+            // typed error frame (throttling/validation/serviceUnavailable) can
+            // arrive after partial text, which would otherwise concatenate the
+            // abandoned prefix onto the retried response. The empty-response
+            // retry below resets for the same reason. `textBlockIndex` and the
+            // tool-call state are per-iteration and need no reset here.
+            output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;
           }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -55,6 +55,13 @@ import {
   MAX_RETRY_DELAY,
 } from "./retry.js";
 import { ThinkingTagParser } from "./thinking-parser.js";
+import {
+  applyContextUsage,
+  applyMeteringCredits,
+  finalizeKiroUsage,
+  type KiroUsage,
+  resetKiroUsage,
+} from "./token-usage.js";
 import { countTokens } from "./tokenizer.js";
 import {
   buildHistory,
@@ -187,20 +194,29 @@ export function streamKiro(
     .AssistantMessageEventStream;
   const stream = new StreamCtor();
   (async () => {
+    // Held as `KiroUsage` (pi's `Usage` plus Kiro-only figures) so the
+    // Kiro-specific fields are compiler-checked instead of being written
+    // through a cast. `output.usage` is the same object.
+    //
+    // cacheRead/cacheWrite start at 0 because pi's `Usage` requires numbers,
+    // but that 0 is a placeholder, not a measurement: until a turn reports
+    // cache counts, `usage.provenance.cache` stays absent so consumers can
+    // tell "no cache hits" apart from "the service never said".
+    const usage: KiroUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
     const output: AssistantMessage = {
       role: "assistant",
       content: [],
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage,
       stopReason: "stop",
       timestamp: Date.now(),
     };
@@ -562,6 +578,9 @@ export function streamKiro(
         let totalContent = "";
         let lastContentData = "";
         let usageEvent: KiroUsageData | null = null;
+        // `usage` outlives this loop; clear whatever a previous attempt reported
+        // so a failed attempt's counts cannot survive into this one.
+        resetKiroUsage(usage);
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -686,9 +705,10 @@ export function streamKiro(
           if (debugEnabled()) debugLog("stream.events", [event]);
           switch (event.type) {
             case "contextUsage": {
-              const pct = event.data.contextUsagePercentage;
-              output.usage.input = Math.round((pct / 100) * model.contextWindow);
-              (output.usage as unknown as Record<string, unknown>).contextPercent = pct;
+              // Provisional only: this arrives long before metadataEvent, so it
+              // keeps live context% moving mid-turn. The input count it derives
+              // is superseded by the measured one in finalizeKiroUsage().
+              applyContextUsage(usage, event.data.contextUsagePercentage, model.contextWindow);
               receivedContextUsage = true;
               break;
             }
@@ -760,8 +780,10 @@ export function streamKiro(
               break;
             }
             case "metering": {
-              // MeteringEvent.usage counts credits, not tokens. Recorded for
-              // observability only; never folded into token accounting.
+              // MeteringEvent.usage counts credits, not tokens. Recorded as its
+              // own field so the actual billing unit is observable; never folded
+              // into token accounting or into Usage.cost.
+              applyMeteringCredits(usage, event.data.credits, event.data.unitPlural ?? event.data.unit);
               if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
@@ -846,33 +868,28 @@ export function streamKiro(
             content: (output.content[textBlockIndex] as TextContent).text,
             partial: output,
           });
-        // The Kiro streaming API does not reliably emit per-response output
-        // token counts (unlike Anthropic's `output_tokens` or Bedrock's
-        // `usage.outputTokens`). When the `usage` event is missing or only
-        // reports `inputTokens`, fall back to a tiktoken estimate over
-        // everything the assistant emitted — text plus tool-call input JSON
-        // (accumulated into `totalContent` above). Otherwise tool-call-only
-        // turns report 0 output tokens and break consumers like the TPS
-        // extension that watch `usage.output`.
+        // Fold in whatever `metadataEvent.tokenUsage` reported.
         //
         // `KiroUsageData.inputTokens` is `TokenUsage.uncachedInputTokens` — the
         // input billed at full rate, NOT total input. pi's `usage.input` is the
         // same uncached slot, with `cacheRead`/`cacheWrite` as siblings, and
-        // `calculateCost` prices all three separately. So the cache counts must
-        // land whenever `input` is taken from the wire; otherwise a cached turn
+        // `calculateCost` prices all three separately, so the cache counts must
+        // land whenever `input` comes from the wire; otherwise a cached turn
         // reports a fraction of its real input and is priced far too low.
-        if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
-        if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
-        if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
-        output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
+        //
         // `TokenUsage.totalTokens` is required on the wire while the cache counts
-        // are optional, so the service's own total is the authoritative figure —
-        // recomputing from components silently under-reports whenever a component
-        // is omitted. Prefer it and fall back to the sum, matching how pi's
-        // bedrock adapter treats the one other wire that supplies a total.
-        output.usage.totalTokens =
-          usageEvent?.totalTokens ??
-          output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
+        // are optional, so the service's own total is authoritative — recomputing
+        // from components under-reports whenever one is omitted.
+        //
+        // finalizeKiroUsage() owns all of that, plus the measured > derived >
+        // estimated precedence and the slot normalization that keeps
+        // input/cacheRead/cacheWrite disjoint. The tiktoken estimate over
+        // everything the assistant emitted (text plus tool-call input JSON,
+        // accumulated into `totalContent`) fills only the figures the wire
+        // omitted: Kiro does not reliably send `outputTokens`, and a
+        // tool-call-only turn reporting 0 output breaks consumers that watch
+        // `usage.output`, such as the TPS extension.
+        finalizeKiroUsage(usage, usageEvent, () => countTokens(totalContent));
         try {
           PiAi.calculateCost(model, output.usage);
         } catch {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -994,6 +994,14 @@ export function streamKiro(
           if (retryCount < maxRetries) {
             retryCount++;
             const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            // `output` is created once outside the retry loop, so anything the
+            // aborted attempt already appended survives into the next one. A
+            // typed error frame (throttling/validation/serviceUnavailable) can
+            // arrive after partial text, which would otherwise concatenate the
+            // abandoned prefix onto the retried response. The empty-response
+            // retry below resets for the same reason. `textBlockIndex` and the
+            // tool-call state are per-iteration and need no reset here.
+            output.content = [];
             await abortableDelay(delayMs, options?.signal);
             continue;
           }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -63,6 +63,13 @@ import {
 } from "./retry.js";
 import { ThinkingTagParser } from "./thinking-parser.js";
 import { kiroTokenTypeHeaders } from "./token-type.js";
+import {
+  applyContextUsage,
+  applyMeteringCredits,
+  finalizeKiroUsage,
+  type KiroUsage,
+  resetKiroUsage,
+} from "./token-usage.js";
 import { countTokens } from "./tokenizer.js";
 import {
   buildHistory,
@@ -236,20 +243,29 @@ export function streamKiro(
     .AssistantMessageEventStream;
   const stream = new StreamCtor();
   (async () => {
+    // Held as `KiroUsage` (pi's `Usage` plus Kiro-only figures) so the
+    // Kiro-specific fields are compiler-checked instead of being written
+    // through a cast. `output.usage` is the same object.
+    //
+    // cacheRead/cacheWrite start at 0 because pi's `Usage` requires numbers,
+    // but that 0 is a placeholder, not a measurement: until a turn reports
+    // cache counts, `usage.provenance.cache` stays absent so consumers can
+    // tell "no cache hits" apart from "the service never said".
+    const usage: KiroUsage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
     const output: AssistantMessage = {
       role: "assistant",
       content: [],
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage,
       stopReason: "stop",
       timestamp: Date.now(),
     };
@@ -775,6 +791,9 @@ export function streamKiro(
         let totalContent = "";
         let lastContentData = "";
         let usageEvent: KiroUsageData | null = null;
+        // `usage` outlives this loop; clear whatever a previous attempt reported
+        // so a failed attempt's counts cannot survive into this one.
+        resetKiroUsage(usage);
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -899,9 +918,10 @@ export function streamKiro(
           if (debugEnabled()) debugLog("stream.events", [event]);
           switch (event.type) {
             case "contextUsage": {
-              const pct = event.data.contextUsagePercentage;
-              output.usage.input = Math.round((pct / 100) * model.contextWindow);
-              (output.usage as unknown as Record<string, unknown>).contextPercent = pct;
+              // Provisional only: this arrives long before metadataEvent, so it
+              // keeps live context% moving mid-turn. The input count it derives
+              // is superseded by the measured one in finalizeKiroUsage().
+              applyContextUsage(usage, event.data.contextUsagePercentage, model.contextWindow);
               receivedContextUsage = true;
               break;
             }
@@ -973,8 +993,10 @@ export function streamKiro(
               break;
             }
             case "metering": {
-              // MeteringEvent.usage counts credits, not tokens. Recorded for
-              // observability only; never folded into token accounting.
+              // MeteringEvent.usage counts credits, not tokens. Recorded as its
+              // own field so the actual billing unit is observable; never folded
+              // into token accounting or into Usage.cost.
+              applyMeteringCredits(usage, event.data.credits, event.data.unitPlural ?? event.data.unit);
               if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
@@ -1075,33 +1097,28 @@ export function streamKiro(
             content: (output.content[textBlockIndex] as TextContent).text,
             partial: output,
           });
-        // The Kiro streaming API does not reliably emit per-response output
-        // token counts (unlike Anthropic's `output_tokens` or Bedrock's
-        // `usage.outputTokens`). When the `usage` event is missing or only
-        // reports `inputTokens`, fall back to a tiktoken estimate over
-        // everything the assistant emitted — text plus tool-call input JSON
-        // (accumulated into `totalContent` above). Otherwise tool-call-only
-        // turns report 0 output tokens and break consumers like the TPS
-        // extension that watch `usage.output`.
+        // Fold in whatever `metadataEvent.tokenUsage` reported.
         //
         // `KiroUsageData.inputTokens` is `TokenUsage.uncachedInputTokens` — the
         // input billed at full rate, NOT total input. pi's `usage.input` is the
         // same uncached slot, with `cacheRead`/`cacheWrite` as siblings, and
-        // `calculateCost` prices all three separately. So the cache counts must
-        // land whenever `input` is taken from the wire; otherwise a cached turn
+        // `calculateCost` prices all three separately, so the cache counts must
+        // land whenever `input` comes from the wire; otherwise a cached turn
         // reports a fraction of its real input and is priced far too low.
-        if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
-        if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
-        if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
-        output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
+        //
         // `TokenUsage.totalTokens` is required on the wire while the cache counts
-        // are optional, so the service's own total is the authoritative figure —
-        // recomputing from components silently under-reports whenever a component
-        // is omitted. Prefer it and fall back to the sum, matching how pi's
-        // bedrock adapter treats the one other wire that supplies a total.
-        output.usage.totalTokens =
-          usageEvent?.totalTokens ??
-          output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
+        // are optional, so the service's own total is authoritative — recomputing
+        // from components under-reports whenever one is omitted.
+        //
+        // finalizeKiroUsage() owns all of that, plus the measured > derived >
+        // estimated precedence and the slot normalization that keeps
+        // input/cacheRead/cacheWrite disjoint. The tiktoken estimate over
+        // everything the assistant emitted (text plus tool-call input JSON,
+        // accumulated into `totalContent`) fills only the figures the wire
+        // omitted: Kiro does not reliably send `outputTokens`, and a
+        // tool-call-only turn reporting 0 output breaks consumers that watch
+        // `usage.output`, such as the TPS extension.
+        finalizeKiroUsage(usage, usageEvent, () => countTokens(totalContent));
         try {
           PiAi.calculateCost(model, output.usage);
         } catch {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1086,7 +1086,13 @@ export function streamKiro(
         if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
         if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
+        // `TokenUsage.totalTokens` is required on the wire while the cache counts
+        // are optional, so the service's own total is the authoritative figure —
+        // recomputing from components silently under-reports whenever a component
+        // is omitted. Prefer it and fall back to the sum, matching how pi's
+        // bedrock adapter treats the one other wire that supplies a total.
         output.usage.totalTokens =
+          usageEvent?.totalTokens ??
           output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,7 +28,7 @@ import {
   type KiroAdditionalModelRequestFields,
 } from "./effort.js";
 import { getKiroEndpoints, getKiroRegionFromEndpoint } from "./endpoints.js";
-import { parseKiroEvent } from "./event-parser.js";
+import { type KiroUsageData, parseKiroEvent } from "./event-parser.js";
 import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
@@ -774,7 +774,7 @@ export function streamKiro(
         const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
         let totalContent = "";
         let lastContentData = "";
-        let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
+        let usageEvent: KiroUsageData | null = null;
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -884,9 +884,18 @@ export function streamKiro(
           const { done, value } = iterResult;
           if (done) break;
           resetIdle();
-          const eventPayload = Object.values(value as Record<string, unknown>)[0] as Record<string, unknown>;
-          const event = parseKiroEvent(eventPayload);
+          // The marshaller keys each frame by its modeled `ChatResponseStream`
+          // union member (from the `:event-type` header). Route on that key
+          // instead of guessing the member from which fields are populated.
+          const frameEntry = Object.entries(value as Record<string, unknown>)[0];
+          if (!frameEntry) continue;
+          const [frameKey, framePayload] = frameEntry;
+          const event = parseKiroEvent(frameKey, (framePayload ?? {}) as Record<string, unknown>);
           if (!event) continue;
+          if (event.type === "ignored") {
+            if (debugEnabled()) debugLog("stream.events.ignored", [event.data.key]);
+            continue;
+          }
           if (debugEnabled()) debugLog("stream.events", [event]);
           switch (event.type) {
             case "contextUsage": {
@@ -957,6 +966,12 @@ export function streamKiro(
             }
             case "usage": {
               usageEvent = event.data;
+              break;
+            }
+            case "metering": {
+              // MeteringEvent.usage counts credits, not tokens. Recorded for
+              // observability only; never folded into token accounting.
+              if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
             case "error": {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -965,7 +965,11 @@ export function streamKiro(
               break;
             }
             case "usage": {
-              usageEvent = event.data;
+              // Every MetadataEvent field is optional, so the service may split
+              // tokenUsage and stopReason/stopDetails across frames. Merge so a
+              // later partial frame cannot erase counts already received.
+              const prev: KiroUsageData = usageEvent ?? {};
+              usageEvent = { ...prev, ...event.data };
               break;
             }
             case "metering": {
@@ -1071,9 +1075,19 @@ export function streamKiro(
         // (accumulated into `totalContent` above). Otherwise tool-call-only
         // turns report 0 output tokens and break consumers like the TPS
         // extension that watch `usage.output`.
+        //
+        // `KiroUsageData.inputTokens` is `TokenUsage.uncachedInputTokens` — the
+        // input billed at full rate, NOT total input. pi's `usage.input` is the
+        // same uncached slot, with `cacheRead`/`cacheWrite` as siblings, and
+        // `calculateCost` prices all three separately. So the cache counts must
+        // land whenever `input` is taken from the wire; otherwise a cached turn
+        // reports a fraction of its real input and is priced far too low.
         if (usageEvent?.inputTokens !== undefined) output.usage.input = usageEvent.inputTokens;
+        if (usageEvent?.cacheReadInputTokens !== undefined) output.usage.cacheRead = usageEvent.cacheReadInputTokens;
+        if (usageEvent?.cacheWriteInputTokens !== undefined) output.usage.cacheWrite = usageEvent.cacheWriteInputTokens;
         output.usage.output = usageEvent?.outputTokens ?? countTokens(totalContent);
-        output.usage.totalTokens = output.usage.input + output.usage.output;
+        output.usage.totalTokens =
+          output.usage.input + output.usage.cacheRead + output.usage.cacheWrite + output.usage.output;
         try {
           PiAi.calculateCost(model, output.usage);
         } catch {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -995,8 +995,9 @@ export function streamKiro(
             case "metering": {
               // MeteringEvent.usage counts credits, not tokens. Recorded as its
               // own field so the actual billing unit is observable; never folded
-              // into token accounting or into Usage.cost.
-              applyMeteringCredits(usage, event.data.credits, event.data.unitPlural ?? event.data.unit);
+              // into token accounting or into Usage.cost. Both grammatical forms
+              // are passed through so the count picks the right one.
+              applyMeteringCredits(usage, event.data.credits, event.data.unit, event.data.unitPlural);
               if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -76,13 +76,22 @@ export type KiroUsage = Usage & {
 const isCount = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v) && v >= 0;
 
 /**
- * Clear everything a single stream attempt wrote, keeping `cost` intact.
+ * Clear everything a single stream attempt wrote, `cost` included.
  *
  * The `usage` object outlives the retry loop, but each attempt re-reports its
  * own counts. Without this reset a failed attempt's cache counts, credits,
  * `normalizedTokenUsage` and provenance would survive into a successful retry
  * that reported none of them — and stale cache legs would then be added into
  * the retry's recomputed `totalTokens`.
+ *
+ * `cost` is reset with them, because it is derived wholly from the counts being
+ * cleared and would otherwise be the one figure left unbacked by any of them.
+ * A successful attempt recomputes it via `PiAi.calculateCost`, so this only
+ * changes what a FAILED turn reports — and there it is the whole point. The
+ * empty-response/echo-loop retry runs after the turn has already been
+ * finalized and priced, so a degenerate-but-priced attempt followed by a
+ * terminal stream error would otherwise emit an error message carrying the
+ * abandoned attempt's charge against zeroed token counts.
  */
 export function resetKiroUsage(usage: KiroUsage): void {
   usage.input = 0;
@@ -90,6 +99,7 @@ export function resetKiroUsage(usage: KiroUsage): void {
   usage.cacheRead = 0;
   usage.cacheWrite = 0;
   usage.totalTokens = 0;
+  usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
   delete usage.contextPercent;
   delete usage.normalizedTokenUsage;
   delete usage.credits;

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -1,0 +1,201 @@
+// ABOUTME: Maps Kiro's modeled MetadataEvent.tokenUsage onto pi's Usage shape.
+// ABOUTME: Measured wire counts win over derived/estimated ones; provenance is recorded.
+
+import type { Usage } from "@earendil-works/pi-ai";
+
+/**
+ * Token accounting as it arrives on the wire, from `MetadataEvent.tokenUsage`.
+ *
+ * Source of truth: the generated Smithy client for the same service
+ * (`@amzn/kiro-runtime-service-typescript-client`, `TokenUsage`). Field names
+ * are the wire names. Every field is optional here because a given turn may
+ * omit any of them, and an absent count must stay distinguishable from zero.
+ *
+ * `inputTokens` deliberately mirrors the wire's `uncachedInputTokens`: it is
+ * the input billed at full rate, NOT the total prompt size. Total prompt size
+ * is `inputTokens + cacheReadInputTokens + cacheWriteInputTokens`, which is
+ * exactly how pi's `Usage` splits the same quantity.
+ */
+export type KiroWireTokenUsage = {
+  /** `TokenUsage.uncachedInputTokens` — input billed at full rate. */
+  inputTokens?: number;
+  outputTokens?: number;
+  /** `TokenUsage.totalTokens` — authoritative; preferred over recomputation. */
+  totalTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  /** `(totalTokens / maxContextWindowTokens) * 100`, as computed by the service. */
+  contextUsagePercentage?: number;
+  /** `TokenUsage.normalizedTokenUsage` — the MPS credit basis, not a token count. */
+  normalizedTokenUsage?: number;
+};
+
+/** Where a usage figure came from. Consumed by diagnostics; never billing. */
+export type KiroUsageSource = "measured" | "derived" | "estimated";
+
+/**
+ * Provenance for the figures pi cannot self-describe.
+ *
+ * `cache` is absent (not `"measured"`) when the turn reported no cache fields
+ * at all, so a genuine 0% cache hit stays distinguishable from "the provider
+ * never told us". Consumers must render the absent case as unknown rather than
+ * as a measured zero.
+ */
+export type KiroUsageProvenance = {
+  input?: KiroUsageSource;
+  output?: KiroUsageSource;
+  totalTokens?: KiroUsageSource;
+  cache?: KiroUsageSource;
+};
+
+/**
+ * pi's `Usage` plus the Kiro-specific figures it has no slot for.
+ *
+ * These were previously written through an `as unknown as Record<string,
+ * unknown>` cast, which let typos through silently. They are declared here so
+ * the compiler checks them.
+ */
+export type KiroUsage = Usage & {
+  /** Service-reported context consumption, 0-100. Verbatim, never derived. */
+  contextPercent?: number;
+  /** `TokenUsage.normalizedTokenUsage` — MPS credit basis. */
+  normalizedTokenUsage?: number;
+  /** `MeteringEvent.usage` — a count of CREDITS, never tokens. */
+  credits?: number;
+  /** Display unit for {@link credits}, e.g. "credit"/"credits". */
+  creditUnit?: string;
+  provenance?: KiroUsageProvenance;
+};
+
+const isCount = (v: unknown): v is number => typeof v === "number" && Number.isFinite(v) && v >= 0;
+
+/**
+ * Clear everything a single stream attempt wrote, keeping `cost` intact.
+ *
+ * The `usage` object outlives the retry loop, but each attempt re-reports its
+ * own counts. Without this reset a failed attempt's cache counts, credits,
+ * `normalizedTokenUsage` and provenance would survive into a successful retry
+ * that reported none of them — and stale cache legs would then be added into
+ * the retry's recomputed `totalTokens`.
+ */
+export function resetKiroUsage(usage: KiroUsage): void {
+  usage.input = 0;
+  usage.output = 0;
+  usage.cacheRead = 0;
+  usage.cacheWrite = 0;
+  usage.totalTokens = 0;
+  delete usage.contextPercent;
+  delete usage.normalizedTokenUsage;
+  delete usage.credits;
+  delete usage.creditUnit;
+  delete usage.provenance;
+}
+
+/**
+ * Record the service's context consumption and a provisional input estimate.
+ *
+ * `contextUsageEvent` arrives mid-stream, well before `metadataEvent`, so this
+ * keeps live context% updating during a turn. The input figure it derives is
+ * back-computed from a percentage and is therefore coarse; it is marked
+ * `"derived"` so {@link finalizeKiroUsage} can overwrite it with the measured
+ * count once metadata lands. `contextPercent` itself is always the service's
+ * own number and is never re-derived from tokens.
+ */
+export function applyContextUsage(usage: KiroUsage, contextUsagePercentage: number, contextWindow: number): void {
+  if (!isCount(contextUsagePercentage)) return;
+  usage.contextPercent = contextUsagePercentage;
+  if (!isCount(contextWindow) || contextWindow === 0) return;
+  usage.input = Math.round((contextUsagePercentage / 100) * contextWindow);
+  usage.provenance = { ...usage.provenance, input: "derived" };
+}
+
+/**
+ * Record `MeteringEvent` credits.
+ *
+ * These are the units the account is actually billed in. They are not tokens
+ * and must never be folded into token counts or into `Usage.cost`.
+ */
+export function applyMeteringCredits(usage: KiroUsage, credits?: number, unit?: string): void {
+  if (isCount(credits)) usage.credits = credits;
+  if (typeof unit === "string" && unit.length > 0) usage.creditUnit = unit;
+}
+
+/**
+ * Fold the modeled token counts into `usage`, then fill remaining gaps.
+ *
+ * Precedence, highest first:
+ *   1. measured  — a count the service reported in `metadataEvent.tokenUsage`
+ *   2. derived   — back-computed from `contextUsagePercentage` (input only)
+ *   3. estimated — tiktoken over what the assistant emitted (output only)
+ *
+ * A measured count always overwrites a derived or estimated one; the reverse
+ * never happens. `estimateOutput` is invoked only when the wire omitted
+ * `outputTokens`, so an estimate can never displace a real measurement.
+ *
+ * Kiro does not reliably emit `outputTokens` on every turn, and a tool-call-only
+ * turn that reported 0 output would break consumers that watch `usage.output`
+ * (the TPS extension, for one) — hence the estimate fallback rather than a zero.
+ */
+export function finalizeKiroUsage(
+  usage: KiroUsage,
+  wire: KiroWireTokenUsage | null | undefined,
+  estimateOutput: () => number,
+): void {
+  const provenance: KiroUsageProvenance = { ...usage.provenance };
+
+  if (isCount(wire?.inputTokens)) {
+    usage.input = wire.inputTokens;
+    provenance.input = "measured";
+  }
+
+  if (isCount(wire?.outputTokens)) {
+    usage.output = wire.outputTokens;
+    provenance.output = "measured";
+  } else {
+    usage.output = estimateOutput();
+    provenance.output = "estimated";
+  }
+
+  // Slot invariant: pi's `input`, `cacheRead` and `cacheWrite` are mutually
+  // exclusive slices of ONE prompt, and `calculateCost` prices each separately.
+  // The wire's `uncachedInputTokens` is exactly the `input` slice, so a measured
+  // input and the cache counts compose correctly. A
+  // `contextUsagePercentage`-derived input does NOT: it spans the whole prompt,
+  // cached portion included. Leaving that in `input` while also reporting cache
+  // counts double-counts the cached tokens — in the total AND in the cost.
+  //
+  // So normalize the slots here rather than special-casing the sum below:
+  // subtract the known cache legs out of a derived input. Then the four slots
+  // never overlap and the total is one unconditional sum in every case.
+  const cacheRead = wire?.cacheReadInputTokens;
+  const cacheWrite = wire?.cacheWriteInputTokens;
+  if (isCount(cacheRead) || isCount(cacheWrite)) {
+    usage.cacheRead = isCount(cacheRead) ? cacheRead : 0;
+    usage.cacheWrite = isCount(cacheWrite) ? cacheWrite : 0;
+    provenance.cache = "measured";
+    if (provenance.input === "derived") {
+      // Floored at 0: the derived figure is a rounded back-computation, so it can
+      // legitimately land under the measured cache legs.
+      usage.input = Math.max(0, usage.input - usage.cacheRead - usage.cacheWrite);
+    }
+  }
+
+  if (isCount(wire?.contextUsagePercentage)) usage.contextPercent = wire.contextUsagePercentage;
+  if (isCount(wire?.normalizedTokenUsage)) usage.normalizedTokenUsage = wire.normalizedTokenUsage;
+
+  if (isCount(wire?.totalTokens)) {
+    // `TokenUsage.totalTokens` is required on the wire while the cache counts are
+    // optional, so the service's own total is authoritative — recomputing from
+    // components under-reports whenever one is omitted. `calculateContextTokens`
+    // reads `totalTokens` first, so this figure drives pi's context gauge.
+    usage.totalTokens = wire.totalTokens;
+    provenance.totalTokens = "measured";
+  } else {
+    // Safe unconditionally: the slots were normalized above to be disjoint.
+    usage.totalTokens = usage.input + usage.cacheRead + usage.cacheWrite + usage.output;
+    provenance.totalTokens =
+      provenance.input === "measured" && provenance.output === "measured" ? "derived" : "estimated";
+  }
+
+  usage.provenance = provenance;
+}

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -109,15 +109,25 @@ export function applyContextUsage(usage: KiroUsage, contextUsagePercentage: numb
   usage.provenance = { ...usage.provenance, input: "derived" };
 }
 
+const nonEmpty = (v: unknown): string | undefined => (typeof v === "string" && v.length > 0 ? v : undefined);
+
 /**
  * Record `MeteringEvent` credits.
  *
  * These are the units the account is actually billed in. They are not tokens
  * and must never be folded into token counts or into `Usage.cost`.
+ *
+ * `MeteringEvent` supplies both grammatical forms (`unit`/`unitPlural`), so the
+ * one that agrees with the count is selected here rather than at the call site:
+ * storing `unitPlural` unconditionally renders "1 credits". Zero takes the
+ * plural, as English does. Either form alone is used as-is.
  */
-export function applyMeteringCredits(usage: KiroUsage, credits?: number, unit?: string): void {
+export function applyMeteringCredits(usage: KiroUsage, credits?: number, unit?: string, unitPlural?: string): void {
   if (isCount(credits)) usage.credits = credits;
-  if (typeof unit === "string" && unit.length > 0) usage.creditUnit = unit;
+  const singular = nonEmpty(unit);
+  const plural = nonEmpty(unitPlural);
+  const preferred = credits === 1 ? (singular ?? plural) : (plural ?? singular);
+  if (preferred !== undefined) usage.creditUnit = preferred;
 }
 
 /**

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -100,6 +100,15 @@ export function resetKiroUsage(usage: KiroUsage): void {
  * `"derived"` so {@link finalizeKiroUsage} can overwrite it with the measured
  * count once metadata lands. `contextPercent` itself is always the service's
  * own number and is never re-derived from tokens.
+ *
+ * Note what the percentage actually measures: the service computes it as
+ * `(totalTokens / maxContextWindowTokens) * 100`, and `totalTokens` spans the
+ * WHOLE turn — uncached input, cache reads/writes AND output. So this figure is
+ * an approximation of `totalTokens`, not of the `input` slot it is parked in.
+ * That is tolerable only because it is provisional: a measured
+ * `uncachedInputTokens` replaces it, and a measured `totalTokens` replaces any
+ * total recomputed from it. See {@link finalizeKiroUsage} for what remains
+ * imprecise when the wire omits both.
  */
 export function applyContextUsage(usage: KiroUsage, contextUsagePercentage: number, contextWindow: number): void {
   if (!isCount(contextUsagePercentage)) return;
@@ -121,12 +130,17 @@ const nonEmpty = (v: unknown): string | undefined => (typeof v === "string" && v
  * one that agrees with the count is selected here rather than at the call site:
  * storing `unitPlural` unconditionally renders "1 credits". Zero takes the
  * plural, as English does. Either form alone is used as-is.
+ *
+ * Agreement is decided against the count now held on `usage`, not against this
+ * call's `credits` argument. Every `MetadataEvent`/`MeteringEvent` field is
+ * optional, so a later frame can carry the unit strings while omitting `usage`;
+ * reading the argument would then re-pluralize an already-recorded count of 1.
  */
 export function applyMeteringCredits(usage: KiroUsage, credits?: number, unit?: string, unitPlural?: string): void {
   if (isCount(credits)) usage.credits = credits;
   const singular = nonEmpty(unit);
   const plural = nonEmpty(unitPlural);
-  const preferred = credits === 1 ? (singular ?? plural) : (plural ?? singular);
+  const preferred = usage.credits === 1 ? (singular ?? plural) : (plural ?? singular);
   if (preferred !== undefined) usage.creditUnit = preferred;
 }
 
@@ -190,6 +204,19 @@ export function finalizeKiroUsage(
     }
   }
 
+  // What the subtraction above does and does not achieve: it stops the cached
+  // tokens being priced twice (once inside the derived `input`, once on
+  // `calculateCost`'s separate `cacheRead` line), which is the part that costs
+  // money. It does NOT make a derived `input` a true prompt-only figure — the
+  // percentage it came from spans the output tokens as well, and those cannot be
+  // subtracted out because the only output count available here may itself be an
+  // estimate. Consequence, confined to the recomputed-total branch below: when
+  // the input is derived AND the wire omitted `totalTokens`, the total
+  // over-reports by roughly the output count. Both conditions together are rare
+  // — `TokenUsage.totalTokens` is a required field, so any conforming
+  // `metadataEvent` supplies the authoritative total and this branch is skipped.
+  // The total is marked `"estimated"` in exactly that case.
+
   if (isCount(wire?.contextUsagePercentage)) usage.contextPercent = wire.contextUsagePercentage;
   if (isCount(wire?.normalizedTokenUsage)) usage.normalizedTokenUsage = wire.normalizedTokenUsage;
 
@@ -201,7 +228,10 @@ export function finalizeKiroUsage(
     usage.totalTokens = wire.totalTokens;
     provenance.totalTokens = "measured";
   } else {
-    // Safe unconditionally: the slots were normalized above to be disjoint.
+    // No authoritative total. Sum the four slots, which the normalization above
+    // made non-overlapping for cost purposes. Accurate when the input was
+    // measured; over-reports by roughly the output count when it was derived,
+    // per the note above — hence the provenance below.
     usage.totalTokens = usage.input + usage.cacheRead + usage.cacheWrite + usage.output;
     provenance.totalTokens =
       provenance.input === "measured" && provenance.output === "measured" ? "derived" : "estimated";

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -64,6 +64,12 @@ export type KiroUsage = Usage & {
   credits?: number;
   /** Display unit for {@link credits}, e.g. "credit"/"credits". */
   creditUnit?: string;
+  /**
+   * Both grammatical forms `MeteringEvent` supplied, retained so {@link
+   * creditUnit} can be re-decided when a later frame revises the count.
+   * Diagnostics should read {@link creditUnit}, not this.
+   */
+  creditUnitForms?: { singular?: string; plural?: string };
   provenance?: KiroUsageProvenance;
 };
 
@@ -88,6 +94,7 @@ export function resetKiroUsage(usage: KiroUsage): void {
   delete usage.normalizedTokenUsage;
   delete usage.credits;
   delete usage.creditUnit;
+  delete usage.creditUnitForms;
   delete usage.provenance;
 }
 
@@ -131,15 +138,30 @@ const nonEmpty = (v: unknown): string | undefined => (typeof v === "string" && v
  * storing `unitPlural` unconditionally renders "1 credits". Zero takes the
  * plural, as English does. Either form alone is used as-is.
  *
- * Agreement is decided against the count now held on `usage`, not against this
- * call's `credits` argument. Every `MetadataEvent`/`MeteringEvent` field is
- * optional, so a later frame can carry the unit strings while omitting `usage`;
- * reading the argument would then re-pluralize an already-recorded count of 1.
+ * Every `MeteringEvent` field is optional (see the generated `MeteringEvent`:
+ * `usage`, `unit` and `unitPlural` are all optional), so the count and the unit
+ * strings can arrive in either order, in separate frames:
+ *
+ *   - units then count — the units frame has no count to agree with, so its
+ *     choice is provisional and must be revisited once the count lands.
+ *   - count then units — the units frame carries no count, so agreement must be
+ *     decided against the count already recorded, not this call's argument.
+ *
+ * Both are handled by keeping the forms themselves on `usage` and re-deciding
+ * agreement from scratch on every frame. Deciding once per frame from only that
+ * frame's fields renders "1 credits" in whichever order is not special-cased.
  */
 export function applyMeteringCredits(usage: KiroUsage, credits?: number, unit?: string, unitPlural?: string): void {
   if (isCount(credits)) usage.credits = credits;
-  const singular = nonEmpty(unit);
-  const plural = nonEmpty(unitPlural);
+
+  const singular = nonEmpty(unit) ?? usage.creditUnitForms?.singular;
+  const plural = nonEmpty(unitPlural) ?? usage.creditUnitForms?.plural;
+  if (singular === undefined && plural === undefined) return;
+  usage.creditUnitForms = { ...(singular !== undefined && { singular }), ...(plural !== undefined && { plural }) };
+
+  // Re-decided against the count now held on `usage`, so a count arriving in a
+  // later frame corrects a provisionally-plural unit. An unknown count takes the
+  // plural, matching the zero case.
   const preferred = usage.credits === 1 ? (singular ?? plural) : (plural ?? singular);
   if (preferred !== undefined) usage.creditUnit = preferred;
 }

--- a/test/event-parser.test.ts
+++ b/test/event-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
-import { parseKiroEvent } from "../src/event-parser.js";
+import { parseKiroEvent, parseKiroEventByShape } from "../src/event-parser.js";
 
 describe("Feature 8: Stream Event Parsing", () => {
   describe("findJsonEnd", () => {
@@ -25,78 +25,214 @@ describe("Feature 8: Stream Event Parsing", () => {
     });
   });
 
-  describe("parseKiroEvent", () => {
-    it("parses content event", () => {
-      expect(parseKiroEvent({ content: "Hello " })).toEqual({ type: "content", data: "Hello " });
+  describe("parseKiroEvent — modeled key routing", () => {
+    it("routes assistantResponseEvent to content", () => {
+      expect(parseKiroEvent("assistantResponseEvent", { content: "Hello " })).toEqual({
+        type: "content",
+        data: "Hello ",
+      });
     });
 
-    it("parses summarized thinking text", () => {
-      expect(parseKiroEvent({ text: "Considering options" })).toEqual({
+    it("routes reasoningContentEvent text to thinkingText", () => {
+      expect(parseKiroEvent("reasoningContentEvent", { text: "Considering options" })).toEqual({
         type: "thinkingText",
         data: "Considering options",
       });
     });
 
-    it("parses summarized thinking signature", () => {
-      expect(parseKiroEvent({ signature: "opaque-signature" })).toEqual({
+    it("routes reasoningContentEvent signature to thinkingSignature", () => {
+      expect(parseKiroEvent("reasoningContentEvent", { signature: "opaque-signature" })).toEqual({
         type: "thinkingSignature",
         data: "opaque-signature",
       });
     });
 
-    it("parses toolUse event", () => {
-      const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: '{"cmd":"ls"}' });
+    it("ignores a reasoningContentEvent carrying only redactedContent", () => {
+      expect(parseKiroEvent("reasoningContentEvent", { redactedContent: "encrypted" })).toEqual({
+        type: "ignored",
+        data: { key: "reasoningContentEvent" },
+      });
+    });
+
+    it("routes toolUseEvent with name+toolUseId to toolUse", () => {
+      const e = parseKiroEvent("toolUseEvent", { name: "bash", toolUseId: "tc1", input: '{"cmd":"ls"}' });
       expect(e?.type).toBe("toolUse");
       expect(e?.type === "toolUse" && e.data.name).toBe("bash");
     });
 
-    it("parses toolUse with stop", () => {
-      const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: "", stop: true });
-      expect(e?.type === "toolUse" && e.data.stop).toBe(true);
+    it("routes toolUseEvent continuation frames to toolUseInput", () => {
+      expect(parseKiroEvent("toolUseEvent", { input: '"ls"}' })).toEqual({
+        type: "toolUseInput",
+        data: { input: '"ls"}' },
+      });
     });
 
-    it("parses toolUseInput", () => {
-      expect(parseKiroEvent({ input: '"ls"}' })).toEqual({ type: "toolUseInput", data: { input: '"ls"}' } });
+    it("routes toolUseEvent stop frame to toolUseStop", () => {
+      expect(parseKiroEvent("toolUseEvent", { stop: true })).toEqual({ type: "toolUseStop", data: { stop: true } });
     });
 
-    it("parses toolUseStop", () => {
-      expect(parseKiroEvent({ stop: true })).toEqual({ type: "toolUseStop", data: { stop: true } });
-    });
-
-    it("parses contextUsage", () => {
-      expect(parseKiroEvent({ contextUsagePercentage: 42.5 })).toEqual({
+    it("routes contextUsageEvent to contextUsage", () => {
+      expect(parseKiroEvent("contextUsageEvent", { contextUsagePercentage: 42.5 })).toEqual({
         type: "contextUsage",
         data: { contextUsagePercentage: 42.5 },
       });
     });
 
-    it("parses followupPrompt event", () => {
-      const e = parseKiroEvent({ followupPrompt: "What would you like to do next?" });
-      expect(e).toEqual({ type: "followupPrompt", data: "What would you like to do next?" });
-    });
-
-    it("parses usage event", () => {
-      const e = parseKiroEvent({ usage: { inputTokens: 100, outputTokens: 50 } });
-      expect(e?.type).toBe("usage");
-      expect(e?.type === "usage" && e.data.inputTokens).toBe(100);
-      expect(e?.type === "usage" && e.data.outputTokens).toBe(50);
-    });
-
-    it("returns null for unrecognized shape", () => {
-      expect(parseKiroEvent({ unknown: true })).toBeNull();
-    });
-
     it("treats empty object input as empty string for toolUse placeholder", () => {
-      const e = parseKiroEvent({ name: "write", toolUseId: "tc1", input: {} });
+      const e = parseKiroEvent("toolUseEvent", { name: "write", toolUseId: "tc1", input: {} });
       expect(e?.type).toBe("toolUse");
       // Empty object placeholder must become "" so toolUseInput concatenation works
       expect(e?.type === "toolUse" && e.data.input).toBe("");
     });
 
     it("preserves non-empty object input as JSON string", () => {
-      const e = parseKiroEvent({ name: "bash", toolUseId: "tc1", input: { cmd: "ls" } });
+      const e = parseKiroEvent("toolUseEvent", { name: "bash", toolUseId: "tc1", input: { cmd: "ls" } });
       expect(e?.type).toBe("toolUse");
       expect(e?.type === "toolUse" && e.data.input).toBe('{"cmd":"ls"}');
+    });
+
+    it("explicitly ignores known members with no consumer", () => {
+      for (const key of ["codeReferenceEvent", "documentCitationEvent", "toolResultEvent"]) {
+        expect(parseKiroEvent(key, {})).toEqual({ type: "ignored", data: { key } });
+      }
+    });
+
+    it("returns null for an unrecognized key with an unrecognized payload", () => {
+      expect(parseKiroEvent("brandNewEvent", { unknown: true })).toBeNull();
+    });
+  });
+
+  describe("parseKiroEvent — metadataEvent token usage", () => {
+    // MetadataEvent = {tokenUsage?, stopReason?, stopDetails?}; TokenUsage =
+    // {uncachedInputTokens, outputTokens, totalTokens, cacheRead..., cacheWrite...,
+    // contextUsagePercentage?}. Previously no branch matched this shape at all.
+    it("produces a usage event from a modeled metadataEvent frame", () => {
+      const e = parseKiroEvent("metadataEvent", {
+        tokenUsage: {
+          uncachedInputTokens: 500,
+          outputTokens: 200,
+          totalTokens: 700,
+          cacheReadInputTokens: 120,
+          cacheWriteInputTokens: 30,
+          contextUsagePercentage: 12.5,
+        },
+        stopReason: "END_TURN",
+      });
+      expect(e).toEqual({
+        type: "usage",
+        data: {
+          inputTokens: 500,
+          outputTokens: 200,
+          totalTokens: 700,
+          cacheReadInputTokens: 120,
+          cacheWriteInputTokens: 30,
+          contextUsagePercentage: 12.5,
+          rawStopReason: "END_TURN",
+        },
+      });
+    });
+
+    it("omits absent token fields rather than emitting undefined", () => {
+      const e = parseKiroEvent("metadataEvent", { stopReason: "MAX_TOKENS" });
+      expect(e).toEqual({ type: "usage", data: { rawStopReason: "MAX_TOKENS" } });
+      expect(e?.type === "usage" && Object.keys(e.data)).toEqual(["rawStopReason"]);
+    });
+
+    it("passes stopDetails through verbatim", () => {
+      const e = parseKiroEvent("metadataEvent", { stopDetails: { refusal: { reason: "POLICY" } } });
+      expect(e?.type === "usage" && e.data.stopDetails).toEqual({ refusal: { reason: "POLICY" } });
+    });
+
+    it("returns null for an empty metadataEvent", () => {
+      expect(parseKiroEvent("metadataEvent", {})).toBeNull();
+    });
+  });
+
+  describe("parseKiroEvent — meteringEvent is credits, not tokens", () => {
+    // MeteringEvent = {usage?: number; unit?: string; unitPlural?: string}.
+    it("surfaces meteringEvent as a credit count", () => {
+      expect(parseKiroEvent("meteringEvent", { usage: 3, unit: "credit", unitPlural: "credits" })).toEqual({
+        type: "metering",
+        data: { credits: 3, unit: "credit", unitPlural: "credits" },
+      });
+    });
+
+    it("never reads token fields off the numeric usage value", () => {
+      const e = parseKiroEvent("meteringEvent", { usage: 7 });
+      expect(e?.type).toBe("metering");
+      expect(e?.type === "usage").toBe(false);
+    });
+  });
+
+  describe("parseKiroEvent — error members keep their modeled class", () => {
+    it("classifies the error member as internalServer", () => {
+      expect(parseKiroEvent("error", { message: "boom" })).toEqual({
+        type: "error",
+        data: { error: "InternalServerException", message: "boom", kind: "internalServer" },
+      });
+    });
+
+    it("classifies throttlingError and preserves retryAfterMilliseconds", () => {
+      expect(
+        parseKiroEvent("throttlingError", {
+          message: "Too many requests",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        }),
+      ).toEqual({
+        type: "error",
+        data: {
+          error: "ThrottlingException",
+          message: "Too many requests",
+          kind: "throttling",
+          reason: "INSUFFICIENT_MODEL_CAPACITY",
+          retryAfterMilliseconds: 4500,
+        },
+      });
+    });
+
+    it("classifies validationError and serviceUnavailableError distinctly", () => {
+      expect(parseKiroEvent("validationError", { message: "bad input" })?.type === "error").toBe(true);
+      const v = parseKiroEvent("validationError", { message: "bad input" });
+      expect(v?.type === "error" && v.data.kind).toBe("validation");
+      const s = parseKiroEvent("serviceUnavailableError", { message: "down" });
+      expect(s?.type === "error" && s.data.kind).toBe("serviceUnavailable");
+    });
+
+    it("still accepts the legacy free-form error field", () => {
+      const e = parseKiroEvent("error", { error: "ThrottlingException", message: "slow down" });
+      expect(e).toEqual({
+        type: "error",
+        data: { error: "ThrottlingException", message: "slow down", kind: "internalServer" },
+      });
+    });
+  });
+
+  describe("parseKiroEventByShape — fail-open fallback", () => {
+    it("is used for unkeyed frames so unknown members degrade gracefully", () => {
+      expect(parseKiroEvent("$unknown", { content: "hi" })).toEqual({ type: "content", data: "hi" });
+    });
+
+    it("recognizes followupPrompt, which has no modeled union member", () => {
+      expect(parseKiroEventByShape({ followupPrompt: "What next?" })).toEqual({
+        type: "followupPrompt",
+        data: "What next?",
+      });
+    });
+
+    it("recognizes a metadata-shaped payload", () => {
+      expect(parseKiroEventByShape({ tokenUsage: { outputTokens: 12 } })).toEqual({
+        type: "usage",
+        data: { outputTokens: 12 },
+      });
+    });
+
+    it("treats a numeric usage as metering", () => {
+      expect(parseKiroEventByShape({ usage: 2 })).toEqual({ type: "metering", data: { credits: 2 } });
+    });
+
+    it("returns null for an unrecognized shape", () => {
+      expect(parseKiroEventByShape({ unknown: true })).toBeNull();
     });
   });
 });

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -1,14 +1,46 @@
 import { EventStreamCodec } from "@smithy/core/event-streams";
+import { isKiroEventKey, type KiroEventKey } from "../../src/event-parser.js";
 
 const codec = new EventStreamCodec(
   (input: Uint8Array) => new TextDecoder().decode(input),
   (input: string) => new TextEncoder().encode(input),
 );
 
-export function encodeEventMessage(payload: object): Uint8Array {
+/**
+ * Infer the `ChatResponseStream` union member a payload belongs to.
+ *
+ * Real frames carry the member name in the `:event-type` header; fixtures are
+ * written as bare payloads, so derive the key from the payload shape to keep
+ * the encoded frame faithful to the wire contract.
+ */
+export function inferEventKey(payload: Record<string, unknown>): KiroEventKey | "$unknown" {
+  if (payload.content !== undefined) return "assistantResponseEvent";
+  if (typeof payload.text === "string" || typeof payload.signature === "string") return "reasoningContentEvent";
+  if (payload.toolUseId !== undefined || payload.input !== undefined || payload.stop !== undefined)
+    return "toolUseEvent";
+  if (payload.contextUsagePercentage !== undefined) return "contextUsageEvent";
+  if (payload.tokenUsage !== undefined || payload.stopReason !== undefined || payload.stopDetails !== undefined)
+    return "metadataEvent";
+  if (typeof payload.usage === "number") return "meteringEvent";
+  if (payload.error !== undefined || payload.Error !== undefined) return "error";
+  return "$unknown";
+}
+
+/**
+ * Encode a payload as one binary event-stream frame.
+ *
+ * `eventType` defaults to the member inferred from the payload shape; pass it
+ * explicitly to exercise a specific union member (including error members,
+ * which share field names with each other).
+ */
+export function encodeEventMessage(payload: object, eventType?: KiroEventKey | "$unknown"): Uint8Array {
+  const key = eventType ?? inferEventKey(payload as Record<string, unknown>);
+  if (key !== "$unknown" && !isKiroEventKey(key)) {
+    throw new Error(`Not a ChatResponseStream member: ${key}`);
+  }
   return codec.encode({
     headers: {
-      ":event-type": { type: "string", value: "assistantResponseEvent" },
+      ":event-type": { type: "string", value: key },
       ":message-type": { type: "string", value: "event" },
     },
     body: new TextEncoder().encode(JSON.stringify(payload)),

--- a/test/helpers/event-stream.ts
+++ b/test/helpers/event-stream.ts
@@ -16,9 +16,12 @@ const codec = new EventStreamCodec(
 export function inferEventKey(payload: Record<string, unknown>): KiroEventKey | "$unknown" {
   if (payload.content !== undefined) return "assistantResponseEvent";
   if (typeof payload.text === "string" || typeof payload.signature === "string") return "reasoningContentEvent";
+  // contextUsagePercentage is checked before the toolUse `stop` branch for the
+  // same reason parseKiroEventByShape guards it: a contextUsageEvent payload can
+  // also carry `stop`, and inferring toolUseEvent there would frame it wrongly.
+  if (payload.contextUsagePercentage !== undefined) return "contextUsageEvent";
   if (payload.toolUseId !== undefined || payload.input !== undefined || payload.stop !== undefined)
     return "toolUseEvent";
-  if (payload.contextUsagePercentage !== undefined) return "contextUsageEvent";
   if (payload.tokenUsage !== undefined || payload.stopReason !== undefined || payload.stopDetails !== undefined)
     return "metadataEvent";
   if (typeof payload.usage === "number") return "meteringEvent";

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2781,6 +2781,30 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("records the singular credit unit for a one-credit turn", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      // Both grammatical forms are on the wire; the count selects one. Passing
+      // only unitPlural through would render "1 credits".
+      '{"usage":1,"unit":"credit","unitPlural":"credits"}',
+      JSON.stringify({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5, totalTokens: 15 } }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.credits).toBe(1);
+    expect(usage.creditUnit).toBe("credit");
+
+    vi.unstubAllGlobals();
+  });
+
   it("leaves cache provenance absent when no metadataEvent arrives", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":10}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2693,6 +2693,100 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("surfaces a mid-stream throttlingError frame and retries", async () => {
+    // throttlingError / validationError / serviceUnavailableError are distinct
+    // ChatResponseStream members. Before key routing they matched no branch and
+    // were dropped, so the turn looked like an empty response. Now they abort
+    // the read and enter the retry path with the modeled class in the message.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({ content: "partial" }),
+                    encodeEventMessage(
+                      {
+                        message: "Too many requests",
+                        reason: "INSUFFICIENT_MODEL_CAPACITY",
+                        retryAfterMilliseconds: 10,
+                      },
+                      "throttlingError",
+                    ),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"recovered"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const done = events.find((e) => e.type === "done");
+    expect(done?.type === "done" && (done.message.content[0] as TextContent).text).toBe("recovered");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports the modeled exception class when a typed error frame outlives every retry", async () => {
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError"),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2617,6 +2617,57 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("records cacheRead/cacheWrite so a cached turn is not priced as uncached input", async () => {
+    // TokenUsage.uncachedInputTokens excludes cache reads. Taking `input` from
+    // it while leaving cacheRead at 0 would report ~200 input tokens for a turn
+    // that actually read 50k cached tokens, and price it accordingly.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+      '{"contextUsagePercentage":5}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(50000);
+    expect(msg.usage.cacheWrite).toBe(0);
+    // input + cacheRead + cacheWrite + output, matching the wire totalTokens.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
+    // Every MetadataEvent field is optional; tokenUsage and stopReason may
+    // arrive in separate frames.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
+      '{"stopReason":"END_TURN"}',
+      '{"contextUsagePercentage":10}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(500);
+    expect(msg.usage.output).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2787,6 +2787,103 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   }, 30000);
 
+  it("does not inherit the failed attempt's cache counts when retrying", async () => {
+    // `usageEvent` is declared inside the retry loop, and the cache writes are
+    // post-loop, so an aborted attempt must contribute nothing to billing.
+    // cacheRead is priced as its own line in calculateCost, so inheriting a
+    // prior attempt's value would over-bill a turn that never read that cache.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({
+                      tokenUsage: {
+                        uncachedInputTokens: 999,
+                        outputTokens: 111,
+                        totalTokens: 41110,
+                        cacheReadInputTokens: 40000,
+                        cacheWriteInputTokens: 7,
+                      },
+                    }),
+                    encodeEventMessage({ message: "throttled" }, "throttlingError"),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Retry succeeds and reports NO metadataEvent at all.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"clean"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    // The abandoned attempt's counts must not appear anywhere in billing.
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.cacheWrite).toBe(0);
+    expect(msg.usage.cost.cacheRead).toBe(0);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to summing components when a non-conforming frame omits totalTokens", async () => {
+    // TokenUsage.totalTokens is required on the wire, so this branch only guards
+    // a non-conforming server. The sum must match how the service itself defines
+    // the total: uncachedInput + cacheRead + cacheWrite + output.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    // Same components as the wire-total test above, which reports 50250.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2644,6 +2644,31 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps the wire totalTokens when the service omits an optional cache count", async () => {
+    // TokenUsage.totalTokens is required on the wire; cacheReadInputTokens and
+    // cacheWriteInputTokens are optional. Recomputing the total from components
+    // would report 250 for a turn the service says cost 50250 context tokens,
+    // and calculateContextTokens drives the context gauge from that total.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
     // Every MetadataEvent field is optional; tokenUsage and stopReason may
     // arrive in separate frames.

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2588,10 +2588,12 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers usage event values over tiktoken when available", async () => {
+  it("prefers metadataEvent token usage over tiktoken when available", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',
-      '{"usage":{"inputTokens":500,"outputTokens":200}}',
+      // MetadataEvent shape from ChatResponseStream: token counts live under
+      // tokenUsage.uncachedInputTokens/outputTokens, not a top-level `usage`.
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
       '{"contextUsagePercentage":10}',
     ]);
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
+import type { KiroUsage } from "../src/token-usage.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
 import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
 
@@ -2588,7 +2589,7 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers metadataEvent token usage over tiktoken when available", async () => {
+  it("prefers measured token counts over the tiktoken estimate", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',
       // MetadataEvent shape from ChatResponseStream: token counts live under
@@ -2604,15 +2605,199 @@ describe("Feature 9: Streaming Integration", () => {
     const msg = done?.type === "done" ? done.message : undefined;
     expect(msg).toBeDefined();
     if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
 
-    // Usage event values should take precedence
-    expect(msg.usage.input).toBe(500);
-    expect(msg.usage.output).toBe(200);
-    expect(msg.usage.totalTokens).toBe(700);
+    // Measured counts win over both the tiktoken estimate and the input figure
+    // back-computed from contextUsagePercentage.
+    expect(usage.input).toBe(500);
+    expect(usage.output).toBe(200);
+    expect(usage.totalTokens).toBe(700);
+    expect(usage.provenance?.input).toBe("measured");
+    expect(usage.provenance?.output).toBe("measured");
 
-    // contextPercent should still reflect the API's contextUsagePercentage,
-    // not be derived from the (overwritten) input token count
-    expect((msg.usage as unknown as Record<string, unknown>).contextPercent).toBe(10);
+    // contextPercent stays the API's own contextUsagePercentage — never
+    // re-derived from the (now overwritten) input count.
+    expect(usage.contextPercent).toBe(10);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports prompt-cache tokens from metadataEvent.tokenUsage", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      JSON.stringify({
+        tokenUsage: {
+          uncachedInputTokens: 1_200,
+          outputTokens: 340,
+          totalTokens: 9_540,
+          cacheReadInputTokens: 8_000,
+          cacheWriteInputTokens: 0,
+          normalizedTokenUsage: 12.5,
+        },
+      }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.provenance?.cache).toBe("measured");
+    // The wire's totalTokens is authoritative, not input+output.
+    expect(usage.totalTokens).toBe(9_540);
+    expect(usage.normalizedTokenUsage).toBe(12.5);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("merges token counts split across separate metadataEvent frames", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      // Every MetadataEvent field is optional, so the service may send tokenUsage
+      // and stopReason in separate frames. The second must not erase the first.
+      JSON.stringify({ tokenUsage: { uncachedInputTokens: 1_200, outputTokens: 340, cacheReadInputTokens: 8_000 } }),
+      JSON.stringify({ stopReason: "END_TURN" }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    // Without the merge, the stopReason-only frame clobbers these and output
+    // silently falls back to the tiktoken estimate.
+    expect(usage.input).toBe(1_200);
+    expect(usage.output).toBe(340);
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.provenance?.output).toBe("measured");
+    expect(usage.provenance?.cache).toBe("measured");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not carry a failed attempt's cache tokens into a successful retry", async () => {
+    // Attempt 1 is degenerate (no text, no tool calls) so it is retried, but it
+    // did report cache tokens and metering credits. Attempt 2 succeeds and
+    // reports neither — none of attempt 1's figures may survive into it.
+    //
+    // This is the empty-response retry path specifically, and it differs from the
+    // stream-error path in a way that matters: a throttle/validation error hits
+    // `if (streamError) break` and retries BEFORE the usage-finalizing block ever
+    // runs, so nothing was written to carry over. Here finalization runs first and
+    // calculateCost has already priced the turn, and only then is the retry
+    // decided — so the cache counts are already on the shared usage object when
+    // the next attempt starts. Priced with a non-zero-cost model so the assertion
+    // covers the money, not just the counts.
+    const emptyWithCache = concatMessages(
+      encodeEventMessage({ usage: 9, unit: "credit", unitPlural: "credits" }),
+      encodeEventMessage({
+        tokenUsage: { uncachedInputTokens: 1_200, outputTokens: 340, cacheReadInputTokens: 8_000 },
+      }),
+      encodeEventMessage({ contextUsagePercentage: 50 }),
+    );
+    const goodResponse = concatMessages(
+      encodeEventMessage({ content: "recovered" }),
+      encodeEventMessage({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5 } }),
+    );
+
+    const respond = (body: Uint8Array) => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: body })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+      },
+    });
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(respond(emptyWithCache))
+      .mockResolvedValueOnce(respond(goodResponse));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(usage.input).toBe(10);
+    expect(usage.output).toBe(5);
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
+    expect(usage.credits).toBeUndefined();
+    // The leak is a billing defect, not just a reporting one: calculateCost
+    // prices cacheRead on its own line, so an inherited count charges for a
+    // cache read this turn never performed.
+    expect(usage.cost.cacheRead).toBe(0);
+    // The stale 8000 cache-read tokens must not be summed into this total.
+    expect(usage.totalTokens).toBe(15);
+    expect(usage.contextPercent).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("records meteringEvent credits without folding them into token counts", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      // MeteringEvent.usage is a COUNT OF CREDITS, not tokens.
+      '{"usage":3,"unit":"credit","unitPlural":"credits"}',
+      JSON.stringify({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5, totalTokens: 15 } }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.credits).toBe(3);
+    expect(usage.creditUnit).toBe("credits");
+    // Credits must not leak into token accounting or cost.
+    expect(usage.input).toBe(10);
+    expect(usage.output).toBe(5);
+    expect(usage.totalTokens).toBe(15);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves cache provenance absent when no metadataEvent arrives", async () => {
+    const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":10}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    // The zeros satisfy pi's Usage type; absent provenance is what stops a
+    // consumer rendering them as a measured 0% cache hit rate.
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
 
     vi.unstubAllGlobals();
   });
@@ -2894,10 +3079,12 @@ describe("Feature 9: Streaming Integration", () => {
     const msg = done?.type === "done" ? done.message : undefined;
     expect(msg).toBeDefined();
     if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
 
-    expect((msg.usage as unknown as Record<string, unknown>).contextPercent).toBe(42);
+    expect(usage.contextPercent).toBe(42);
     // input should be back-calculated from percentage
-    expect(msg.usage.input).toBe(Math.round(0.42 * 200000));
+    expect(usage.input).toBe(Math.round(0.42 * 200000));
+    expect(usage.provenance?.input).toBe("derived");
 
     vi.unstubAllGlobals();
   });

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3778,6 +3778,53 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not bill an errored turn for a priced attempt it abandoned", async () => {
+    // The empty-response/echo-loop retry is decided AFTER finalizeKiroUsage and
+    // PiAi.calculateCost have run, so attempt 1 here — degenerate (no text, no
+    // tool calls) but reporting real token counts — prices the turn before it is
+    // retried. The remaining attempts fail terminally, so the turn is emitted
+    // through the error path with the reset zeroed counts. Without cost in the
+    // reset, that error message carries attempt 1's charge against zero tokens:
+    // a priced turn with nothing backing the price.
+    const pricedDegenerate = encodeEventMessage({
+      tokenUsage: { uncachedInputTokens: 100_000, outputTokens: 50_000, totalTokens: 150_000 },
+    });
+    const failing = encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError");
+
+    const respond = (body: Uint8Array) => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: body })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValueOnce(respond(pricedDegenerate)).mockResolvedValue(respond(failing));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type).toBe("error");
+    if (error?.type !== "error") throw new Error("Expected an errored turn");
+    const usage = error.error.usage as KiroUsage;
+
+    expect(usage.totalTokens).toBe(0);
+    expect(usage.input).toBe(0);
+    expect(usage.output).toBe(0);
+    // Attempt 1 priced at ~1.05; none of it may survive onto this turn.
+    expect(usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
   it("records meteringEvent credits without folding them into token counts", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3612,10 +3612,12 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers usage event values over tiktoken when available", async () => {
+  it("prefers metadataEvent token usage over tiktoken when available", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',
-      '{"usage":{"inputTokens":500,"outputTokens":200}}',
+      // MetadataEvent shape from ChatResponseStream: token counts live under
+      // tokenUsage.uncachedInputTokens/outputTokens, not a top-level `usage`.
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
       '{"contextUsagePercentage":10}',
     ]);
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3805,6 +3805,30 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("records the singular credit unit for a one-credit turn", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      // Both grammatical forms are on the wire; the count selects one. Passing
+      // only unitPlural through would render "1 credits".
+      '{"usage":1,"unit":"credit","unitPlural":"credits"}',
+      JSON.stringify({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5, totalTokens: 15 } }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.credits).toBe(1);
+    expect(usage.creditUnit).toBe("credit");
+
+    vi.unstubAllGlobals();
+  });
+
   it("leaves cache provenance absent when no metadataEvent arrives", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":10}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3717,6 +3717,100 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("surfaces a mid-stream throttlingError frame and retries", async () => {
+    // throttlingError / validationError / serviceUnavailableError are distinct
+    // ChatResponseStream members. Before key routing they matched no branch and
+    // were dropped, so the turn looked like an empty response. Now they abort
+    // the read and enter the retry path with the modeled class in the message.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({ content: "partial" }),
+                    encodeEventMessage(
+                      {
+                        message: "Too many requests",
+                        reason: "INSUFFICIENT_MODEL_CAPACITY",
+                        retryAfterMilliseconds: 10,
+                      },
+                      "throttlingError",
+                    ),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"recovered"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const done = events.find((e) => e.type === "done");
+    expect(done?.type === "done" && (done.message.content[0] as TextContent).text).toBe("recovered");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports the modeled exception class when a typed error frame outlives every retry", async () => {
+    const mockFetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: encodeEventMessage({ message: "capacity exhausted" }, "serviceUnavailableError"),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          releaseLock: () => {},
+        }),
+      },
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const error = events.find((e) => e.type === "error");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("ServiceUnavailableException");
+    expect(error?.type === "error" && error.error.errorMessage).toContain("capacity exhausted");
+
+    vi.unstubAllGlobals();
+  }, 30000);
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3829,6 +3829,47 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("singularizes the credit unit when the count arrives in a later metering frame", async () => {
+    // Every MeteringEvent field is optional, so the unit strings can arrive before
+    // the count. The units frame has no count to agree with, so its plural choice
+    // is provisional and must be revised once the count lands. Framed with an
+    // explicit key because a units-only payload has no numeric `usage` for the
+    // fixture helper to infer `meteringEvent` from — on the wire the union member
+    // comes from the `:event-type` header, not the payload shape.
+    const body = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage({ unit: "credit", unitPlural: "credits" }, "meteringEvent"),
+      encodeEventMessage({ usage: 1 }, "meteringEvent"),
+      encodeEventMessage({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5, totalTokens: 15 } }),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: body })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.credits).toBe(1);
+    expect(usage.creditUnit).toBe("credit");
+
+    vi.unstubAllGlobals();
+  });
+
   it("leaves cache provenance absent when no metadataEvent arrives", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":10}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3811,6 +3811,103 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   }, 30000);
 
+  it("does not inherit the failed attempt's cache counts when retrying", async () => {
+    // `usageEvent` is declared inside the retry loop, and the cache writes are
+    // post-loop, so an aborted attempt must contribute nothing to billing.
+    // cacheRead is priced as its own line in calculateCost, so inheriting a
+    // prior attempt's value would over-bill a turn that never read that cache.
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: vi
+                .fn()
+                .mockResolvedValueOnce({
+                  done: false,
+                  value: concatMessages(
+                    encodeEventMessage({
+                      tokenUsage: {
+                        uncachedInputTokens: 999,
+                        outputTokens: 111,
+                        totalTokens: 41110,
+                        cacheReadInputTokens: 40000,
+                        cacheWriteInputTokens: 7,
+                      },
+                    }),
+                    encodeEventMessage({ message: "throttled" }, "throttlingError"),
+                  ),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+              cancel: vi.fn().mockResolvedValue(undefined),
+              releaseLock: () => {},
+            }),
+          },
+        };
+      }
+      // Retry succeeds and reports NO metadataEvent at all.
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"clean"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            releaseLock: () => {},
+          }),
+        },
+      };
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((msg.content[0] as TextContent).text).toBe("clean");
+    // The abandoned attempt's counts must not appear anywhere in billing.
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.cacheWrite).toBe(0);
+    expect(msg.usage.cost.cacheRead).toBe(0);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to summing components when a non-conforming frame omits totalTokens", async () => {
+    // TokenUsage.totalTokens is required on the wire, so this branch only guards
+    // a non-conforming server. The sum must match how the service itself defines
+    // the total: uncachedInput + cacheRead + cacheWrite + output.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    // Same components as the wire-total test above, which reports 50250.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -14,6 +14,7 @@ import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { validateKiroConversation, validateKiroToolStructure } from "../src/history-validator.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
+import type { KiroUsage } from "../src/token-usage.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
 import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
 import { RECORD_279_COMMAND, RECORD_279_SUMMARY, RECORD_279_TEXT } from "./helpers/invoke-fixture.js";
@@ -3612,7 +3613,7 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers metadataEvent token usage over tiktoken when available", async () => {
+  it("prefers measured token counts over the tiktoken estimate", async () => {
     const mockFetch = mockFetchChunked([
       '{"content":"Hello"}',
       // MetadataEvent shape from ChatResponseStream: token counts live under
@@ -3628,15 +3629,199 @@ describe("Feature 9: Streaming Integration", () => {
     const msg = done?.type === "done" ? done.message : undefined;
     expect(msg).toBeDefined();
     if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
 
-    // Usage event values should take precedence
-    expect(msg.usage.input).toBe(500);
-    expect(msg.usage.output).toBe(200);
-    expect(msg.usage.totalTokens).toBe(700);
+    // Measured counts win over both the tiktoken estimate and the input figure
+    // back-computed from contextUsagePercentage.
+    expect(usage.input).toBe(500);
+    expect(usage.output).toBe(200);
+    expect(usage.totalTokens).toBe(700);
+    expect(usage.provenance?.input).toBe("measured");
+    expect(usage.provenance?.output).toBe("measured");
 
-    // contextPercent should still reflect the API's contextUsagePercentage,
-    // not be derived from the (overwritten) input token count
-    expect((msg.usage as unknown as Record<string, unknown>).contextPercent).toBe(10);
+    // contextPercent stays the API's own contextUsagePercentage — never
+    // re-derived from the (now overwritten) input count.
+    expect(usage.contextPercent).toBe(10);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("reports prompt-cache tokens from metadataEvent.tokenUsage", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      JSON.stringify({
+        tokenUsage: {
+          uncachedInputTokens: 1_200,
+          outputTokens: 340,
+          totalTokens: 9_540,
+          cacheReadInputTokens: 8_000,
+          cacheWriteInputTokens: 0,
+          normalizedTokenUsage: 12.5,
+        },
+      }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.provenance?.cache).toBe("measured");
+    // The wire's totalTokens is authoritative, not input+output.
+    expect(usage.totalTokens).toBe(9_540);
+    expect(usage.normalizedTokenUsage).toBe(12.5);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("merges token counts split across separate metadataEvent frames", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      // Every MetadataEvent field is optional, so the service may send tokenUsage
+      // and stopReason in separate frames. The second must not erase the first.
+      JSON.stringify({ tokenUsage: { uncachedInputTokens: 1_200, outputTokens: 340, cacheReadInputTokens: 8_000 } }),
+      JSON.stringify({ stopReason: "END_TURN" }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    // Without the merge, the stopReason-only frame clobbers these and output
+    // silently falls back to the tiktoken estimate.
+    expect(usage.input).toBe(1_200);
+    expect(usage.output).toBe(340);
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.provenance?.output).toBe("measured");
+    expect(usage.provenance?.cache).toBe("measured");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not carry a failed attempt's cache tokens into a successful retry", async () => {
+    // Attempt 1 is degenerate (no text, no tool calls) so it is retried, but it
+    // did report cache tokens and metering credits. Attempt 2 succeeds and
+    // reports neither — none of attempt 1's figures may survive into it.
+    //
+    // This is the empty-response retry path specifically, and it differs from the
+    // stream-error path in a way that matters: a throttle/validation error hits
+    // `if (streamError) break` and retries BEFORE the usage-finalizing block ever
+    // runs, so nothing was written to carry over. Here finalization runs first and
+    // calculateCost has already priced the turn, and only then is the retry
+    // decided — so the cache counts are already on the shared usage object when
+    // the next attempt starts. Priced with a non-zero-cost model so the assertion
+    // covers the money, not just the counts.
+    const emptyWithCache = concatMessages(
+      encodeEventMessage({ usage: 9, unit: "credit", unitPlural: "credits" }),
+      encodeEventMessage({
+        tokenUsage: { uncachedInputTokens: 1_200, outputTokens: 340, cacheReadInputTokens: 8_000 },
+      }),
+      encodeEventMessage({ contextUsagePercentage: 50 }),
+    );
+    const goodResponse = concatMessages(
+      encodeEventMessage({ content: "recovered" }),
+      encodeEventMessage({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5 } }),
+    );
+
+    const respond = (body: Uint8Array) => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: body })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+      },
+    });
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(respond(emptyWithCache))
+      .mockResolvedValueOnce(respond(goodResponse));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const priced = makeModel({ cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } });
+    const stream = streamKiro(priced, makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(usage.input).toBe(10);
+    expect(usage.output).toBe(5);
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
+    expect(usage.credits).toBeUndefined();
+    // The leak is a billing defect, not just a reporting one: calculateCost
+    // prices cacheRead on its own line, so an inherited count charges for a
+    // cache read this turn never performed.
+    expect(usage.cost.cacheRead).toBe(0);
+    // The stale 8000 cache-read tokens must not be summed into this total.
+    expect(usage.totalTokens).toBe(15);
+    expect(usage.contextPercent).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("records meteringEvent credits without folding them into token counts", async () => {
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      // MeteringEvent.usage is a COUNT OF CREDITS, not tokens.
+      '{"usage":3,"unit":"credit","unitPlural":"credits"}',
+      JSON.stringify({ tokenUsage: { uncachedInputTokens: 10, outputTokens: 5, totalTokens: 15 } }),
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    expect(usage.credits).toBe(3);
+    expect(usage.creditUnit).toBe("credits");
+    // Credits must not leak into token accounting or cost.
+    expect(usage.input).toBe(10);
+    expect(usage.output).toBe(5);
+    expect(usage.totalTokens).toBe(15);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves cache provenance absent when no metadataEvent arrives", async () => {
+    const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":10}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
+
+    // The zeros satisfy pi's Usage type; absent provenance is what stops a
+    // consumer rendering them as a measured 0% cache hit rate.
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
 
     vi.unstubAllGlobals();
   });
@@ -3918,10 +4103,12 @@ describe("Feature 9: Streaming Integration", () => {
     const msg = done?.type === "done" ? done.message : undefined;
     expect(msg).toBeDefined();
     if (!msg) throw new Error("Expected a completed assistant message");
+    const usage = msg.usage as KiroUsage;
 
-    expect((msg.usage as unknown as Record<string, unknown>).contextPercent).toBe(42);
+    expect(usage.contextPercent).toBe(42);
     // input should be back-calculated from percentage
-    expect(msg.usage.input).toBe(Math.round(0.42 * 200000));
+    expect(usage.input).toBe(Math.round(0.42 * 200000));
+    expect(usage.provenance?.input).toBe("derived");
 
     vi.unstubAllGlobals();
   });

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3641,6 +3641,57 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("records cacheRead/cacheWrite so a cached turn is not priced as uncached input", async () => {
+    // TokenUsage.uncachedInputTokens excludes cache reads. Taking `input` from
+    // it while leaving cacheRead at 0 would report ~200 input tokens for a turn
+    // that actually read 50k cached tokens, and price it accordingly.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250,"cacheReadInputTokens":50000,"cacheWriteInputTokens":0}}',
+      '{"contextUsagePercentage":5}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(50000);
+    expect(msg.usage.cacheWrite).toBe(0);
+    // input + cacheRead + cacheWrite + output, matching the wire totalTokens.
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
+    // Every MetadataEvent field is optional; tokenUsage and stopReason may
+    // arrive in separate frames.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":500,"outputTokens":200,"totalTokens":700}}',
+      '{"stopReason":"END_TURN"}',
+      '{"contextUsagePercentage":10}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(500);
+    expect(msg.usage.output).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+
   it("passes through contextPercent even without usage event", async () => {
     const mockFetch = mockFetchOk('{"content":"Hi"}{"contextUsagePercentage":42}');
     vi.stubGlobal("fetch", mockFetch);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3668,6 +3668,31 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps the wire totalTokens when the service omits an optional cache count", async () => {
+    // TokenUsage.totalTokens is required on the wire; cacheReadInputTokens and
+    // cacheWriteInputTokens are optional. Recomputing the total from components
+    // would report 250 for a turn the service says cost 50250 context tokens,
+    // and calculateContextTokens drives the context gauge from that total.
+    const mockFetch = mockFetchChunked([
+      '{"content":"Hello"}',
+      '{"tokenUsage":{"uncachedInputTokens":200,"outputTokens":50,"totalTokens":50250}}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg).toBeDefined();
+    if (!msg) throw new Error("Expected a completed assistant message");
+
+    expect(msg.usage.input).toBe(200);
+    expect(msg.usage.cacheRead).toBe(0);
+    expect(msg.usage.totalTokens).toBe(50250);
+
+    vi.unstubAllGlobals();
+  });
+
   it("merges metadataEvent frames so a later stopReason frame cannot erase token counts", async () => {
     // Every MetadataEvent field is optional; tokenUsage and stopReason may
     // arrive in separate frames.

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -412,7 +412,7 @@ describe("finalizeKiroUsage", () => {
 });
 
 describe("resetKiroUsage", () => {
-  it("clears everything one attempt reported, preserving cost", () => {
+  it("clears everything one attempt reported, cost included", () => {
     const usage = freshUsage();
     usage.cost = { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 };
     applyContextUsage(usage, 50, CONTEXT_WINDOW);
@@ -427,7 +427,11 @@ describe("resetKiroUsage", () => {
       cacheRead: 0,
       cacheWrite: 0,
       totalTokens: 0,
-      cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+      // Cost is derived wholly from the counts above, so leaving it behind would
+      // leave the one figure nothing backs. A successful retry recomputes it;
+      // an attempt that never gets that far must not report the previous
+      // attempt's charge against these zeros.
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     });
   });
 
@@ -443,6 +447,22 @@ describe("resetKiroUsage", () => {
     expect(usage.credits).toBe(1);
     expect(usage.creditUnit).toBeUndefined();
     expect(usage.creditUnitForms).toBeUndefined();
+  });
+
+  it("leaves no priced cost behind when the next attempt reports nothing", () => {
+    const usage = freshUsage();
+    // The empty-response/echo-loop retry is decided AFTER the turn has been
+    // finalized and priced, so a degenerate-but-priced attempt reaches here with
+    // a real charge on `cost`. If the retry then fails terminally, the errored
+    // turn is emitted with these zeroed counts — and must not still carry the
+    // abandoned attempt's charge.
+    finalizeKiroUsage(usage, fullWire(), neverEstimate);
+    usage.cost = { input: 0.3, output: 0.75, cacheRead: 0.0024, cacheWrite: 0, total: 1.0524 };
+
+    resetKiroUsage(usage);
+
+    expect(usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+    expect(usage.totalTokens).toBe(0);
   });
 
   it("stops a failed attempt's cache counts leaking into a clean retry", () => {

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -144,6 +144,38 @@ describe("applyMeteringCredits", () => {
     expect(usage.credits).toBe(4);
     expect(usage.creditUnit).toBe("credits");
   });
+
+  it("singularizes when the count arrives in a frame after the unit strings", () => {
+    const usage = freshUsage();
+    // The mirror image of the case above: `MeteringEvent.usage` is optional, so a
+    // units-only frame can precede the count. With no count to agree with its
+    // choice is provisional, and must be revisited once the count lands —
+    // otherwise the provisional plural sticks and renders "1 credits".
+    applyMeteringCredits(usage, undefined, "credit", "credits");
+    expect(usage.creditUnit).toBe("credits");
+
+    applyMeteringCredits(usage, 1, undefined, undefined);
+
+    expect(usage.credits).toBe(1);
+    expect(usage.creditUnit).toBe("credit");
+  });
+
+  it("keeps the plural when a later count is not one", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, undefined, "credit", "credits");
+    applyMeteringCredits(usage, 6, undefined, undefined);
+
+    expect(usage.creditUnit).toBe("credits");
+  });
+
+  it("remembers a single form supplied by an earlier frame", () => {
+    const usage = freshUsage();
+    // Only the singular was ever sent, so it stays in use whatever the count.
+    applyMeteringCredits(usage, undefined, "credit", undefined);
+    applyMeteringCredits(usage, 3, undefined, undefined);
+
+    expect(usage.creditUnit).toBe("credit");
+  });
 });
 
 describe("finalizeKiroUsage", () => {
@@ -397,6 +429,20 @@ describe("resetKiroUsage", () => {
       totalTokens: 0,
       cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
     });
+  });
+
+  it("clears the retained unit forms so a later count cannot revive them", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 4, "credit", "credits");
+
+    resetKiroUsage(usage);
+    // A retry that reports only a count must not inherit the previous attempt's
+    // unit strings.
+    applyMeteringCredits(usage, 1, undefined, undefined);
+
+    expect(usage.credits).toBe(1);
+    expect(usage.creditUnit).toBeUndefined();
+    expect(usage.creditUnitForms).toBeUndefined();
   });
 
   it("stops a failed attempt's cache counts leaking into a clean retry", () => {

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyContextUsage,
+  applyMeteringCredits,
+  finalizeKiroUsage,
+  type KiroUsage,
+  type KiroWireTokenUsage,
+  resetKiroUsage,
+} from "../src/token-usage.js";
+
+const CONTEXT_WINDOW = 200_000;
+
+function freshUsage(): KiroUsage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+/** A fully populated wire payload, as a cache-warm turn actually reports it. */
+function fullWire(): KiroWireTokenUsage {
+  return {
+    inputTokens: 1_200,
+    outputTokens: 340,
+    totalTokens: 9_540,
+    cacheReadInputTokens: 8_000,
+    cacheWriteInputTokens: 0,
+    contextUsagePercentage: 4.77,
+    normalizedTokenUsage: 12.5,
+  };
+}
+
+/** Fails the test if called — proves the estimate never displaces a measurement. */
+const neverEstimate = () => {
+  throw new Error("estimateOutput must not be called when the wire reported outputTokens");
+};
+
+describe("applyContextUsage", () => {
+  it("records the service percentage verbatim and marks derived input", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 42, CONTEXT_WINDOW);
+
+    expect(usage.contextPercent).toBe(42);
+    expect(usage.input).toBe(Math.round(0.42 * CONTEXT_WINDOW));
+    expect(usage.provenance?.input).toBe("derived");
+  });
+
+  it("keeps a fractional percentage unrounded", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 4.77, CONTEXT_WINDOW);
+
+    expect(usage.contextPercent).toBe(4.77);
+  });
+
+  it("still reports the percentage when the context window is unknown", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 30, 0);
+
+    expect(usage.contextPercent).toBe(30);
+    expect(usage.input).toBe(0);
+    expect(usage.provenance?.input).toBeUndefined();
+  });
+
+  it("ignores a non-finite percentage", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, Number.NaN, CONTEXT_WINDOW);
+
+    expect(usage.contextPercent).toBeUndefined();
+    expect(usage.input).toBe(0);
+  });
+});
+
+describe("applyMeteringCredits", () => {
+  it("records credits and unit without touching token counts", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 3, "credits");
+
+    expect(usage.credits).toBe(3);
+    expect(usage.creditUnit).toBe("credits");
+    expect(usage.input).toBe(0);
+    expect(usage.output).toBe(0);
+    expect(usage.totalTokens).toBe(0);
+  });
+
+  it("records an explicit zero credit charge", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 0, "credit");
+
+    expect(usage.credits).toBe(0);
+  });
+
+  it("leaves credits absent when the event carried none", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, undefined, undefined);
+
+    expect(usage.credits).toBeUndefined();
+    expect(usage.creditUnit).toBeUndefined();
+  });
+});
+
+describe("finalizeKiroUsage", () => {
+  it("maps every modeled field onto pi's Usage", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, fullWire(), neverEstimate);
+
+    expect(usage.input).toBe(1_200);
+    expect(usage.output).toBe(340);
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.totalTokens).toBe(9_540);
+    expect(usage.contextPercent).toBe(4.77);
+    expect(usage.normalizedTokenUsage).toBe(12.5);
+  });
+
+  it("prefers the wire totalTokens over recomputing it", () => {
+    const usage = freshUsage();
+    // 1200 + 340 + 8000 + 0 = 9540 would coincide, so use a wire value that cannot
+    // be produced by summation — proving the wire figure is the one reported.
+    finalizeKiroUsage(usage, { ...fullWire(), totalTokens: 9_999 }, neverEstimate);
+
+    expect(usage.totalTokens).toBe(9_999);
+    expect(usage.provenance?.totalTokens).toBe("measured");
+  });
+
+  it("lets a measured input overwrite a contextUsage-derived one", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 50, CONTEXT_WINDOW);
+    expect(usage.input).toBe(100_000);
+
+    finalizeKiroUsage(usage, { inputTokens: 1_234, outputTokens: 7 }, neverEstimate);
+
+    expect(usage.input).toBe(1_234);
+    expect(usage.provenance?.input).toBe("measured");
+  });
+
+  it("keeps the derived input when the wire omitted inputTokens", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 25, CONTEXT_WINDOW);
+
+    finalizeKiroUsage(usage, { outputTokens: 11 }, neverEstimate);
+
+    expect(usage.input).toBe(50_000);
+    expect(usage.provenance?.input).toBe("derived");
+  });
+
+  it("prefers the metadata contextUsagePercentage over an earlier mid-stream one", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 10, CONTEXT_WINDOW);
+
+    finalizeKiroUsage(usage, { contextUsagePercentage: 12.5, outputTokens: 1 }, neverEstimate);
+
+    expect(usage.contextPercent).toBe(12.5);
+  });
+
+  it("does not re-derive contextPercent from token counts", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 10, CONTEXT_WINDOW);
+
+    // Metadata reports tokens but no percentage: the mid-stream percentage stands.
+    finalizeKiroUsage(usage, { inputTokens: 4, outputTokens: 4, totalTokens: 8 }, neverEstimate);
+
+    expect(usage.contextPercent).toBe(10);
+  });
+
+  it("estimates output only when the wire omitted outputTokens", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 500 }, () => 77);
+
+    expect(usage.output).toBe(77);
+    expect(usage.provenance?.output).toBe("estimated");
+    expect(usage.provenance?.input).toBe("measured");
+  });
+
+  it("does not let the estimate displace a measured zero output", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 0 }, neverEstimate);
+
+    expect(usage.output).toBe(0);
+    expect(usage.provenance?.output).toBe("measured");
+  });
+
+  it("estimates output when there is no metadata event at all", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, null, () => 42);
+
+    expect(usage.output).toBe(42);
+    expect(usage.totalTokens).toBe(42);
+    expect(usage.provenance?.output).toBe("estimated");
+  });
+
+  it("leaves cache provenance absent when the turn reported no cache fields", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, neverEstimate);
+
+    // The zeros are placeholders required by pi's Usage type, NOT a measured
+    // 0% cache hit rate. Absent provenance is what makes the two separable.
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
+  });
+
+  it("marks a genuine zero cache hit as measured", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 5, cacheReadInputTokens: 0 }, neverEstimate);
+
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.provenance?.cache).toBe("measured");
+  });
+
+  it("defaults the missing half of a partial cache report to zero", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 5, cacheWriteInputTokens: 2_048 }, neverEstimate);
+
+    expect(usage.cacheWrite).toBe(2_048);
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.provenance?.cache).toBe("measured");
+  });
+
+  it("adds the cache legs back in when recomputing a missing total", () => {
+    const usage = freshUsage();
+    // The wire's input is the UNCACHED slice, so a total of input+output alone
+    // would under-report this turn by the 8000 cache-read tokens.
+    finalizeKiroUsage(
+      usage,
+      { inputTokens: 100, outputTokens: 50, cacheReadInputTokens: 8_000, cacheWriteInputTokens: 10 },
+      neverEstimate,
+    );
+
+    expect(usage.totalTokens).toBe(8_160);
+  });
+
+  it("normalizes a derived input against measured cache legs instead of double-counting", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 10, CONTEXT_WINDOW);
+    expect(usage.input).toBe(20_000);
+
+    // Cache counts arrive but uncachedInputTokens does not. The derived input
+    // spans the WHOLE prompt, cached portion included, so the cache legs are
+    // subtracted out of it rather than added on top. Otherwise the 8000 cached
+    // tokens are counted twice — in totalTokens and, worse, in cost, since
+    // calculateCost prices input and cacheRead as separate lines.
+    finalizeKiroUsage(usage, { outputTokens: 50, cacheReadInputTokens: 8_000 }, neverEstimate);
+
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.provenance?.cache).toBe("measured");
+    expect(usage.input).toBe(12_000);
+    // The four slots are disjoint, so they sum back to the derived prompt total
+    // (20000) plus output — not 28050.
+    expect(usage.input + usage.cacheRead + usage.cacheWrite).toBe(20_000);
+    expect(usage.totalTokens).toBe(20_050);
+    expect(usage.provenance?.totalTokens).toBe("estimated");
+  });
+
+  it("floors a normalized derived input at zero when the cache legs exceed it", () => {
+    const usage = freshUsage();
+    // 1% of 200k = 2000, under the reported 8000 cache-read tokens. The derived
+    // figure is a rounded back-computation, so this is reachable.
+    applyContextUsage(usage, 1, CONTEXT_WINDOW);
+
+    finalizeKiroUsage(usage, { outputTokens: 5, cacheReadInputTokens: 8_000 }, neverEstimate);
+
+    expect(usage.input).toBe(0);
+    expect(usage.cacheRead).toBe(8_000);
+    expect(usage.totalTokens).toBe(8_005);
+  });
+
+  it("does not normalize a measured input against the cache legs", () => {
+    const usage = freshUsage();
+    applyContextUsage(usage, 10, CONTEXT_WINDOW);
+
+    // uncachedInputTokens IS the uncached slice, so it already excludes the cache
+    // legs and must be left alone.
+    finalizeKiroUsage(usage, { inputTokens: 1_200, outputTokens: 50, cacheReadInputTokens: 8_000 }, neverEstimate);
+
+    expect(usage.input).toBe(1_200);
+    expect(usage.totalTokens).toBe(9_250);
+  });
+
+  it("marks a recomputed total estimated when output was estimated", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 100 }, () => 50);
+
+    expect(usage.totalTokens).toBe(150);
+    expect(usage.provenance?.totalTokens).toBe("estimated");
+  });
+
+  it("marks a recomputed total derived when both legs were measured", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(usage, { inputTokens: 100, outputTokens: 50 }, neverEstimate);
+
+    expect(usage.provenance?.totalTokens).toBe("derived");
+  });
+
+  it("ignores negative and non-finite counts rather than reporting them", () => {
+    const usage = freshUsage();
+    finalizeKiroUsage(
+      usage,
+      {
+        inputTokens: -5,
+        outputTokens: Number.NaN,
+        totalTokens: Number.POSITIVE_INFINITY,
+        cacheReadInputTokens: -1,
+      },
+      () => 9,
+    );
+
+    expect(usage.input).toBe(0);
+    expect(usage.provenance?.input).toBeUndefined();
+    expect(usage.output).toBe(9);
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
+    expect(usage.totalTokens).toBe(9);
+  });
+
+  it("carries normalizedTokenUsage and metering credits together", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 2, "credits");
+    finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 5, normalizedTokenUsage: 0.25 }, neverEstimate);
+
+    // Credits (MeteringEvent) and normalizedTokenUsage (TokenUsage) are the two
+    // actual billing units; neither may leak into the token counts.
+    expect(usage.credits).toBe(2);
+    expect(usage.normalizedTokenUsage).toBe(0.25);
+    expect(usage.totalTokens).toBe(15);
+  });
+});
+
+describe("resetKiroUsage", () => {
+  it("clears everything one attempt reported, preserving cost", () => {
+    const usage = freshUsage();
+    usage.cost = { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 };
+    applyContextUsage(usage, 50, CONTEXT_WINDOW);
+    applyMeteringCredits(usage, 7, "credits");
+    finalizeKiroUsage(usage, fullWire(), neverEstimate);
+
+    resetKiroUsage(usage);
+
+    expect(usage).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+    });
+  });
+
+  it("stops a failed attempt's cache counts leaking into a clean retry", () => {
+    const usage = freshUsage();
+    // Attempt 1: cache-warm turn, then the stream fails and is retried.
+    finalizeKiroUsage(usage, fullWire(), neverEstimate);
+    applyMeteringCredits(usage, 9, "credits");
+    expect(usage.cacheRead).toBe(8_000);
+
+    resetKiroUsage(usage);
+
+    // Attempt 2 reports no cache fields and no credits at all.
+    finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 5 }, neverEstimate);
+
+    expect(usage.cacheRead).toBe(0);
+    expect(usage.cacheWrite).toBe(0);
+    expect(usage.provenance?.cache).toBeUndefined();
+    expect(usage.credits).toBeUndefined();
+    expect(usage.normalizedTokenUsage).toBeUndefined();
+    // Critically, the stale 8000 cache-read tokens are not summed into this total.
+    expect(usage.totalTokens).toBe(15);
+  });
+});

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -120,6 +120,30 @@ describe("applyMeteringCredits", () => {
     expect(usage.credits).toBeUndefined();
     expect(usage.creditUnit).toBeUndefined();
   });
+
+  it("keeps the singular unit when a later frame carries units but no count", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 1, "credit", "credits");
+    expect(usage.creditUnit).toBe("credit");
+
+    // Every MeteringEvent field is optional, so a later frame can repeat the unit
+    // strings with no `usage` number. Agreement must be decided against the count
+    // already recorded, not against this call's absent argument, or the recorded
+    // single credit is re-pluralized into "1 credits".
+    applyMeteringCredits(usage, undefined, "credit", "credits");
+
+    expect(usage.credits).toBe(1);
+    expect(usage.creditUnit).toBe("credit");
+  });
+
+  it("repluralizes when a later frame revises the count upward", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 1, "credit", "credits");
+    applyMeteringCredits(usage, 4, "credit", "credits");
+
+    expect(usage.credits).toBe(4);
+    expect(usage.creditUnit).toBe("credits");
+  });
 });
 
 describe("finalizeKiroUsage", () => {
@@ -268,9 +292,15 @@ describe("finalizeKiroUsage", () => {
     expect(usage.cacheRead).toBe(8_000);
     expect(usage.provenance?.cache).toBe("measured");
     expect(usage.input).toBe(12_000);
-    // The four slots are disjoint, so they sum back to the derived prompt total
-    // (20000) plus output — not 28050.
+    // The three prompt slots no longer overlap, so cost is charged once per
+    // cached token: 12000 back to the derived figure of 20000.
     expect(usage.input + usage.cacheRead + usage.cacheWrite).toBe(20_000);
+    // The recomputed total is 20050, and it is knowingly imprecise: the 20000 it
+    // builds on was back-computed from contextUsagePercentage, which the service
+    // derives from totalTokens — output tokens included. So those 50 output
+    // tokens are counted twice here. Unavoidable without a measured input, and
+    // marked "estimated" for exactly that reason. Only reachable when the wire
+    // omitted the required totalTokens field.
     expect(usage.totalTokens).toBe(20_050);
     expect(usage.provenance?.totalTokens).toBe("estimated");
   });

--- a/test/token-usage.test.ts
+++ b/test/token-usage.test.ts
@@ -77,7 +77,7 @@ describe("applyContextUsage", () => {
 describe("applyMeteringCredits", () => {
   it("records credits and unit without touching token counts", () => {
     const usage = freshUsage();
-    applyMeteringCredits(usage, 3, "credits");
+    applyMeteringCredits(usage, 3, "credit", "credits");
 
     expect(usage.credits).toBe(3);
     expect(usage.creditUnit).toBe("credits");
@@ -86,16 +86,36 @@ describe("applyMeteringCredits", () => {
     expect(usage.totalTokens).toBe(0);
   });
 
+  it("picks the singular unit for a single credit", () => {
+    const usage = freshUsage();
+    applyMeteringCredits(usage, 1, "credit", "credits");
+
+    // Storing unitPlural unconditionally would render "1 credits".
+    expect(usage.creditUnit).toBe("credit");
+  });
+
   it("records an explicit zero credit charge", () => {
     const usage = freshUsage();
-    applyMeteringCredits(usage, 0, "credit");
+    applyMeteringCredits(usage, 0, "credit", "credits");
 
     expect(usage.credits).toBe(0);
+    // Zero takes the plural, as English does.
+    expect(usage.creditUnit).toBe("credits");
+  });
+
+  it("uses whichever form the event supplied when only one is present", () => {
+    const pluralOnly = freshUsage();
+    applyMeteringCredits(pluralOnly, 1, undefined, "credits");
+    expect(pluralOnly.creditUnit).toBe("credits");
+
+    const singularOnly = freshUsage();
+    applyMeteringCredits(singularOnly, 4, "credit", undefined);
+    expect(singularOnly.creditUnit).toBe("credit");
   });
 
   it("leaves credits absent when the event carried none", () => {
     const usage = freshUsage();
-    applyMeteringCredits(usage, undefined, undefined);
+    applyMeteringCredits(usage, undefined, undefined, undefined);
 
     expect(usage.credits).toBeUndefined();
     expect(usage.creditUnit).toBeUndefined();
@@ -318,7 +338,7 @@ describe("finalizeKiroUsage", () => {
 
   it("carries normalizedTokenUsage and metering credits together", () => {
     const usage = freshUsage();
-    applyMeteringCredits(usage, 2, "credits");
+    applyMeteringCredits(usage, 2, "credit", "credits");
     finalizeKiroUsage(usage, { inputTokens: 10, outputTokens: 5, normalizedTokenUsage: 0.25 }, neverEstimate);
 
     // Credits (MeteringEvent) and normalizedTokenUsage (TokenUsage) are the two
@@ -334,7 +354,7 @@ describe("resetKiroUsage", () => {
     const usage = freshUsage();
     usage.cost = { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 };
     applyContextUsage(usage, 50, CONTEXT_WINDOW);
-    applyMeteringCredits(usage, 7, "credits");
+    applyMeteringCredits(usage, 7, "credit", "credits");
     finalizeKiroUsage(usage, fullWire(), neverEstimate);
 
     resetKiroUsage(usage);
@@ -353,7 +373,7 @@ describe("resetKiroUsage", () => {
     const usage = freshUsage();
     // Attempt 1: cache-warm turn, then the stream fails and is retried.
     finalizeKiroUsage(usage, fullWire(), neverEstimate);
-    applyMeteringCredits(usage, 9, "credits");
+    applyMeteringCredits(usage, 9, "credit", "credits");
     expect(usage.cacheRead).toBe(8_000);
 
     resetKiroUsage(usage);


### PR DESCRIPTION
## Problem

Every Kiro turn reported a fabricated 0% prompt-cache hit rate, and no measured token count ever reached pi.

`src/stream.ts` hardcoded `cacheRead: 0, cacheWrite: 0` and nothing ever wrote them. The only input figure that landed was back-computed from `contextUsagePercentage` (`round(pct / 100 * model.contextWindow)`), stashed through an `as unknown as Record<string, unknown>` cast. Output tokens always fell through to a tiktoken estimate, and `totalTokens` was recomputed as `input + output` instead of using the wire value. `PiAi.calculateCost` then priced `cacheRead: 0`, so the cache-read discount line was missing from every cost.

The service does send this data. `TokenUsage` arrives on `metadataEvent.tokenUsage` with `uncachedInputTokens`, `outputTokens`, `totalTokens`, `cacheReadInputTokens`, `cacheWriteInputTokens`, `contextUsagePercentage` and `normalizedTokenUsage`. Kiro's own consumer reads the two cache fields in practice, so these are populated rather than merely modeled.

## Change

New `src/token-usage.ts` owns the wire-to-pi mapping so the precedence rules live in one place instead of being scattered through the stream orchestrator.

- `uncachedInputTokens` -> `usage.input`, `outputTokens` -> `usage.output`, `cacheReadInputTokens` -> `usage.cacheRead`, `cacheWriteInputTokens` -> `usage.cacheWrite`, and the wire's `totalTokens` is preferred over a recomputed sum.
- Explicit provenance per slot (`measured` | `derived` | `estimated`). A measured count always overwrites a derived or estimated one; the reverse never happens, so tiktoken stays a fallback for genuinely absent fields and can no longer clobber a real count.
- The `contextUsagePercentage`-derived input is retained only as a pre-metadata provisional, tagged `derived`, so live context% still updates mid-stream before metadata arrives. Precedence is documented at the mapping site.
- `contextPercent` is now a typed field on the usage shape; the `as unknown as Record<string, unknown>` cast is gone.
- `normalizedTokenUsage` (the MPS credit basis) and the `meteringEvent` credits are carried through, so the actual billing units are observable for the first time.
- Usage and cost are cleared together at the retry boundary, so a failed attempt's cache counts cannot be priced into a successful retry.

Semantic note for reviewers: the wire field is *uncached* input, not total input. pi's `Usage.input` is the full-rate slot with `cacheRead`/`cacheWrite` as siblings, so the mapping is correct — but only because the cache legs are populated in the same commit. `provenance.cache` is left absent rather than `measured` when the turn reported no cache fields, so a consumer can distinguish a real 0% cache hit from "the provider never told us".

## Stack

Stacked on #113 (`kermes/task-bouncing-fox`, event routing by modeled event-type key), which must merge first — `metadataEvent` is dropped entirely without it, so this mapping has nothing to read.

GitHub renders the parent's commits here because the parent branch lives on the fork, not in this repository, so a cross-fork PR cannot base on it. The scope collapses to this card's own commits once #113 merges.

Parent commits (owned by #113, review there): `a40406e`, `b141d92`, `df5abd2`, `ce9debc`, `262289d`.

This card's commits: `0f9039d` (map modeled TokenUsage with explicit provenance), `965ac13`, `67625d7`, `029f056` (credit-unit agreement with the recorded count), `9cac727` (clear cost at the retry boundary with the counts it prices).

Card-only diff is `262289d..HEAD`: `src/token-usage.ts` (new), `src/stream.ts`, `src/event-parser.ts`, `test/token-usage.test.ts` (new), `test/stream.test.ts`.

## Validation

Rebased onto `main` at `a8641ac`, which had advanced by two commits (`8c4199d` history/image bounding and `a8641ac` entry-module re-export). Trunk touched `src/stream.ts` and `test/stream.test.ts`, both of which this branch also changes, so the full gate was re-run rather than trusted from the pre-rebase tip. `git range-diff` reports all ten commits content-identical across the replay.

On `9cac727`: `npm run check` (strict `tsc --noEmit` plus the test tsconfig) exit 0, `npm run lint` (biome, 56 files) exit 0, `npm run build` exit 0, `npm test` exit 0 — 23 files, 589 tests, 0 failures. The three biome warnings are pre-existing `as any` uses in `test/login.test.ts` and are untouched by this branch.

## Follow-up (separate, in the pi consumer)

pi should stop rendering an unmeasured `0` as a measurement: until a turn reports cache data, cache-efficiency cells should render an em dash the way unmeasured CPU/MEM cells already do. This PR supplies the `provenance.cache` absence needed to do that.
