### PR TITLE
fix: recover XML-dialect tool calls from text

### DIFF
--- a/src/invoke-tool-parser.ts
+++ b/src/invoke-tool-parser.ts
@@ -1,0 +1,176 @@
+// ABOUTME: Extracts XML-dialect tool calls from content text as a fallback.
+// ABOUTME: Parses <invoke name="..."><parameter name="...">value</parameter></invoke> blocks.
+
+export interface InvokeToolCall {
+  toolUseId: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface InvokeParseResult {
+  toolCalls: InvokeToolCall[];
+  cleanedText: string;
+}
+
+const INVOKE_OPEN_ANCHORED = /^<invoke name="([\w-]+)">/;
+const INVOKE_OPEN_SEARCH = "<invoke name=";
+const INVOKE_OPEN_ANYWHERE = /<invoke name="[\w-]+">/;
+const PARAM_OPEN_ANCHORED = /^<parameter name="([^"]*)">/;
+const INVOKE_CLOSE = "</invoke>";
+const PARAM_CLOSE = "</parameter>";
+const FENCE = "```";
+
+interface ParsedBlock {
+  name: string;
+  arguments: Record<string, unknown>;
+  /** Index just past the block's `</invoke>`. */
+  end: number;
+}
+
+/**
+ * Byte ranges covered by an *opened* fenced code block. Fences are counted
+ * pairwise; a trailing unclosed fence extends to end of text. Used to reject
+ * `<invoke>` blocks that appear inside documentation rather than as a real
+ * (misrouted) tool call — model output that discusses this very bug quotes the
+ * dialect verbatim, and executing a command out of a code sample would be
+ * strictly worse than not recovering it.
+ */
+function fencedRanges(text: string): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = [];
+  let searchFrom = 0;
+  while (true) {
+    const open = text.indexOf(FENCE, searchFrom);
+    if (open < 0) break;
+    const close = text.indexOf(FENCE, open + FENCE.length);
+    if (close < 0) {
+      ranges.push({ start: open, end: text.length });
+      break;
+    }
+    ranges.push({ start: open, end: close + FENCE.length });
+    searchFrom = close + FENCE.length;
+  }
+  return ranges;
+}
+
+/** Thrown when a block's markup cannot be attributed unambiguously. */
+class AmbiguousDialectError extends Error {}
+
+/**
+ * Parses one `<invoke>` block starting at `start`, or returns null if the
+ * markup there is not a complete, well-formed block.
+ *
+ * The block end is found structurally — by walking parameters — never by
+ * searching for `</invoke>`. A naive search would stop at a `</invoke>` that
+ * happens to sit inside a parameter value, truncating the value and then
+ * accepting the truncation as if it were the whole argument.
+ *
+ * Strict by design: the body must consist of nothing but whitespace and
+ * well-formed `<parameter name="...">...</parameter>` elements. Any other
+ * content (prose, an ellipsis placeholder, a stray tag) rejects the block,
+ * because a partial parse would either fabricate arguments or half-strip the
+ * text.
+ */
+function parseBlockAt(text: string, start: number): ParsedBlock | null {
+  const openMatch = INVOKE_OPEN_ANCHORED.exec(text.substring(start));
+  if (!openMatch) return null;
+
+  const args: Record<string, unknown> = {};
+  let cursor = start + openMatch[0].length;
+
+  while (true) {
+    const remainder = text.substring(cursor);
+    const leadingWhitespace = remainder.length - remainder.trimStart().length;
+    if (leadingWhitespace > 0) {
+      cursor += leadingWhitespace;
+      continue;
+    }
+    if (text.startsWith(INVOKE_CLOSE, cursor)) {
+      return { name: openMatch[1], arguments: args, end: cursor + INVOKE_CLOSE.length };
+    }
+    const paramMatch = PARAM_OPEN_ANCHORED.exec(text.substring(cursor));
+    if (!paramMatch) return null;
+    const valueStart = cursor + paramMatch[0].length;
+    const valueEnd = text.indexOf(PARAM_CLOSE, valueStart);
+    if (valueEnd < 0) return null;
+    const value = text.substring(valueStart, valueEnd);
+    // A parameter value that itself contains an `<invoke>` open tag makes the
+    // block unattributable: the value's real extent may have been cut short by
+    // a `</parameter>` belonging to the nested markup, and the nested tag would
+    // otherwise be harvested as an independent call. Neither outcome is
+    // acceptable — one corrupts an argument, the other invents a call out of
+    // data — so the whole text is abandoned rather than guessed at.
+    if (INVOKE_OPEN_ANYWHERE.test(value)) throw new AmbiguousDialectError();
+    args[paramMatch[1]] = coerceValue(value);
+    cursor = valueEnd + PARAM_CLOSE.length;
+  }
+}
+
+/**
+ * Parameter values are raw text — multi-line, and freely containing quotes,
+ * newlines, `>` and braces — so they are preserved byte-for-byte. The single
+ * exception is a value whose first non-whitespace character is `[` or `{` and
+ * which parses as JSON: those are structured arguments (array/object-typed
+ * parameters) that the dialect encodes as JSON, and are decoded so the
+ * recovered call matches the tool's schema. Scalars are never coerced, so a
+ * literal `true` or `42` stays the string the model wrote.
+ */
+function coerceValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) return raw;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Recovers tool calls that a model emitted as XML text instead of as structured
+ * tool-use frames. Mirrors {@link parseBracketToolCalls}: returns the recovered
+ * calls plus the text with each consumed `<invoke>` span spliced out. A block
+ * that cannot be parsed in full is left in the text untouched.
+ */
+export function parseInvokeToolCalls(text: string): InvokeParseResult {
+  const toolCalls: InvokeToolCall[] = [];
+  const removals: Array<{ start: number; end: number }> = [];
+  const fences = fencedRanges(text);
+  const untouched: InvokeParseResult = { toolCalls: [], cleanedText: text };
+
+  let cursor = 0;
+  while (cursor < text.length) {
+    const openStart = text.indexOf(INVOKE_OPEN_SEARCH, cursor);
+    if (openStart < 0) break;
+    let block: ParsedBlock | null;
+    try {
+      block = parseBlockAt(text, openStart);
+    } catch (e) {
+      if (e instanceof AmbiguousDialectError) return untouched;
+      throw e;
+    }
+    if (block === null) {
+      cursor = openStart + INVOKE_OPEN_SEARCH.length;
+      continue;
+    }
+    const insideFence = fences.some((r) => openStart >= r.start && openStart < r.end);
+    if (!insideFence) {
+      toolCalls.push({ toolUseId: crypto.randomUUID(), name: block.name, arguments: block.arguments });
+      removals.push({ start: openStart, end: block.end });
+    }
+    // Resume past the whole block: its parameter values are data, not markup.
+    // With the nesting bail above this is belt-and-braces — any value holding a
+    // full open tag has already abandoned the parse — so no test can currently
+    // distinguish it from resuming at the search hit. Kept because it is the
+    // structurally correct resume point, and the bail is the only thing making
+    // the weaker one safe.
+    cursor = block.end;
+  }
+
+  // Splice out consumed spans in reverse order so earlier indices stay valid.
+  let cleanedText = text;
+  for (let i = removals.length - 1; i >= 0; i--) {
+    const { start, end } = removals[i];
+    cleanedText = cleanedText.substring(0, start) + cleanedText.substring(end);
+  }
+
+  return { toolCalls, cleanedText };
+}

