### PR TITLE
feat: export Kiro reason codes and classification predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,15 @@ isNonRetryableBodyError(body); // hard quota → do not retry
 ```
 
 These are Kiro's own codes, not a provider taxonomy: mapping them to your own
-semantics is the consumer's job. The entry point also imports pi's host packages
-(`@earendil-works/pi-ai` and friends), which are already present wherever this
-extension runs.
+semantics is the consumer's job.
+
+One caveat for consumers outside pi: the entry point is the whole provider, so
+importing it loads modules that import pi's host packages
+(`@earendil-works/pi-ai`, `-pi-coding-agent`, `-pi-tui`). They are declared as
+optional peer dependencies — present already wherever this runs as a pi
+extension, but a standalone project must install them itself or the import fails
+with `ERR_MODULE_NOT_FOUND`. The types resolve without them under the usual
+`skipLibCheck`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ This provider only keeps local recovery for Kiro-specific cases:
 - empty-stream retries
 - non-retryable Kiro body markers like `MONTHLY_REQUEST_COUNT` and `INSUFFICIENT_MODEL_CAPACITY`
 
+The reason codes this provider classifies on are published from the package
+entry point, so consumers can interpret a code without hardcoding their own copy
+of the literals:
+
+```ts
+import {
+  KIRO_REASON_CODES,
+  isCapacityError,
+  isNonRetryableBodyError,
+  isTooBigError,
+} from "pi-provider-kiro";
+
+isTooBigError(400, body); // size rejection → safe to compact and retry
+isCapacityError(body); // transient capacity → safe to retry as-is
+isNonRetryableBodyError(body); // hard quota → do not retry
+```
+
+These are Kiro's own codes, not a provider taxonomy: mapping them to your own
+semantics is the consumer's job.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ isNonRetryableBodyError(body); // hard quota → do not retry
 ```
 
 These are Kiro's own codes, not a provider taxonomy: mapping them to your own
-semantics is the consumer's job.
+semantics is the consumer's job. The entry point also imports pi's host packages
+(`@earendil-works/pi-ai` and friends), which are already present wherever this
+extension runs.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.9.3",
   "description": "pi extension for the Kiro API (AWS CodeWhisperer/Q) — 12 kiro-cli-verified models with OAuth authentication",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -22,7 +24,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --banner:js=\"import{createRequire as __kiroCreateRequire}from'node:module';const require=__kiroCreateRequire(import.meta.url);\" --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui && tsc --emitDeclarationOnly",
     "check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,22 @@
     "esbuild": "^0.25.0",
     "js-tiktoken": "^1.0.21"
   },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": ">=0.80.10",
+    "@earendil-works/pi-coding-agent": ">=0.80.10",
+    "@earendil-works/pi-tui": ">=0.80.10"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-ai": {
+      "optional": true
+    },
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "@earendil-works/pi-tui": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "2.4.2",
     "@earendil-works/pi-ai": "0.80.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,20 @@ import { fetchKiroUsage } from "./usage.js";
 export { resolveApiRegion } from "./endpoints.js";
 export type { KiroStreamEvent } from "./event-parser.js";
 export { KIRO_MODEL_IDS, kiroModels, resolveKiroModel } from "./models.js";
