### PR TITLE
fix(region): map sa-east-1 to Kiro API region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Route IAM Identity Center sessions from `sa-east-1` to Kiro's `us-east-1` API region, avoiding catalog refresh requests to the unsupported `management.sa-east-1.kiro.dev` endpoint.
 - Preserve every literal `<thinking>`, `<think>`, `<reasoning>`, or `<thought>` region in one streamed response as its own thinking block instead of leaking every region after the first into visible assistant text.
 - Keep parsed thinking blocks in the order the wire delivered them instead of splicing them ahead of text already emitted. The parser moved a thinking block into the index of an existing text block to make the content array read thinking → text, which made the persisted array contradict the stream and reused one `contentIndex` for two different blocks — an index-addressed consumer such as pi-mono's proxy transport overwrote the text it had already placed and then threw on the following `text_end`. Empty tagged regions are still materialized. Presentation order is unaffected: outbound history still prepends every thinking block, and renderers drive thinking from stream events.
 

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Keeps management and runtime host selection independent from request URLs.
 
 const API_REGION_MAP: Record<string, string> = {
+  "sa-east-1": "us-east-1",
   "us-west-1": "us-east-1",
   "us-west-2": "us-east-1",
   "us-east-2": "us-east-1",

--- a/src/login.ts
+++ b/src/login.ts
@@ -48,6 +48,7 @@ const IDC_PROBE_REGIONS = [
   "eu-west-2", // SSO region → eu-central-1 API
   "eu-west-3", // SSO region → eu-central-1 API
   "eu-north-1", // SSO region → eu-central-1 API
+  "sa-east-1", // SSO region → us-east-1 API
   "ap-southeast-1",
   "ap-northeast-1",
   "us-west-2",

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -110,6 +110,7 @@ describe("Feature 2: Model Definitions", () => {
       ["us-east-2", "us-east-1"],
       ["eu-west-1", "eu-central-1"],
       ["ap-southeast-2", "us-east-1"],
+      ["sa-east-1", "us-east-1"],
       ["us-east-1", "us-east-1"],
       [undefined, "us-east-1"],
     ])("maps %s to %s", (ssoRegion, apiRegion) => {


### PR DESCRIPTION
## Problem

IAM Identity Center credentials can carry `sa-east-1` as the SSO region while the Kiro profile is hosted in `us-east-1`. The provider passed `sa-east-1` through unchanged because it was missing from `API_REGION_MAP`, then attempted catalog discovery against `management.sa-east-1.kiro.dev`.

Kiro management endpoints are available in the canonical commercial regions, so this produced the startup warning:

`Kiro management ListAvailableProfiles request failed in sa-east-1`

## Fix

- Map `sa-east-1` to the Kiro API region `us-east-1` in `resolveApiRegion`.
- Include `sa-east-1` in IAM Identity Center region auto-detection, keeping the probe list aligned with the region map.
- Add a regression test for the region conversion.

This is separate from the existing profile-region fallback work: that handles an endpoint returning an empty profile list, while this fix prevents requests from being sent to an unsupported regional host in the first place.

## Verification

- `npm run check`
- `npm run lint`
- `npm test` — 448 tests passed
- `npm run build`