--- a/src/invoke-tool-parser.ts
+++ b/src/invoke-tool-parser.ts
@@ -80,13 +80,17 @@ function parseBlockAt(text: string, start: number): ParsedBlock | null {
   while (true) {
     const remainder = text.substring(cursor);
     const leadingWhitespace = remainder.length - remainder.trimStart().length;
-    if (leadingWhitespace > 0) {
-      cursor += leadingWhitespace;
-      continue;
-    }
+    if (leadingWhitespace > 0) cursor += leadingWhitespace;
+
     if (text.startsWith(INVOKE_CLOSE, cursor)) {
-      return { name: openMatch[1], arguments: args, end: cursor + INVOKE_CLOSE.length };
+      const end = cursor + INVOKE_CLOSE.length;
+      // A consumed block must end cleanly. This rejects a literal
+      // `</parameter></invoke>` inside a value: accepting that prefix would
+      // execute a silently truncated command and leave quote/tag debris behind.
+      if (end < text.length && !/\s/.test(text[end])) return null;
+      return { name: openMatch[1], arguments: args, end };
     }
+
     const paramMatch = PARAM_OPEN_ANCHORED.exec(text.substring(cursor));
     if (!paramMatch) return null;
     const valueStart = cursor + paramMatch[0].length;
@@ -94,33 +98,13 @@ function parseBlockAt(text: string, start: number): ParsedBlock | null {
     if (valueEnd < 0) return null;
     const value = text.substring(valueStart, valueEnd);
     // A parameter value that itself contains an `<invoke>` open tag makes the
-    // block unattributable: the value's real extent may have been cut short by
-    // a `</parameter>` belonging to the nested markup, and the nested tag would
-    // otherwise be harvested as an independent call. Neither outcome is
-    // acceptable — one corrupts an argument, the other invents a call out of
-    // data — so the whole text is abandoned rather than guessed at.
+    // block unattributable: nested markup could otherwise be harvested as a
+    // call the model never made.
     if (INVOKE_OPEN_ANYWHERE.test(value)) throw new AmbiguousDialectError();
-    args[paramMatch[1]] = coerceValue(value);
+    // Values in this dialect are raw text, not JSON. Preserve every byte:
+    // parsing or trimming can silently change a command that will be executed.
+    args[paramMatch[1]] = value;
     cursor = valueEnd + PARAM_CLOSE.length;
-  }
-}
-
-/**
- * Parameter values are raw text — multi-line, and freely containing quotes,
- * newlines, `>` and braces — so they are preserved byte-for-byte. The single
- * exception is a value whose first non-whitespace character is `[` or `{` and
- * which parses as JSON: those are structured arguments (array/object-typed
- * parameters) that the dialect encodes as JSON, and are decoded so the
- * recovered call matches the tool's schema. Scalars are never coerced, so a
- * literal `true` or `42` stays the string the model wrote.
- */
-function coerceValue(raw: string): unknown {
-  const trimmed = raw.trim();
-  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) return raw;
-  try {
-    return JSON.parse(trimmed) as unknown;
-  } catch {
-    return raw;
   }
 }
 