+// Kiro's own error vocabulary and the predicates this provider classifies it
+// with. Published so consumers can interpret a reason code without an error
+// instance in hand (e.g. a persisted log line) instead of hardcoding copies of
+// the literals, which drift when the service adds a code.
+export type { KiroReasonCode } from "./retry.js";
+export {
+  CAPACITY_PATTERN,
+  isCapacityError,
+  isNonRetryableBodyError,
+  isTooBigError,
+  KIRO_REASON_CODES,
+  NON_RETRYABLE_BODY_PATTERNS,
+  TOO_BIG_PATTERNS,
+} from "./retry.js";
 export { streamKiro } from "./stream.js";
 
 /**

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -28,16 +28,43 @@ export function exponentialBackoff(attempt: number, baseMs: number, maxMs: numbe
 
 export const MAX_RETRY_DELAY = 10_000;
 
-// Size markers only. "Improperly formed request." is Kiro's generic
-// request-validation rejection (reason `REQUEST_BODY_INVALID`) — it is returned
-// for a malformed body of any size, including an empty `content` field or a
-// history referencing tools absent from the catalog. Classifying it as
-// "too big" made every such 400 surface as `context_length_exceeded`, which
-// sends the caller into a compaction loop it can never satisfy: the request is
-// invalid, not oversized, so no amount of history reduction fixes it.
-export const TOO_BIG_PATTERNS = ["CONTENT_LENGTH_EXCEEDS_THRESHOLD", "Input is too long"];
-const NON_RETRYABLE_BODY_PATTERNS = ["MONTHLY_REQUEST_COUNT"];
-const CAPACITY_PATTERN = "INSUFFICIENT_MODEL_CAPACITY";
+/**
+ * Machine reason codes returned by the Kiro API, plus the one prose marker the
+ * service emits without a code (`INPUT_TOO_LONG`).
+ *
+ * Single source of truth for the provider's error vocabulary: the pattern lists
+ * and predicates below are derived from it, and it is re-exported from the
+ * package entry point so consumers can classify a code without holding an error
+ * instance — e.g. reading a persisted log line. These are the service's own
+ * codes, deliberately not renamed or mapped into a provider taxonomy.
+ */
+export const KIRO_REASON_CODES = Object.freeze({
+  /** Request body exceeded the service's size threshold. */
+  CONTENT_LENGTH_EXCEEDS_THRESHOLD: "CONTENT_LENGTH_EXCEEDS_THRESHOLD",
+  /** Prose-only size rejection; the service sends no reason code for this one. */
+  INPUT_TOO_LONG: "Input is too long",
+  /** Monthly request quota exhausted — hard limit, not transient. */
+  MONTHLY_REQUEST_COUNT: "MONTHLY_REQUEST_COUNT",
+  /** Model capacity temporarily unavailable — transient, worth retrying. */
+  INSUFFICIENT_MODEL_CAPACITY: "INSUFFICIENT_MODEL_CAPACITY",
+  /**
+   * Generic request-validation rejection, returned for a malformed body of any
+   * size (empty `content`, history referencing tools absent from the catalog).
+   * Not a size signal: classifying it as "too big" makes the caller compact a
+   * history that was never the problem, a loop it can never satisfy.
+   */
+  REQUEST_BODY_INVALID: "REQUEST_BODY_INVALID",
+} as const);
+
+export type KiroReasonCode = (typeof KIRO_REASON_CODES)[keyof typeof KIRO_REASON_CODES];
+
+// Size markers only — REQUEST_BODY_INVALID is excluded on purpose (see above).
+export const TOO_BIG_PATTERNS: readonly string[] = Object.freeze([
+  KIRO_REASON_CODES.CONTENT_LENGTH_EXCEEDS_THRESHOLD,
+  KIRO_REASON_CODES.INPUT_TOO_LONG,
+]);
+export const NON_RETRYABLE_BODY_PATTERNS: readonly string[] = Object.freeze([KIRO_REASON_CODES.MONTHLY_REQUEST_COUNT]);
+export const CAPACITY_PATTERN = KIRO_REASON_CODES.INSUFFICIENT_MODEL_CAPACITY;
 export const CAPACITY_MAX_RETRIES = 3;
 export const CAPACITY_BASE_DELAY_MS = 5_000;
 

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -66,6 +66,19 @@ describe("published package surface", () => {
     expect(pkg.scripts.build).toContain("tsc --emitDeclarationOnly");
   });
 
