### PR TITLE
Stop logging capacity retries to stderr

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -491,7 +491,6 @@ export function streamKiro(
               capacityRetryCount++;
               const delayMs = exponentialBackoff(capacityRetryCount - 1, capacityRetryConfig.baseDelayMs, 30_000);
               const msg = `INSUFFICIENT_MODEL_CAPACITY — retrying in ${delayMs}ms (${capacityRetryCount}/${capacityRetryConfig.maxRetries})`;
-              console.error(`[pi-provider-kiro] ${msg}`);
               logCapacityEvent(msg);
               await abortableDelay(delayMs, options?.signal);
               continue;


### PR DESCRIPTION
Kiro sometimes returns `INSUFFICIENT_MODEL_CAPACITY`, which we already retry. The retry was being printed to stderr, and in pi’s TUI that output can appear on top of the prompt, like you can see here:

<img width="867" height="202" alt="CleanShot 2026-08-07 at 16 46 37" src="https://github.com/user-attachments/assets/750b1f22-f0ee-4027-accb-54d806de759a" />

This change removes the console output so we don't clog the prompt input. The retry behavior stays the same. I didn't think adding tests adds any value.

For comparison, [pi’s Codex provider](https://github.com/earendil-works/pi/blob/8dc78834cde4e329284cf505f9e3f99763df5529/packages/ai/src/api/openai-codex-responses.ts#L350-L400) retries silently.