@@ -140,6 +124,12 @@ export function parseInvokeToolCalls(text: string): InvokeParseResult {
   while (cursor < text.length) {
     const openStart = text.indexOf(INVOKE_OPEN_SEARCH, cursor);
     if (openStart < 0) break;
+    const containingFence = fences.find((range) => openStart >= range.start && openStart < range.end);
+    if (containingFence) {
+      cursor = containingFence.end;
+      continue;
+    }
+
     let block: ParsedBlock | null;
     try {
       block = parseBlockAt(text, openStart);
@@ -147,15 +137,20 @@ export function parseInvokeToolCalls(text: string): InvokeParseResult {
       if (e instanceof AmbiguousDialectError) return untouched;
       throw e;
     }
-    if (block === null) {
-      cursor = openStart + INVOKE_OPEN_SEARCH.length;
-      continue;
-    }
-    const insideFence = fences.some((r) => openStart >= r.start && openStart < r.end);
-    if (!insideFence) {
-      toolCalls.push({ toolUseId: crypto.randomUUID(), name: block.name, arguments: block.arguments });
-      removals.push({ start: openStart, end: block.end });
-    }
+    // A malformed opener can enclose later valid-looking markup as argument
+    // data. Without a structural end, independence cannot be proven; abandon
+    // all recovery rather than execute an embedded call.
+    if (block === null) return untouched;
+
+    // If apparent block end truncated a raw value containing closing-tag text,
+    // real outer closers remain later in prose. Never execute that prefix.
+    const nextOpen = text.indexOf(INVOKE_OPEN_SEARCH, block.end);
+    const interstitialEnd = nextOpen < 0 ? text.length : nextOpen;
+    const interstitial = text.substring(block.end, interstitialEnd);
+    if (interstitial.includes(PARAM_CLOSE) || interstitial.includes(INVOKE_CLOSE)) return untouched;
+
+    toolCalls.push({ toolUseId: crypto.randomUUID(), name: block.name, arguments: block.arguments });
+    removals.push({ start: openStart, end: block.end });
     // Resume past the whole block: its parameter values are data, not markup.
     // With the nesting bail above this is belt-and-braces — any value holding a
     // full open tag has already abandoned the parse — so no test can currently

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -37,6 +37,7 @@ import {
   prepareHistory,
 } from "./history.js";
 import { isKiroToolStructureRule, kiroConversationEntries, repairKiroConversation } from "./history-validator.js";
+import { parseInvokeToolCalls } from "./invoke-tool-parser.js";
 import { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, refreshViaKiroCli } from "./kiro-cli.js";
 import {
   invalidateKiroProfileArn,
@@ -894,14 +895,30 @@ export function streamKiro(
           thinkingParser.finalize();
           textBlockIndex = thinkingParser.getTextBlockIndex();
         }
-        // Fallback: extract bracket-style tool calls from content if no native tool calls
+        // Fallback: extract text-dialect tool calls from content if no native
+        // tool calls arrived. Two dialects are recovered at this seam:
+        //   1. Kiro's own `[Called name with args: {...}]` bracket form.
+        //   2. Anthropic's `<invoke name="..."><parameter .../></invoke>` XML
+        //      form, which opus-class models emit as plain text at high context.
+        // Without this, the turn ends `stopReason:"stop"` with zero tool calls —
+        // the agent loop sees a finished answer and an unattended session stalls
+        // indefinitely with no error recorded anywhere.
         if (!sawAnyToolCalls && textBlockIndex !== null) {
           const textBlock = output.content[textBlockIndex] as TextContent;
+          const recovered: Array<{ toolUseId: string; name: string; arguments: Record<string, unknown> }> = [];
           const bracketResult = parseBracketToolCalls(textBlock.text);
           if (bracketResult.toolCalls.length > 0) {
-            sawAnyToolCalls = true;
             textBlock.text = bracketResult.cleanedText;
-            for (const btc of bracketResult.toolCalls) {
+            recovered.push(...bracketResult.toolCalls);
+          }
+          const invokeResult = parseInvokeToolCalls(textBlock.text);
+          if (invokeResult.toolCalls.length > 0) {
+            textBlock.text = invokeResult.cleanedText;
+            recovered.push(...invokeResult.toolCalls);
+          }
+          if (recovered.length > 0) {
+            sawAnyToolCalls = true;
+            for (const btc of recovered) {
               if (
                 emitToolCall(
                   {

--- a/test/helpers/invoke-fixture.ts
+++ b/test/helpers/invoke-fixture.ts
@@ -1,0 +1,32 @@
+// ABOUTME: Byte-exact fixture of the observed XML-dialect tool-call leak.
+// ABOUTME: Shared by invoke-tool-parser and stream end-to-end regressions.
+
+/**
+ * Verbatim leak payload from
+ * `~/.kermes/sessions/b72e20b9a9e8/kanban-task-1786606873-6ee4-merge-2.jsonl`
+ * record 279 — an assistant record with `stopReason: "stop"`, zero `toolCall`
+ * blocks, and this text. The command embeds single quotes, double quotes, a `>`
+ * redirect and a multi-line `python3 -c` program, so byte-exact preservation is
+ * the regression that matters most: a corrupted recovery would *execute*
+ * something the model never wrote, which is worse than not recovering at all.
+ */
+export const RECORD_279_COMMAND = `cd /workplace/sauhsoj/kermes/worktrees/happy-toucan/src/KermesAgent && timeout 120 mcscli curl -s -L 'https://code.amazon.com/reviews/CR-296790373/revisions/1?format=json' 2>/dev/null > /tmp/cr3.json; python3 -c "
+import json
+d=json.load(open('/tmp/cr3.json'))
+r=d['revision']['cr_revision']
+desc=r.get('description') or ''
+local=open('.agents/scratchpad/cr-description.md').read()
+print('remote desc bytes:', len(desc.encode()))
+print('local  desc bytes:', len(local.encode()))
+print('IDENTICAL:', desc==local)
+print('glued bullets remote:', desc.count(';- '))
+print('status:', r.get('status'), '| diff_source:', json.dumps(r.get('diff_source')))
+print('summary:', r.get('summary'))
+"`;
+
+export const RECORD_279_SUMMARY = "read back description to confirm the fix landed";
+
+export const RECORD_279_TEXT = `<invoke name="shell">
+<parameter name="command">${RECORD_279_COMMAND}</parameter>
+<parameter name="summary">${RECORD_279_SUMMARY}</parameter>
+</invoke>`;

--- a/test/invoke-tool-parser.test.ts
+++ b/test/invoke-tool-parser.test.ts
@@ -1,0 +1,238 @@
+// ABOUTME: Tests for XML-dialect tool call extraction from content text.
+// ABOUTME: Validates <invoke name="..."><parameter name="...">…</parameter></invoke> parsing.
+
+import { describe, expect, it } from "vitest";
+import { parseInvokeToolCalls } from "../src/invoke-tool-parser.js";
+import { RECORD_279_COMMAND, RECORD_279_SUMMARY, RECORD_279_TEXT } from "./helpers/invoke-fixture.js";
+
+describe("parseInvokeToolCalls", () => {
+  it("extracts a single invoke with one parameter and cleans the text", () => {
+    const text = 'Running it now.\n<invoke name="shell">\n<parameter name="command">ls -la</parameter>\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe("shell");
+    expect(result.toolCalls[0].arguments).toEqual({ command: "ls -la" });
+    expect(result.cleanedText).toBe("Running it now.\n");
+  });
+
+  it("preserves a multi-line parameter value byte-for-byte (record 279)", () => {
+    const result = parseInvokeToolCalls(RECORD_279_TEXT);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe("shell");
+    // Byte-identical, not merely equivalent: no unescaping, no whitespace
+    // normalization, no entity decoding anywhere along the path.
+    expect(result.toolCalls[0].arguments.command).toBe(RECORD_279_COMMAND);
+    expect(result.toolCalls[0].arguments.summary).toBe(RECORD_279_SUMMARY);
+    expect(String(result.toolCalls[0].arguments.command)).toContain("2>/dev/null > /tmp/cr3.json");
+    expect(String(result.toolCalls[0].arguments.command).split("\n")).toHaveLength(13);
+    expect(result.cleanedText).toBe("");
+  });
+
+  it("preserves leading and trailing whitespace inside a parameter value", () => {
+    // Trimming looks harmless and is a no-op on the record 279 fixture, but it
+    // silently corrupts payloads whose edges are significant — a heredoc body,
+    // an indented patch, a file whose final newline matters. Pinned explicitly
+    // so the byte-exactness contract is not merely incidental to one fixture.
+    const value = "\n  cat <<'EOF' > /tmp/x\n    indented\nEOF\n\n";
+    const text = `<invoke name="shell">\n<parameter name="command">${value}</parameter>\n</invoke>`;
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments.command).toBe(value);
+  });
+
+  it("handles multiple parameters whose values contain > and }", () => {
+    const text =
+      '<invoke name="shell">\n' +
+      '<parameter name="command">echo "{a: 1}" > /tmp/x.json && test 3 -gt 2</parameter>\n' +
+      '<parameter name="summary">write {} and > safely</parameter>\n' +
+      "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments).toEqual({
+      command: 'echo "{a: 1}" > /tmp/x.json && test 3 -gt 2',
+      summary: "write {} and > safely",
+    });
+  });
+
+  it("extracts two invoke blocks from one text block", () => {
+    const text =
+      '<invoke name="read">\n<parameter name="path">a.txt</parameter>\n</invoke>\n' +
+      'then\n<invoke name="task_comment">\n<parameter name="id">t-1</parameter>\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0].name).toBe("read");
+    expect(result.toolCalls[1].name).toBe("task_comment");
+    expect(result.toolCalls[1].arguments).toEqual({ id: "t-1" });
+    expect(result.cleanedText).toBe("\nthen\n");
+  });
+
+  it("decodes a JSON array parameter value to a real array", () => {
+    // Array-typed params (e.g. ReadInternalWebsites.inputs) are JSON-encoded in
+    // the dialect; observed in the corpus. Decoded so the recovered call matches
+    // the tool schema instead of failing validation on a stringified array.
+    const text =
+      '<invoke name="ReadInternalWebsites">\n' +
+      '<parameter name="inputs">["https://code.amazon.com/reviews/CR-1"]</parameter>\n' +
+      "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls[0].arguments.inputs).toEqual(["https://code.amazon.com/reviews/CR-1"]);
+  });
+
+  it("does not coerce scalar-looking values", () => {
+    // `true` is a real shell command; `42` could be a literal string argument.
+    const text =
+      '<invoke name="shell">\n' +
+      '<parameter name="command">true</parameter>\n' +
+      '<parameter name="timeout">42</parameter>\n' +
+      "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls[0].arguments).toEqual({ command: "true", timeout: "42" });
+  });
+
+  it("keeps a JSON-looking-but-invalid value as raw text", () => {
+    const text = '<invoke name="shell">\n<parameter name="command">{not json</parameter>\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls[0].arguments).toEqual({ command: "{not json" });
+  });
+
+  it("abandons the text when a parameter value contains nested invoke markup", () => {
+    // The dangerous shape: a legitimate call whose argument *contains* the
+    // dialect as data — a command that greps for it, or writes a test fixture
+    // containing it. Two defects lurk here. A `</parameter>` belonging to the
+    // nested markup can cut the outer value short, so the outer call would run
+    // a truncated command; and the nested tag would be harvested as a second,
+    // independent call that the model never asked for. Neither is acceptable,
+    // and the correct extent is genuinely unknowable, so nothing is recovered
+    // and the text is left whole for a human to act on.
+    const text =
+      '<invoke name="shell">\n' +
+      '<parameter name="command">printf \'<invoke name="shell">' +
+      '<parameter name="command">rm -rf /</parameter></invoke>\' > sample.txt</parameter>\n' +
+      '<parameter name="summary">write a doc sample</parameter>\n' +
+      "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("never harvests an embedded call as an independent tool call", () => {
+    // Narrower probe on the second half of the defect: even if the outer block
+    // were somehow discarded, the embedded `rm -rf /` must not survive as a
+    // recovered call.
+    const text =
+      '<invoke name="shell">\n' +
+      '<parameter name="command">echo \'<invoke name="shell">' +
+      '<parameter name="command">rm -rf /</parameter></invoke>\'</parameter>\n' +
+      "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls.map((t) => t.arguments.command)).not.toContain("rm -rf /");
+    expect(result.toolCalls).toHaveLength(0);
+  });
+
+  it("recovers a value that contains a bare closing invoke tag", () => {
+    // `</invoke>` alone in a value is unambiguous: the block end is found by
+    // walking parameters, not by searching for the closing tag, so this stays
+    // recoverable and byte-exact.
+    const command = "grep -rn '</invoke>' src/";
+    const text = `<invoke name="shell">\n<parameter name="command">${command}</parameter>\n</invoke>`;
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments.command).toBe(command);
+    expect(result.cleanedText).toBe("");
+  });
+
+  it("recovers a value containing an invoke open tag that is not the full dialect", () => {
+    // A grep for the tag prefix is not nested markup — no quoted name, no
+    // close — so it must not trip the ambiguity bail.
+    const command = `grep -rn '<invoke name=' src/`;
+    const text = `<invoke name="shell">\n<parameter name="command">${command}</parameter>\n</invoke>`;
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments.command).toBe(command);
+  });
+
+  it("leaves text untouched for an unterminated invoke", () => {
+    const text = '<invoke name="shell">\n<parameter name="command">ls</parameter>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("leaves text untouched for an unterminated parameter", () => {
+    const text = '<invoke name="shell">\n<parameter name="command">ls\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("rejects an invoke whose body holds anything but parameters", () => {
+    // Never half-strip: a body with prose in it is not a call we can faithfully
+    // reconstruct, so the whole block is left alone.
+    const text = '<invoke name="shell">\nrun something clever\n<parameter name="command">ls</parameter>\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("recovers a zero-parameter invoke", () => {
+    const text = '<invoke name="mcp">\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments).toEqual({});
+  });
+
+  it("emits an unknown tool name verbatim without validating it", () => {
+    // Same contract as parseBracketToolCalls: the parser has no tool registry.
+    // An unknown name becomes a toolCall and the agent loop reports the error,
+    // which is strictly better than a silent stall.
+    const text = '<invoke name="not_a_real_tool">\n<parameter name="x">1</parameter>\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe("not_a_real_tool");
+  });
+
+  it("ignores an invoke inside a fenced code block", () => {
+    // Documentation about this very bug quotes the dialect verbatim — three
+    // such records exist in the session corpus that motivated this parser.
+    // Executing a command out of a code sample is worse than not recovering,
+    // so fenced regions are excluded.
+    const text = ["Here is the leak shape:", "```", RECORD_279_TEXT, "```", "Want me to file a card?"].join("\n");
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("ignores an invoke after an unclosed fence", () => {
+    const text = `Example:\n\`\`\`\n${RECORD_279_TEXT}`;
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("still recovers an unfenced invoke that follows a closed code block", () => {
+    const text = `Here is the log:\n\`\`\`\nsome output\n\`\`\`\n${RECORD_279_TEXT}`;
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments.command).toBe(RECORD_279_COMMAND);
+  });
+
+  it("returns empty for text with no invoke blocks", () => {
+    const text = "Just prose mentioning parameters and invocations.";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("handles empty text", () => {
+    const result = parseInvokeToolCalls("");
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe("");
+  });
+
+  it("assigns unique toolUseIds to each recovered call", () => {
+    const text = '<invoke name="a">\n</invoke>\n<invoke name="b">\n</invoke>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0].toolUseId).not.toBe(result.toolCalls[1].toolUseId);
+  });
+});

--- a/test/invoke-tool-parser.test.ts
+++ b/test/invoke-tool-parser.test.ts
@@ -66,16 +66,18 @@ describe("parseInvokeToolCalls", () => {
     expect(result.cleanedText).toBe("\nthen\n");
   });
 
-  it("decodes a JSON array parameter value to a real array", () => {
-    // Array-typed params (e.g. ReadInternalWebsites.inputs) are JSON-encoded in
-    // the dialect; observed in the corpus. Decoded so the recovered call matches
-    // the tool schema instead of failing validation on a stringified array.
-    const text =
-      '<invoke name="ReadInternalWebsites">\n' +
-      '<parameter name="inputs">["https://code.amazon.com/reviews/CR-1"]</parameter>\n' +
-      "</invoke>";
+  it("preserves a JSON-looking parameter value as raw text", () => {
+    const value = '["https://code.amazon.com/reviews/CR-1"]';
+    const text = `<invoke name="ReadInternalWebsites">\n<parameter name="inputs">${value}</parameter>\n</invoke>`;
     const result = parseInvokeToolCalls(text);
-    expect(result.toolCalls[0].arguments.inputs).toEqual(["https://code.amazon.com/reviews/CR-1"]);
+    expect(result.toolCalls[0].arguments.inputs).toBe(value);
+  });
+
+  it("preserves a JSON object parameter including edge whitespace", () => {
+    const value = '  {"path":"a.txt","content":"x"}\n';
+    const text = `<invoke name="write">\n<parameter name="args">${value}</parameter>\n</invoke>`;
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls[0].arguments.args).toBe(value);
   });
 
   it("does not coerce scalar-looking values", () => {
@@ -129,6 +131,24 @@ describe("parseInvokeToolCalls", () => {
     expect(result.toolCalls).toHaveLength(0);
   });
 
+  it("leaves text untouched when a value contains ambiguous parameter markup", () => {
+    const text =
+      '<invoke name="shell">\n' + "<parameter name=\"command\">printf '</parameter>'</parameter>\n" + "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
+  it("leaves text untouched when a value contains a complete invoke closing sequence", () => {
+    const text =
+      '<invoke name="shell">\n' +
+      "<parameter name=\"command\">printf '</parameter></invoke>'</parameter>\n" +
+      "</invoke>";
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
+  });
+
   it("recovers a value that contains a bare closing invoke tag", () => {
     // `</invoke>` alone in a value is unambiguous: the block end is found by
     // walking parameters, not by searching for the closing tag, so this stays
@@ -149,6 +169,16 @@ describe("parseInvokeToolCalls", () => {
     const result = parseInvokeToolCalls(text);
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolCalls[0].arguments.command).toBe(command);
+  });
+
+  it("abandons all recovery when malformed markup precedes a valid-looking invoke", () => {
+    const text =
+      '<invoke name="shell">\n' +
+      '<parameter name="command">printf \'<invoke name="shell">' +
+      '<parameter name="command">rm -rf /</parameter></invoke>\'</parameter>';
+    const result = parseInvokeToolCalls(text);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.cleanedText).toBe(text);
   });
 
   it("leaves text untouched for an unterminated invoke", () => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -16,6 +16,7 @@ import { capacityRetryConfig, retryConfig } from "../src/retry.js";
 import { resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
 import { concatMessages, encodeEventMessage } from "./helpers/event-stream.js";
+import { RECORD_279_COMMAND, RECORD_279_SUMMARY, RECORD_279_TEXT } from "./helpers/invoke-fixture.js";
 
 const ts = Date.now();
 const zeroUsage = {
@@ -3347,6 +3348,107 @@ describe("Feature 9: Streaming Integration", () => {
     const toolCalls = msg?.content.filter((b) => b.type === "toolCall");
     expect(toolCalls).toHaveLength(1);
     expect(toolCalls?.[0].type === "toolCall" && toolCalls?.[0].name).toBe("bash");
+
+    vi.unstubAllGlobals();
+  });
+
+  // =========================================================================
+  // XML-dialect tool call recovery (<invoke name="...">)
+  // =========================================================================
+
+  it("recovers an XML-dialect tool call and returns stopReason toolUse (record 279)", async () => {
+    // Reproduces the observed stall: the model emitted its shell call as text in
+    // Anthropic's XML function-calling dialect, so the turn ended
+    // stopReason:"stop" with zero toolCall blocks and the agent loop parked at
+    // the prompt. The assertion that matters is the stopReason flip — that is
+    // what keeps an unattended session moving.
+    const mockFetch = mockFetchOk(`${JSON.stringify({ content: RECORD_279_TEXT })}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+
+    const toolCalls = msg?.content.filter((b) => b.type === "toolCall");
+    expect(toolCalls).toHaveLength(1);
+    const call = toolCalls?.[0];
+    expect(call?.type === "toolCall" && call.name).toBe("shell");
+    // Byte-exact all the way through JSON.stringify → emitToolCall → JSON.parse.
+    expect(call?.type === "toolCall" && call.arguments.command).toBe(RECORD_279_COMMAND);
+    expect(call?.type === "toolCall" && call.arguments.summary).toBe(RECORD_279_SUMMARY);
+
+    const textBlock = msg?.content.find((b) => b.type === "text");
+    expect(textBlock?.type === "text" && textBlock.text).not.toContain("<invoke name=");
+
+    // The fix: "stop" would stall the agent loop; "toolUse" continues it.
+    expect(done?.type === "done" && done.reason).toBe("toolUse");
+    expect(msg?.stopReason).toBe("toolUse");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("recovers XML-dialect calls split across stream chunks", async () => {
+    // The dialect arrives as ordinary content deltas, so a tag can straddle a
+    // chunk boundary. Recovery runs on the assembled text block, after the
+    // stream ends, so boundaries must not matter.
+    const mid = Math.floor(RECORD_279_TEXT.length / 2);
+    const mockFetch = mockFetchChunked([
+      JSON.stringify({ content: RECORD_279_TEXT.slice(0, mid) }),
+      JSON.stringify({ content: RECORD_279_TEXT.slice(mid) }),
+      '{"contextUsagePercentage":10}',
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    const toolCalls = msg?.content.filter((b) => b.type === "toolCall");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls?.[0].type === "toolCall" && toolCalls?.[0].arguments.command).toBe(RECORD_279_COMMAND);
+    expect(done?.type === "done" && done.reason).toBe("toolUse");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not recover XML-dialect calls when native tool calls exist", async () => {
+    const toolPayload = '{"name":"bash","toolUseId":"tc1","input":"{\\"cmd\\":\\"ls\\"}","stop":true}';
+    const mockFetch = mockFetchOk(
+      `${JSON.stringify({ content: RECORD_279_TEXT })}${toolPayload}{"contextUsagePercentage":10}`,
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    const toolCalls = msg?.content.filter((b) => b.type === "toolCall");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls?.[0].type === "toolCall" && toolCalls?.[0].name).toBe("bash");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves prose that merely quotes the dialect alone", async () => {
+    // Model output analysing this bug quotes the dialect inside a code fence.
+    // Recovering from that would execute a command out of documentation.
+    const prose = ["The leak looks like:", "```", RECORD_279_TEXT, "```", "Want me to file a card?"].join("\n");
+    const mockFetch = mockFetchOk(`${JSON.stringify({ content: prose })}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg?.content.filter((b) => b.type === "toolCall")).toHaveLength(0);
+    const textBlock = msg?.content.find((b) => b.type === "text");
+    expect(textBlock?.type === "text" && textBlock.text).toBe(prose);
+    expect(done?.type === "done" && done.reason).toBe("stop");
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Summary

- recover Anthropic `<invoke name="...">` tool calls emitted as assistant text when no native `toolUse` arrived
- preserve raw parameter bodies byte-for-byte and fail closed on malformed, nested, fenced, or ambiguous markup
- remove consumed XML text and reuse existing `emitToolCall` path so completed turns return `stopReason: "toolUse"` instead of stalling with `"stop"`

## Evidence

Observed corpus: 12 assistant records, all `kiro/claude-opus-5`, `stopReason: "stop"`, zero structured tool calls, text beginning with `<invoke name="...">`. One record re-emitted identical command as native tool call after manual `continue` and succeeded.

- `npm run check` — pass
- `npm run lint` — pass, 51 files
- `npm test` — pass, 20 files / 429 tests
- `npm run build` — pass
- mutation probe: deleting `<invoke>` fallback arm makes record-279 end-to-end test fail with zero recovered tool calls
- second-model review after safety hardening — no findings

Fork-internal CI run will be linked after completion because upstream fork PR workflows require maintainer approval (`action_required`).

## Safety / scope

- existing `!sawAnyToolCalls && textBlockIndex !== null` gate unchanged
- unknown tool names follow existing bracket fallback behavior
- fenced examples remain prose; malformed/ambiguous blocks remain untouched
- no history serialization/prevention changes
- no Kermes stopgap bundle patch: parser addition is poor fit for string replacement; upstream release should carry fix