+  // Bundled CJS dependencies call `require("buffer")` — the @smithy/core
+  // event-stream marshaller `stream.ts` uses reaches it through util-utf8. In an
+  // ESM bundle esbuild's `__require` shim throws for those unless a real
+  // `require` is in scope, and the call sites sit inside lazily-initialised CJS
+  // wrappers, so dropping this banner still imports cleanly and only fails when
+  // a stream is actually opened. Nothing else catches that: the suite runs from
+  // src, never from dist.
+  it("gives the bundled CJS graph a real require", () => {
+    expect(pkg.scripts.build).toContain("--banner:js=");
+    expect(pkg.scripts.build).toMatch(/createRequire[^"]*from\s*'node:module'/);
+    expect(pkg.scripts.build).toMatch(/\brequire\s*=\s*\w*[cC]reateRequire\(import\.meta\.url\)/);
+  });
+
   // The bundle keeps pi's packages external, so they must be resolvable in the
   // consumer's tree. Declaring them makes that requirement machine-readable
   // instead of an ERR_MODULE_NOT_FOUND at first import; `optional` keeps npm

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -21,20 +21,33 @@ const pkg = JSON.parse(readFileSync(`${repoRoot}package.json`, "utf8")) as {
 // able to introduce an undeclared host import without failing this test.
 const SRC_FILES = readdirSync(`${repoRoot}src`).filter((f) => f.endsWith(".ts"));
 
+const HOST_SCOPE = "@earendil-works/";
+
 /**
  * `import type` is erased at compile time, so it creates no runtime resolution
  * requirement. Anything else does.
+ *
+ * Matches every import statement regardless of specifier, then filters to host
+ * packages. Anchoring the pattern on the host scope instead would let a single
+ * match straddle statements — its clause may swallow a later `import` — so a
+ * leading `import type { X } from "./local.js"` would hide the host value
+ * import beneath it, and a leading value import would falsely mark a host
+ * type-only import as a runtime one.
  */
 function runtimeHostImports(source: string): string[] {
   const found = new Set<string>();
-  for (const match of source.matchAll(/import\s+(type\s+)?([\s\S]*?)from\s+"(@earendil-works\/[^"]+)"/g)) {
+  for (const match of source.matchAll(/\bimport\s+(type\s+)?([\s\S]*?)\bfrom\s+"([^"]+)"/g)) {
     const [, typeOnlyKeyword, clause, specifier] = match;
-    if (typeOnlyKeyword) continue;
+    if (!specifier.startsWith(HOST_SCOPE) || typeOnlyKeyword) continue;
     // `import { type Api, clampThinkingLevel }` still emits a runtime import;
     // `import { type Api, type Model }` does not.
     const bindings = clause.replace(/[{}]/g, "").split(",");
     const hasValueBinding = bindings.some((b) => b.trim().length > 0 && !b.trim().startsWith("type "));
     if (hasValueBinding || !clause.includes("{")) found.add(specifier);
+  }
+  // Side-effect imports have no clause to inspect and are always runtime.
+  for (const [, specifier] of source.matchAll(/\bimport\s+"([^"]+)"/g)) {
+    if (specifier.startsWith(HOST_SCOPE)) found.add(specifier);
   }
   return [...found];
 }
@@ -90,5 +103,39 @@ describe("runtimeHostImports", () => {
       "@earendil-works/pi-ai",
     ]);
     expect(runtimeHostImports('import * as PiAi from "@earendil-works/pi-ai";')).toEqual(["@earendil-works/pi-ai"]);
+  });
+
+  // The guard exists to fail when a new source file imports an undeclared host
+  // package, so a preceding statement must not be able to hide one.
+  it("detects a host value import beneath a type-only import of another module", () => {
+    const source = ['import type { Foo } from "./foo.js";', 'import { Container } from "@earendil-works/pi-tui";'].join(
+      "\n",
+    );
+    expect(runtimeHostImports(source)).toEqual(["@earendil-works/pi-tui"]);
+  });
+
+  it("detects a multi-line host value import beneath other statements", () => {
+    const source = [
+      'import { readFileSync } from "node:fs";',
+      "import {",
+      "  type Api,",
+      "  clampThinkingLevel,",
+      '} from "@earendil-works/pi-ai";',
+    ].join("\n");
+    expect(runtimeHostImports(source)).toEqual(["@earendil-works/pi-ai"]);
+  });
+
+  it("detects bare side-effect host imports", () => {
+    expect(runtimeHostImports('import "@earendil-works/pi-tui";\nimport { readFileSync } from "node:fs";')).toEqual([
+      "@earendil-works/pi-tui",
+    ]);
+  });
+
+  it("ignores a host type-only import beneath a value import of another module", () => {
+    const source = [
+      'import { readFileSync } from "node:fs";',
+      'import type { Api } from "@earendil-works/pi-ai";',
+    ].join("\n");
+    expect(runtimeHostImports(source)).toEqual([]);
   });
 });

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -1,0 +1,94 @@
+// ABOUTME: Guards the published package surface — entry fields and the pi host
+// ABOUTME: packages the bundle imports rather than bundling must stay declared.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const pkg = JSON.parse(readFileSync(`${repoRoot}package.json`, "utf8")) as {
+  main?: string;
+  types?: string;
+  files?: string[];
+  scripts: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  pi?: { extensions?: string[] };
+};
+
+// Read from disk rather than a hardcoded list: a new source file must not be
+// able to introduce an undeclared host import without failing this test.
+const SRC_FILES = readdirSync(`${repoRoot}src`).filter((f) => f.endsWith(".ts"));
+
+/**
+ * `import type` is erased at compile time, so it creates no runtime resolution
+ * requirement. Anything else does.
+ */
+function runtimeHostImports(source: string): string[] {
+  const found = new Set<string>();
+  for (const match of source.matchAll(/import\s+(type\s+)?([\s\S]*?)from\s+"(@earendil-works\/[^"]+)"/g)) {
+    const [, typeOnlyKeyword, clause, specifier] = match;
+    if (typeOnlyKeyword) continue;
+    // `import { type Api, clampThinkingLevel }` still emits a runtime import;
+    // `import { type Api, type Model }` does not.
+    const bindings = clause.replace(/[{}]/g, "").split(",");
+    const hasValueBinding = bindings.some((b) => b.trim().length > 0 && !b.trim().startsWith("type "));
+    if (hasValueBinding || !clause.includes("{")) found.add(specifier);
+  }
+  return [...found];
+}
+
+describe("published package surface", () => {
+  // Without these a bare-specifier `import "pi-provider-kiro"` cannot resolve at
+  // all: Node falls back to the package root, which is not published.
+  it("publishes a resolvable entry point and types", () => {
+    expect(pkg.main).toBe("./dist/index.js");
+    expect(pkg.types).toBe("./dist/index.d.ts");
+    expect(pkg.files).toContain("dist");
+    expect(pkg.pi?.extensions).toEqual(["./dist/index.js"]);
+  });
+
+  it("emits declarations alongside the bundle", () => {
+    expect(pkg.scripts.build).toContain("tsc --emitDeclarationOnly");
+  });
+
+  // The bundle keeps pi's packages external, so they must be resolvable in the
+  // consumer's tree. Declaring them makes that requirement machine-readable
+  // instead of an ERR_MODULE_NOT_FOUND at first import; `optional` keeps npm
+  // from installing a second copy beside the host's own.
+  it("declares every pi host package the bundle imports at runtime", () => {
+    const imported = new Set<string>();
+    for (const file of SRC_FILES) {
+      for (const specifier of runtimeHostImports(readFileSync(`${repoRoot}src/${file}`, "utf8"))) {
+        imported.add(specifier);
+      }
+    }
+
+    expect(imported.size).toBeGreaterThan(0);
+    for (const specifier of imported) {
+      expect(pkg.peerDependencies ?? {}, `${specifier} is imported but not declared`).toHaveProperty(specifier);
+      expect(pkg.peerDependenciesMeta?.[specifier]?.optional).toBe(true);
+    }
+  });
+
+  it("keeps pi's packages external so the host's own copy is used", () => {
+    for (const specifier of Object.keys(pkg.peerDependencies ?? {})) {
+      expect(pkg.scripts.build).toContain(`--external:${specifier}`);
+    }
+  });
+});
+
+describe("runtimeHostImports", () => {
+  it("ignores type-only imports", () => {
+    expect(runtimeHostImports('import type { Api } from "@earendil-works/pi-ai";')).toEqual([]);
+    expect(runtimeHostImports('import { type Api, type Model } from "@earendil-works/pi-ai";')).toEqual([]);
+  });
+
+  it("detects value imports, including mixed type/value clauses", () => {
+    expect(runtimeHostImports('import { type Api, clampThinkingLevel } from "@earendil-works/pi-ai";')).toEqual([
+      "@earendil-works/pi-ai",
+    ]);
+    expect(runtimeHostImports('import * as PiAi from "@earendil-works/pi-ai";')).toEqual(["@earendil-works/pi-ai"]);
+  });
+});

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -23,6 +23,36 @@ describe("Feature 1: Extension Registration", () => {
     expect(typeof mod.default).toBe("function");
   });
 
