### PR TITLE
feat: re-export KiroManagementHttpError from the package index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve every literal `<thinking>`, `<think>`, `<reasoning>`, or `<thought>` region in one streamed response as its own thinking block instead of leaking every region after the first into visible assistant text.
 - Keep parsed thinking blocks in the order the wire delivered them instead of splicing them ahead of text already emitted. The parser moved a thinking block into the index of an existing text block to make the content array read thinking → text, which made the persisted array contradict the stream and reused one `contentIndex` for two different blocks — an index-addressed consumer such as pi-mono's proxy transport overwrote the text it had already placed and then threw on the following `text_end`. Empty tagged regions are still materialized. Presentation order is unaffected: outbound history still prepends every thinking block, and renderers drive thinking from stream events.
 
+### Added
+
+- The entry module now re-exports `KiroManagementHttpError`. The class already shipped in 0.10.0 and is thrown by every management-plane request that returns a non-OK status (profile discovery, model catalog, usage limits) and already caught in `stream.ts`, where a 403 drives the credential-refresh retry — but it was not re-exported from `src/index.ts`, and there is no per-module file to deep-import instead: the build bundles the whole graph into one `dist/index.js`, and the published 0.10.0 tarball contains exactly `dist/index.js`, `package.json`, and `README.md`. Whatever `dist/index.js` re-exports is therefore the entire reachable surface, so a consumer wanting to branch on this error was left string-matching `error.name` or the message prose. No behaviour change and no new API: the class, its `status` field, and every throw and catch site are unchanged. Same entry-point caveat as the 0.10.0 re-exports below — this is the extension entry the pi host loads, not a resolvable npm entry point.
+
 ## [0.10.0] - 2026-08-16
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {
   validateKiroConversation,
   validateKiroToolStructure,
 } from "./history-validator.js";
+export { KiroManagementHttpError } from "./management.js";
 export { KIRO_MODEL_IDS, kiroModels, resolveKiroModel } from "./models.js";
 export { streamKiro } from "./stream.js";
 export {

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -267,4 +267,16 @@ describe("Feature 1: Extension Registration", () => {
     expect(mod.SYNTHETIC_FAILED_TOOL_RESULT_TEXT).toBe("Tool use was interrupted and did not produce a result.");
     expect(mod.EMPTY_CONTENT_PLACEHOLDER).toBe("Please proceed with the task.");
   });
+
+  // Same entry-module caveat as above: this pins that the symbol leaves this
+  // module, so a consumer can `instanceof` the error the provider already
+  // throws from every management-plane request that returns a non-OK status.
+  // There is no per-module alternative — the build bundles everything into one
+  // `dist/index.js`, so what this module re-exports is the whole reachable
+  // surface and the fallback was string-matching `error.name` or the message.
+  it("re-exports KiroManagementHttpError from the entry module", async () => {
+    const mod = await import("../src/index.js");
+    const { KiroManagementHttpError } = await import("../src/management.js");
+    expect(mod.KiroManagementHttpError).toBe(KiroManagementHttpError);
+  });
 });


### PR DESCRIPTION
## What

One line in `src/index.ts`:

```ts
export { KiroManagementHttpError } from "./management.js";
```

plus one assertion in the existing entry-module surface test in
`test/registration.test.ts`, and a CHANGELOG entry under
`Unreleased -> Added` (the same place 0.10.0 documented the analogous
history-validator re-exports).

## Why

`KiroManagementHttpError` already ships in 0.10.0. It is thrown by every
management-plane request that returns a non-OK status -- profile discovery,
model catalog, and usage limits all funnel through
`parseManagementResponse` -- and it is already caught in `src/stream.ts`,
where `error instanceof KiroManagementHttpError && error.status === 403`
drives the token-refresh retry. But the entry module never re-exported it.

There is no per-module file a consumer could import instead. `npm run
build` bundles the whole graph into a single `dist/index.js`, and the
published 0.10.0 tarball contains exactly three entries: `dist/index.js`,
`package.json`, and `README.md`. So whatever `dist/index.js` re-exports is
the entire reachable surface of this package, and a consumer that wants to
branch on this error is left string-matching `error.name` or the message
prose against a class the provider already has in hand.

This closes that gap for a class that is already part of shipped
behaviour.

## Not in scope

No behaviour change and no new API. The class, its `status` field, and
every throw and catch site are untouched -- this only makes the existing
class reachable from the entry module. `management.ts` is not modified.

Same entry-point caveat as the 0.10.0 re-exports: this is the extension
entry the pi host loads via `pi.extensions`, not a resolvable npm entry
point, since `package.json` declares no `main`/`exports`/`types`.

## Validation

- `npm run check` -- clean (both tsconfigs)
- `npx biome check .` -- 51 files, no fixes applied
- `npm test` -- 448 passed / 20 files. Baseline on `main` measured in the
  same worktree by checking out `origin/main`'s `src/index.ts` and
  `test/registration.test.ts`: 447 / 20. The +1 is the new assertion.
- `npm run build` -- emits `dist/index.js`, and the symbol appears in the
  bundle's final `export { ... }` block.
- Mutation probe: deleting the new export line reds the new spec
  (1 failed / 18 passed) and also reds `tsc --noEmit -p tsconfig.test.json`
  with TS2339; restoring it byte-identically (verified by sha256) returns
  19 passed.
- Bundle diff for the no-behaviour-change claim: rebuilt `origin/main`'s
  `src/index.ts` through the same esbuild command and diffed the two
  bundles. Exactly two lines differ -- `KiroManagementHttpError,` in the
  final export block, and one extra `init_management();` in the index init
  block. The latter is inert: `init_management` already runs from three
  earlier init blocks and esbuild's `__esm` wrapper clears its factory on
  first call, so repeat invocations return the memoized namespace.

Note on the runtime check: `import("./dist/index.js")` fails on `main`
today with `Dynamic require of "buffer" is not supported` (esbuild's ESM
`__require` shim meeting a CommonJS path under `@smithy/core`). That is
pre-existing and unrelated -- it reproduces after checking out unmodified
`origin/main:src/index.ts` and rebuilding, and it also reproduces against
the published 0.10.0 tarball straight off the registry. To verify the
export actually resolves at runtime I rebuilt the same entry with a
`createRequire` banner and imported it: `typeof KiroManagementHttpError`
is `function`, `.name` is `"KiroManagementHttpError"`, `new ... ("x", 403)`
is an `instanceof Error` with `status === 403`, and none of PR #112's
auth-plane symbols leak in.

## Relationship to #112

This is the index re-export split out of #112 so it can land on its own.
#112 keeps the auth-plane discrimination API (`isKiroManagementHttpError`,
a `plane` discriminator, `refreshAttempted`), which is a design discussion
and does require changes to `management.ts`. Nothing here depends on it.
#112 will need a trivial rebase afterwards -- both branches add lines at
the same point in `src/index.ts`'s alphabetical export order.
