### PR TITLE
fix(region): map ap-northeast-2 to Kiro API region

### DIFF
--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -8,6 +8,7 @@ const API_REGION_MAP: Record<string, string> = {
   "ap-southeast-1": "us-east-1",
   "ap-southeast-2": "us-east-1",
   "ap-northeast-1": "us-east-1",
+  "ap-northeast-2": "us-east-1",
   "ap-south-1": "us-east-1",
   "eu-west-1": "eu-central-1",
   "eu-west-2": "eu-central-1",

--- a/src/login.ts
+++ b/src/login.ts
@@ -65,6 +65,7 @@ const IDC_PROBE_REGIONS = [
   "eu-north-1", // SSO region → eu-central-1 API
   "ap-southeast-1",
   "ap-northeast-1",
+  "ap-northeast-2",
   "us-west-2",
 ];
 

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -116,6 +116,7 @@ describe("Feature 2: Model Definitions", () => {
       ["us-east-2", "us-east-1"],
       ["eu-west-1", "eu-central-1"],
       ["ap-southeast-2", "us-east-1"],
+      ["ap-northeast-2", "us-east-1"],
       ["us-east-1", "us-east-1"],
       [undefined, "us-east-1"],
     ])("maps %s to %s", (ssoRegion, apiRegion) => {


### PR DESCRIPTION
## Problem

IAM Identity Center credentials can carry `ap-northeast-2` as the SSO region for users in Korea. The provider passed `ap-northeast-2` through unchanged because it was missing from `API_REGION_MAP`, then attempted catalog discovery against `management.ap-northeast-2.kiro.dev`.

Kiro management and runtime endpoints are available through the canonical `us-east-1` API region, so this could prevent Korean-region users from loading models or making requests.

## Fix

- Map `ap-northeast-2` to the Kiro API region `us-east-1` in `resolveApiRegion`.
- Include `ap-northeast-2` in IAM Identity Center region auto-detection, keeping the probe list aligned with the region map.
- Add regression coverage for the region conversion.

This follows the same region-resolution pattern as #128, while addressing the Korean AWS region specifically.

## Verification

- `npm run check`
- `npm run lint`
- `npm test` — 523 tests passed
- `npm run build`