+  // Consumers that classify a reason code without an error instance in hand
+  // (a persisted log line, say) need the vocabulary through the package entry
+  // point, not a deep import into src/retry.js.
+  it("exposes Kiro's reason codes and classification predicates from the entry point", async () => {
+    const mod = await import("../src/index.js");
+    const retry = await import("../src/retry.js");
+
+    expect(mod.KIRO_REASON_CODES).toBe(retry.KIRO_REASON_CODES);
+    expect(mod.TOO_BIG_PATTERNS).toBe(retry.TOO_BIG_PATTERNS);
+    expect(mod.NON_RETRYABLE_BODY_PATTERNS).toBe(retry.NON_RETRYABLE_BODY_PATTERNS);
+    expect(mod.CAPACITY_PATTERN).toBe(retry.CAPACITY_PATTERN);
+    expect(mod.isTooBigError).toBe(retry.isTooBigError);
+    expect(mod.isNonRetryableBodyError).toBe(retry.isNonRetryableBodyError);
+    expect(mod.isCapacityError).toBe(retry.isCapacityError);
+  });
+
+  it("keeps predicate behaviour unchanged through the entry point", async () => {
+    const { KIRO_REASON_CODES, isCapacityError, isNonRetryableBodyError, isTooBigError } = await import(
+      "../src/index.js"
+    );
+
+    expect(isTooBigError(413, "")).toBe(true);
+    expect(isTooBigError(400, KIRO_REASON_CODES.CONTENT_LENGTH_EXCEEDS_THRESHOLD)).toBe(true);
+    expect(isTooBigError(400, KIRO_REASON_CODES.REQUEST_BODY_INVALID)).toBe(false);
+    expect(isNonRetryableBodyError(KIRO_REASON_CODES.MONTHLY_REQUEST_COUNT)).toBe(true);
+    expect(isNonRetryableBodyError(KIRO_REASON_CODES.INSUFFICIENT_MODEL_CAPACITY)).toBe(false);
+    expect(isCapacityError(KIRO_REASON_CODES.INSUFFICIENT_MODEL_CAPACITY)).toBe(true);
+    expect(isCapacityError(KIRO_REASON_CODES.MONTHLY_REQUEST_COUNT)).toBe(false);
+  });
+
   it("calls registerProvider with 'kiro'", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -3,13 +3,17 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  CAPACITY_PATTERN,
   exponentialBackoff,
   FIRST_TOKEN_TIMEOUT,
   isCapacityError,
   isNonRetryableBodyError,
   isTooBigError,
+  KIRO_REASON_CODES,
   MAX_RETRY_DELAY,
+  NON_RETRYABLE_BODY_PATTERNS,
   retryConfig,
+  TOO_BIG_PATTERNS,
 } from "../src/retry.js";
 
 describe("exponentialBackoff", () => {
@@ -36,6 +40,42 @@ describe("exponentialBackoff", () => {
 describe("MAX_RETRY_DELAY", () => {
   it("is exported as 10000ms", () => {
     expect(MAX_RETRY_DELAY).toBe(10000);
+  });
+});
+
+describe("KIRO_REASON_CODES", () => {
+  it("exposes the service's codes verbatim", () => {
+    expect(KIRO_REASON_CODES).toEqual({
+      CONTENT_LENGTH_EXCEEDS_THRESHOLD: "CONTENT_LENGTH_EXCEEDS_THRESHOLD",
+      INPUT_TOO_LONG: "Input is too long",
+      MONTHLY_REQUEST_COUNT: "MONTHLY_REQUEST_COUNT",
+      INSUFFICIENT_MODEL_CAPACITY: "INSUFFICIENT_MODEL_CAPACITY",
+      REQUEST_BODY_INVALID: "REQUEST_BODY_INVALID",
+    });
+  });
+
+  it("is frozen so consumers cannot mutate the shared vocabulary", () => {
+    expect(Object.isFrozen(KIRO_REASON_CODES)).toBe(true);
+    expect(Object.isFrozen(TOO_BIG_PATTERNS)).toBe(true);
+    expect(Object.isFrozen(NON_RETRYABLE_BODY_PATTERNS)).toBe(true);
+  });
+
+  it("is the source the pattern lists derive from", () => {
+    expect(TOO_BIG_PATTERNS).toEqual([
+      KIRO_REASON_CODES.CONTENT_LENGTH_EXCEEDS_THRESHOLD,
+      KIRO_REASON_CODES.INPUT_TOO_LONG,
+    ]);
+    expect(NON_RETRYABLE_BODY_PATTERNS).toEqual([KIRO_REASON_CODES.MONTHLY_REQUEST_COUNT]);
+    expect(CAPACITY_PATTERN).toBe(KIRO_REASON_CODES.INSUFFICIENT_MODEL_CAPACITY);
+  });
+
+  // REQUEST_BODY_INVALID is published as vocabulary but must not be a size
+  // marker: treating it as one sends the caller into an unsatisfiable
+  // compaction loop over a history that was never the problem.
+  it("keeps REQUEST_BODY_INVALID out of every classification list", () => {
+    expect(TOO_BIG_PATTERNS).not.toContain(KIRO_REASON_CODES.REQUEST_BODY_INVALID);
+    expect(NON_RETRYABLE_BODY_PATTERNS).not.toContain(KIRO_REASON_CODES.REQUEST_BODY_INVALID);
+    expect(isTooBigError(400, KIRO_REASON_CODES.REQUEST_BODY_INVALID)).toBe(false);
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "declaration": true,
-    "declarationMap": true,
+    // Off deliberately: `files` publishes `dist` only, so declaration maps would
+    // point at `../src/*.ts` paths absent from the tarball — dead maps that
+    // break go-to-definition for consumers instead of helping it.
+    "declarationMap": false,
     "sourceMap": true
   },
   "include": ["src"],


### PR DESCRIPTION
## Problem

The provider's error vocabulary lives as module-private literals in `src/retry.ts`:

```ts
export const TOO_BIG_PATTERNS = ["CONTENT_LENGTH_EXCEEDS_THRESHOLD", "Input is too long"];
const NON_RETRYABLE_BODY_PATTERNS = ["MONTHLY_REQUEST_COUNT"];
const CAPACITY_PATTERN = "INSUFFICIENT_MODEL_CAPACITY";
```

Only `TOO_BIG_PATTERNS` is exported, and none of it reaches `src/index.ts`. These are stable machine reason codes returned by the Kiro API, not prose — but every consumer ends up hardcoding its own copy of the same literals, and those copies drift when the service adds a code. `isTooBigError`, `isNonRetryableBodyError`, and `isCapacityError` are similarly module-local.

## Change

- Collect the codes into one frozen `KIRO_REASON_CODES` record with a `KiroReasonCode` type, and derive `TOO_BIG_PATTERNS`, `NON_RETRYABLE_BODY_PATTERNS`, and `CAPACITY_PATTERN` from it, so there is a single source of truth.
- Re-export the record, the pattern lists, and the three predicates from `src/index.ts`. Predicate behaviour is unchanged.

These are Kiro's own codes, published as-is: no renaming, no new taxonomy, no abstraction layer. Consumers map them to their own semantics.

`REQUEST_BODY_INVALID` is included in the vocabulary but deliberately absent from every classification list. It is a generic request-validation rejection, not a size signal; treating it as one sends the caller into a compaction loop over a history that was never the problem. A test pins that.

## Why

`reasonCode` on a typed error covers the common case. This serves the case where a code must be interpreted with no error instance in hand — classifying a persisted historic log line, for example.

## Packaging fixes (commits 2–6)

Publishing an API only helps if consumers can reach it, and they could not:

- `package.json` had no `main`, `types`, or `exports`, so `import { ... } from "pi-provider-kiro"` resolved to a package-root `index.js` that is never published. Now `main` points at the bundle, `types` at generated declarations, and the build emits them (`tsconfig` already set `declaration: true`; nothing ran it).
- The esbuild ESM bundle could not load outside pi's extension host at all: the bundled CJS chain (`@smithy/core` → `@aws-crypto` → `util-utf8`) calls `require("buffer")`, and esbuild's `__require` shim throws for node builtins when no `require` is in scope. Added the standard `createRequire` banner.
- The declaration emit turned a dormant `declarationMap: true` into 21 published `.d.ts.map` files (84K) pointing at `../src/*.ts`, which `files` never publishes — dead maps that break go-to-definition instead of enabling it. Turned off, with the reason recorded inline. Tarball drops 45 files → 24.
- The bundle keeps pi's packages external, but they were declared only as devDependencies, so a standalone consumer importing the entry point failed at first import with `ERR_MODULE_NOT_FOUND` on `@earendil-works/pi-ai`. All three are now **optional** peerDependencies (`>=0.80.10`) — optional so npm does not install a second copy of pi beside the host's own, and the range is open because pi is a fast-moving 0.x. Verified from a packed tarball that neither a bare install nor one with pi already present hits ERESOLVE. README corrected; it had claimed the host packages are simply always present.

Happy to split the packaging work into its own PR if you'd rather keep this one to the exports.

## Tests

`npm run check`, `npm run lint`, and `npm test` all pass — 333 tests, 19 files. New coverage:

- `test/retry.test.ts` — record contents verbatim, frozen-ness, pattern lists derive from the record, `REQUEST_BODY_INVALID` stays out of classification.
- `test/registration.test.ts` — every symbol reachable through the entry point is the same binding as `src/retry.ts`, and predicate behaviour through the entry point is unchanged.
- `test/packaging.test.ts` — pins the published build contract: `main`, `types`, `files`, `pi.extensions`, the declaration emit, each `--external:` flag, and the `--banner:js` `createRequire` shim (asserting it imports `node:module` **and** binds `require`; a banner that imports `createRequire` without binding it is the same runtime failure). Also pins the invariant that every runtime `@earendil-works/*` import in `src` is both declared as a peer and kept external. The import scan ignores type-only imports, which are erased and create no runtime requirement; it matches per-import-statement so a match cannot straddle statements and hide a host value import behind a preceding type-only one.

Also verified against a packed tarball installed into a scratch project outside the repo tree: bare-specifier import works in plain Node ESM, and consumer `tsc --strict` resolves the exported types.
