### PR TITLE
fix(management): continue region probe past a regional 403 on ListAvailableProfiles (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Profile discovery now continues probing the remaining canonical management regions after a regional 403 on ListAvailableProfiles, instead of aborting on the primary region. A region-mismatched token whose profile lives in another canonical region (e.g. us-east-1 token, eu-central-1 profile) previously surfacing `ListAvailableProfiles failed in <region>: 403 Forbidden` now resolves correctly (#131). A 403 on every region is still rethrown so credential refresh/retry paths (#107) engage for genuine auth failures.
+
 ## [0.10.1] - 2026-08-24
 
 ### Fixed

--- a/src/management.ts
+++ b/src/management.ts
@@ -185,16 +185,31 @@ export async function resolveKiroProfileArn(auth: KiroManagementAuth, providedAr
     // ListAvailableProfiles is regional to where the profile actually lives, not
     // to the SSO-derived API region. Probe the primary region first, then the
     // remaining canonical management regions, so a region-mismatched token still
-    // resolves a profile instead of failing hard (#104).
+    // resolves a profile instead of failing hard (#104, #131).
     let lastResponse: KiroListAvailableProfilesResponse | undefined;
+    let lastHttpError: KiroManagementHttpError | undefined;
     for (const region of candidateManagementRegions(auth.region)) {
-      const response = await requestManagement<KiroListAvailableProfilesResponse>(
-        { ...auth, region },
-        "ListAvailableProfiles",
-        LIST_PROFILES_PATH,
-        "POST",
-        {},
-      );
+      let response: KiroListAvailableProfilesResponse;
+      try {
+        response = await requestManagement<KiroListAvailableProfilesResponse>(
+          { ...auth, region },
+          "ListAvailableProfiles",
+          LIST_PROFILES_PATH,
+          "POST",
+          {},
+        );
+      } catch (error) {
+        // A regional 403 means the token has no profile *in this region*, not
+        // that it is globally rejected. The profile can live in another
+        // canonical region, so keep probing; only rethrow if no region yields
+        // a profile, so callers that treat a 403 as "refresh credentials and
+        // retry" (#107) still see the auth-plane signal when it is genuine.
+        if (error instanceof KiroManagementHttpError && error.status === 403) {
+          lastHttpError = error;
+          continue;
+        }
+        throw error;
+      }
       lastResponse = response;
       const arn = response.profiles?.find((profile) => profile.arn)?.arn;
       if (arn) {
@@ -204,6 +219,7 @@ export async function resolveKiroProfileArn(auth: KiroManagementAuth, providedAr
         return arn;
       }
     }
+    if (lastHttpError) throw lastHttpError;
     const attemptedRegions = candidateManagementRegions(auth.region).join(", ");
     throw new Error(
       `Kiro management ListAvailableProfiles returned no profile in ${attemptedRegions} ` +

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -191,6 +191,54 @@ describe("Kiro management control plane", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("continues probing after a 403 on the primary region and resolves in the fallback (#131)", async () => {
+    const euArn = "arn:aws:codewhisperer:eu-central-1:123456789012:profile/eu";
+    const fetchMock = vi
+      .fn()
+      // Primary (us-east-1): 403 Forbidden — token has no profile in this region
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
+      // Fallback (eu-central-1): profile found
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ profiles: [{ arn: euArn }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveKiroProfileArn(auth)).resolves.toBe(euArn);
+
+    // Both canonical regions were probed; the 403 did not abort the probe.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://management.eu-central-1.kiro.dev/List-Available-Profiles");
+
+    // Second resolution is served from cache — no further probing.
+    await expect(resolveKiroProfileArn(auth)).resolves.toBe(euArn);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows the 403 when every canonical region rejects (#131)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // A 403 on every region is a genuine auth-plane failure — keep the 403 so
+    // callers that refresh credentials and retry on 403 (#107) still handle it.
+    await expect(resolveKiroProfileArn(auth)).rejects.toThrow(
+      "Kiro management ListAvailableProfiles failed in eu-central-1: 403 Forbidden",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not catch non-403 management errors as a region-mismatch signal (#131)", async () => {
+    const fetchMock = vi
+      .fn()
+      // Primary (us-east-1): 500 — transient service error, not a region mismatch
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: "Internal Server Error" })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ profiles: [{ arn: profileArn }] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveKiroProfileArn(auth)).rejects.toThrow(
+      "Kiro management ListAvailableProfiles failed in us-east-1: 500 Internal Server Error",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not re-probe a region whitelisted by the SSO-derived primary (#104)", async () => {
     // us-east-1 as primary: candidate set is [us-east-1, eu-central-1] — the
     // same region should only be queried once.

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -490,7 +490,12 @@ describe("Feature 9: Streaming Integration", () => {
     const freshProfileArn = "arn:aws:codewhisperer:us-east-1:123:profile/FRESH";
     const mockFetch = vi
       .fn()
+      // Primary (us-east-1): stale token rejected
       .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
+      // Fallback (eu-central-1): stale token rejected there too — genuine auth rejection,
+      // so the probe rethrows 403 and the #107 newer-credential path engages
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
+      // Re-probe with the newer kiro-cli token: profile found
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ profiles: [{ arn: freshProfileArn }] }),
@@ -528,11 +533,14 @@ describe("Feature 9: Streaming Integration", () => {
     const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "stale-token" }));
 
     expect(refreshSpy).not.toHaveBeenCalled();
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
     expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer stale-token");
-    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer fresh-token");
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer stale-token");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://management.eu-central-1.kiro.dev/List-Available-Profiles");
     expect(mockFetch.mock.calls[2][1].headers.Authorization).toBe("Bearer fresh-token");
-    expect(JSON.parse(mockFetch.mock.calls[2][1].body).profileArn).toBe(freshProfileArn);
+    expect(mockFetch.mock.calls[3][1].headers.Authorization).toBe("Bearer fresh-token");
+    expect(JSON.parse(mockFetch.mock.calls[3][1].body).profileArn).toBe(freshProfileArn);
     expect(events.find((event) => event.type === "done")).toBeDefined();
 
     getCredsSpy.mockRestore();
@@ -545,6 +553,7 @@ describe("Feature 9: Streaming Integration", () => {
     const freshProfileArn = "arn:aws:codewhisperer:us-east-1:123:profile/REFRESHED";
     const mockFetch = vi
       .fn()
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
       .mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" })
       .mockResolvedValueOnce({
         ok: true,
@@ -580,10 +589,11 @@ describe("Feature 9: Streaming Integration", () => {
     const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "stale-token" }));
 
     expect(refreshSpy).toHaveBeenCalledOnce();
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer stale-token");
-    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer fresh-token");
-    expect(JSON.parse(mockFetch.mock.calls[1][1].body).profileArn).toBe(freshProfileArn);
+    expect(mockFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer stale-token");
+    expect(mockFetch.mock.calls[2][1].headers.Authorization).toBe("Bearer fresh-token");
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body).profileArn).toBe(freshProfileArn);
     expect(events.find((event) => event.type === "done")).toBeDefined();
 
     getCredsSpy.mockRestore();


### PR DESCRIPTION
## Summary

Fixes #131: `Failed to refresh Kiro model catalog in us-east-1: Kiro management ListAvailableProfiles failed in us-east-1: 403 Forbidden`

## Root cause

The region probe in `resolveKiroProfileArn` (added for #104) only tolerated a wrong region returning `200 + empty profile list`. A region-mismatched token — profile lives in another canonical management region (e.g. token for us-east-1, profile in eu-central-1) — can be rejected with **403 Forbidden** on ListAvailableProfiles in the primary region. That 403 aborted the entire probe loop, so the fallback canonical region was never tried, and the background catalog refresh surfaced the warning the reporter saw after `/login kiro`.

`#107`'s credential refresh did not help: it only re-reads/refreshes the token, but the token is valid — it's the *region* that mismatches.

## Change

- The probe now treats a per-region 403 as "no profile in this region" and continues to the remaining canonical management regions.
- A 403 on **every** canonical region is still rethrown, so `stream.ts`'s existing credential refresh-and-retry (`#107`) engages for genuine auth-plane failures.
- Non-403 errors (e.g. 5xx) still propagate immediately — they are transient service errors, not region-mismatch signals.

## Verification

- `tsc --noEmit` x2 (src + test config): PASS
- `biome check .`: clean (52 files)
- `vitest run`: **477/477 PASS** (21 files), incl. new regression tests:
  - continue probing after a 403 on the primary region and resolve in the fallback
  - rethrow the 403 when every canonical region rejects (preserves #107 path)
  - non-403 errors are not masked as region-mismatch signals
- Updated existing #107 tests for the corrected multi-region probe semantics (2×403 before refresh path engages)
- No secrets in diff

## Notes

- The reporter and #81 both hit this same 403 class; this addresses the remaining code-path gap. `#81` asks the reporter to confirm on 0.10.0 — this fix should be validated against the latest head before closing either.