### PR TITLE
feat(auth): support kiro-cli external IdP credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,12 +56,13 @@ Raw bytes → `parseKiroEvents()` → typed `KiroStreamEvent` → `ThinkingTagPa
 On 413/too-large: error propagated immediately to the caller (no retry). The caller is responsible for handling context overflow (e.g., compaction or history trimming), matching kiro-cli behavior.
 
 ### Credential Cascade
-1. kiro-cli SQLite DB — checks social token first (`kirocli:social:token`), then IDC token
+1. kiro-cli SQLite DB — checks social token first (`kirocli:social:token`), then IDC token, then external IdP token (`kirocli:external-idp:token`)
 2. OAuth device code flow (interactive, opens browser)
 
 ### Auth Methods
 - `idc`: AWS Builder ID or IAM Identity Center (SSO). Refresh via SSO OIDC endpoint. Token format: `refreshToken|clientId|clientSecret|idc`. Preferred — has clientId/clientSecret for refresh.
 - `desktop`: Google/GitHub social login via Kiro auth service. Refresh via `prod.{region}.auth.desktop.kiro.dev`. Token format: `refreshToken|desktop`
+- `external-idp`: Enterprise OIDC IdP (e.g. Okta) configured by the org, established by `kiro-cli login`. Refresh is a public-client `refresh_token` grant against the tenant's own `token_endpoint` (form-encoded, snake_case response, no client secret). Token format: `refreshToken|clientId|tokenEndpoint|external-idp`. Requests **must** carry `tokentype: EXTERNAL_IDP` or Kiro answers 403 "Invalid token" — see `src/token-type.ts`.
 
 ### Login Methods
 Users can authenticate via:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [pi](https://shittycodingagent.ai/) provider extension that connects pi to the
 
 Kiro gives you a strong free model menu, but pi needs a provider that speaks Kiro's auth, model catalog, and streaming protocol cleanly. `pi-provider-kiro` handles that bridge, including:
 
-- AWS Builder ID, IAM Identity Center, Google, and GitHub login flows
+- AWS Builder ID, IAM Identity Center, Google, GitHub, and enterprise external IdP (OIDC) login flows
 - shared credentials from an existing `kiro-cli` session when available
 - reasoning-aware streaming
 - region-aware model filtering so pi only shows models your Kiro region can actually use
@@ -36,6 +36,9 @@ The login flow supports:
 - **Your organization** — IAM Identity Center start URL
 - **Google** — social login via `kiro-cli`
 - **GitHub** — social login via `kiro-cli`
+
+If your organization uses an external identity provider (e.g. Okta) through Kiro, log in once with
+`kiro-cli login` and the provider reuses that session — no separate pi login needed.
 
 If you already use [kiro-cli](https://kiro.dev), the provider can reuse those credentials instead of forcing a second login.
 
@@ -132,6 +135,7 @@ src/
 ├── transform.ts        # Message format conversion
 ├── history.ts          # Conversation history management
 ├── thinking-parser.ts  # Streaming <thinking> tag parser
+├── token-type.ts       # `tokentype` header for external IdP bearer tokens
 ├── event-parser.ts     # Kiro stream event parser
 └── stream.ts           # Main streaming orchestrator
 ```

--- a/src/kiro-cli.ts
+++ b/src/kiro-cli.ts
@@ -11,6 +11,9 @@ import type { KiroAuthMethod, KiroCredentials } from "./oauth.js";
 
 const require = createRequire(import.meta.url);
 
+/** kiro-cli's secret-store key for an enterprise external IdP (OIDC) session. */
+const EXTERNAL_IDP_TOKEN_KEY = "kirocli:external-idp:token";
+
 export function getKiroCliDbPath(): string | undefined {
   const p = platform();
   let dbPath: string;
@@ -99,6 +102,11 @@ export function getKiroCliCredentials(): KiroCredentials | undefined {
     const desktopCreds = tryKiroCliToken(dbPath, "kirocli:social:token", "desktop");
     if (desktopCreds) return desktopCreds;
 
+    // Enterprise external IdP (OIDC) login — refreshed against the customer's
+    // own token endpoint rather than AWS SSO
+    const externalIdpCreds = tryKiroCliToken(dbPath, EXTERNAL_IDP_TOKEN_KEY, "external-idp");
+    if (externalIdpCreds) return externalIdpCreds;
+
     return undefined;
   } catch {
     return undefined;
@@ -119,6 +127,9 @@ export function getKiroCliCredentialsAllowExpired(): KiroCredentials | undefined
 
     const desktopCreds = tryKiroCliToken(dbPath, "kirocli:social:token", "desktop", true);
     if (desktopCreds) return desktopCreds;
+
+    const externalIdpCreds = tryKiroCliToken(dbPath, EXTERNAL_IDP_TOKEN_KEY, "external-idp", true);
+    if (externalIdpCreds) return externalIdpCreds;
 
     return undefined;
   } catch {
@@ -152,6 +163,28 @@ function tryKiroCliToken(
       clientSecret: "",
       region,
       authMethod: "desktop",
+      profileArn: tokenData.profile_arn || tokenData.profileArn,
+    };
+  }
+
+  // External IdP — the customer's own OIDC app. It is a public PKCE client, so
+  // there is no client secret; carry the token endpoint through the refresh
+  // string because it is per-tenant and not derivable from a region.
+  if (authMethod === "external-idp") {
+    const idpClientId = tokenData.client_id || tokenData.clientId || "";
+    const issuerUrl: string = tokenData.issuer_url || "";
+    const tokenEndpoint =
+      tokenData.token_endpoint ||
+      tokenData.tokenEndpoint ||
+      (issuerUrl ? `${issuerUrl.replace(/\/+$/, "")}/v1/token` : "");
+    return {
+      refresh: `${tokenData.refresh_token}|${idpClientId}|${tokenEndpoint}|external-idp`,
+      access: tokenData.access_token,
+      expires: expiresAt,
+      clientId: idpClientId,
+      clientSecret: "",
+      region,
+      authMethod: "external-idp",
       profileArn: tokenData.profile_arn || tokenData.profileArn,
     };
   }
@@ -219,6 +252,7 @@ export function getKiroCliSocialTokenAllowExpired(): KiroCredentials | undefined
 const TOKEN_KEY_BY_AUTH_METHOD: Record<KiroAuthMethod, string[]> = {
   idc: ["kirocli:odic:token", "codewhisperer:odic:token"],
   desktop: ["kirocli:social:token"],
+  "external-idp": [EXTERNAL_IDP_TOKEN_KEY],
 };
 
 export function saveKiroCliCredentials(creds: KiroCredentials): void {
@@ -242,8 +276,12 @@ export function saveKiroCliCredentials(creds: KiroCredentials): void {
       tokenData.access_token = creds.access;
       tokenData.refresh_token = rawRefreshToken;
       tokenData.expires_at = expiresAt;
-      if (creds.region) tokenData.region = creds.region;
-      if (creds.profileArn) tokenData.profile_arn = creds.profileArn;
+      // kiro-cli's ExternalIdpToken record has no region/profile_arn fields;
+      // don't add keys it never wrote.
+      if (creds.authMethod !== "external-idp") {
+        if (creds.region) tokenData.region = creds.region;
+        if (creds.profileArn) tokenData.profile_arn = creds.profileArn;
+      }
 
       const escaped = JSON.stringify(tokenData).replace(/'/g, "''");
       const sql = `UPDATE auth_kv SET value = '${escaped}' WHERE key = '${key}';`;

--- a/src/management.ts
+++ b/src/management.ts
@@ -4,6 +4,7 @@
 import { createHash } from "node:crypto";
 import { debugLog, redactSensitiveText } from "./debug.js";
 import { getKiroEndpoints } from "./endpoints.js";
+import { kiroTokenTypeHeaders } from "./token-type.js";
 
 const LIST_PROFILES_PATH = "List-Available-Profiles";
 const LIST_MODELS_PATH = "List-Available-Models";
@@ -102,6 +103,7 @@ async function requestManagement<TResponse>(
     headers: {
       Accept: "application/json",
       Authorization: `Bearer ${auth.accessToken}`,
+      ...kiroTokenTypeHeaders(auth.accessToken),
     },
   };
   if (method === "GET") {
@@ -294,6 +296,7 @@ export async function getUsageLimits<TResponse>(
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${auth.accessToken}`,
+        ...kiroTokenTypeHeaders(auth.accessToken),
         "User-Agent": "pi-provider-kiro",
       },
     });

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -24,7 +24,7 @@ export const SSO_SCOPES = [
   "codewhisperer:taskassist",
 ];
 
-export type KiroAuthMethod = "idc" | "desktop";
+export type KiroAuthMethod = "idc" | "desktop" | "external-idp";
 export type KiroLoginMethod = "auto" | "builder-id" | "google" | "github";
 
 export interface KiroCredentials extends OAuthCredentials {
@@ -91,11 +91,16 @@ async function loginKiroInternal(
     cliCreds = getKiroCliCredentials();
   }
 
-  if (cliCreds && (preferredMethod === "auto" || cliCreds.authMethod === "idc")) {
+  if (
+    cliCreds &&
+    (preferredMethod === "auto" || cliCreds.authMethod === "idc" || cliCreds.authMethod === "external-idp")
+  ) {
     (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
       cliCreds.authMethod === "desktop"
         ? "Using existing kiro-cli social credentials"
-        : "Using existing kiro-cli credentials",
+        : cliCreds.authMethod === "external-idp"
+          ? "Using existing kiro-cli external IdP credentials"
+          : "Using existing kiro-cli credentials",
     );
     return cliCreds;
   }
@@ -248,6 +253,47 @@ async function refreshKiroTokenDirect(credentials: OAuthCredentials): Promise<OA
       region,
       authMethod: "desktop" as KiroAuthMethod,
       profileArn: data.profileArn || (credentials as KiroCredentials).profileArn,
+    };
+  }
+
+  // External IdP (enterprise OIDC, e.g. Okta) — standard public-client refresh
+  // against the customer's own token endpoint. kiro-cli does the same:
+  // form-encoded grant_type/client_id/refresh_token, snake_case response, and
+  // no client secret because the OIDC app is a public PKCE client.
+  if (authMethod === "external-idp") {
+    const idpClientId = parts[1] ?? "";
+    const tokenEndpoint = parts[2] ?? "";
+    if (!tokenEndpoint) throw new Error("External IdP token refresh: missing token endpoint");
+    const response = await fetch(tokenEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "User-Agent": "pi-cli",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: idpClientId,
+        refresh_token: refreshToken,
+      }).toString(),
+    });
+    if (!response.ok) throw new Error(`External IdP token refresh failed: ${response.status}`);
+    const data = (await response.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
+    if (!data.access_token) throw new Error("External IdP token refresh: missing access_token");
+    const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 3600;
+    return {
+      refresh: `${data.refresh_token || refreshToken}|${idpClientId}|${tokenEndpoint}|external-idp`,
+      access: data.access_token,
+      expires: Date.now() + expiresIn * 1000 - 5 * 60 * 1000,
+      clientId: idpClientId,
+      clientSecret: "",
+      region,
+      authMethod: "external-idp" as KiroAuthMethod,
+      profileArn: (credentials as KiroCredentials).profileArn,
     };
   }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -57,6 +57,7 @@ import {
   MAX_RETRY_DELAY,
 } from "./retry.js";
 import { ThinkingTagParser } from "./thinking-parser.js";
+import { kiroTokenTypeHeaders } from "./token-type.js";
 import { countTokens } from "./tokenizer.js";
 import {
   buildHistory,
@@ -584,6 +585,7 @@ export function streamKiro(
               "Content-Type": "application/json",
               Accept: "application/vnd.amazon.eventstream",
               Authorization: `Bearer ${accessToken}`,
+              ...kiroTokenTypeHeaders(accessToken),
               "x-amzn-codewhisperer-optout": "true",
               "amz-sdk-invocation-id": crypto.randomUUID(),
               "amz-sdk-request": "attempt=1; max=1",

--- a/src/token-type.ts
+++ b/src/token-type.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Derives the `tokentype` request header Kiro requires for external IdP bearer tokens.
+// ABOUTME: Kiro rejects an external IdP access token with 403 unless the header is present.
+
+/**
+ * Audience claim Kiro's external IdP integration issues tokens for. kiro-cli
+ * configures the customer's OIDC app with this audience, so it is the reliable
+ * signal that a bearer token came from an external IdP rather than AWS SSO.
+ */
+const EXTERNAL_IDP_AUDIENCE = "api://kiro";
+
+/**
+ * True when the access token is an external IdP (enterprise OIDC) JWT.
+ *
+ * AWS SSO / Builder ID and Kiro desktop tokens are opaque strings, so a
+ * three-segment JWT carrying `aud: "api://kiro"` identifies the external IdP
+ * case without needing the auth method threaded through every call site.
+ */
+export function isExternalIdpAccessToken(accessToken: string | undefined): boolean {
+  if (typeof accessToken !== "string") return false;
+  const segments = accessToken.split(".");
+  if (segments.length !== 3) return false;
+  const payloadSegment = segments[1];
+  if (!payloadSegment) return false;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(payloadSegment.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf-8"),
+    ) as { aud?: unknown };
+    return payload.aud === EXTERNAL_IDP_AUDIENCE;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extra headers Kiro's management and runtime APIs require for the given token.
+ *
+ * kiro-cli sends `tokentype: EXTERNAL_IDP` on every request made with an
+ * external IdP token (its `TokenTypeInterceptor`); without it both
+ * `management.*.kiro.dev` and `runtime.*.kiro.dev` answer 403 "Invalid token".
+ * Returns an empty object for AWS SSO and desktop tokens, which must not carry
+ * the header.
+ */
+export function kiroTokenTypeHeaders(accessToken: string | undefined): Record<string, string> {
+  return isExternalIdpAccessToken(accessToken) ? { tokentype: "EXTERNAL_IDP" } : {};
+}

--- a/test/kiro-cli.test.ts
+++ b/test/kiro-cli.test.ts
@@ -62,6 +62,85 @@ describe("tryKiroCliToken (#110)", () => {
   });
 });
 
+describe("external IdP tokens", () => {
+  function makeExternalIdpDb(token: Record<string, unknown>): string {
+    tempDir = mkdtempSync(join(tmpdir(), "kiro-cli-test-"));
+    const dbPath = join(tempDir, "data.sqlite3");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)`);
+    db.prepare(`INSERT INTO auth_kv (key, value) VALUES (?, ?)`).run(
+      "kirocli:external-idp:token",
+      JSON.stringify(token),
+    );
+    db.close();
+    return dbPath;
+  }
+
+  const baseToken = {
+    access_token: "idp-access",
+    refresh_token: "idp-refresh",
+    client_id: "0oaEXAMPLE",
+    token_endpoint: "https://example.okta.com/oauth2/default/v1/token",
+    issuer_url: "https://example.okta.com/oauth2/default",
+    scopes: "codewhisperer:conversations codewhisperer:completions offline_access",
+  };
+
+  it("reads the kirocli:external-idp:token record", () => {
+    const dbPath = makeExternalIdpDb({
+      ...baseToken,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    });
+    const result = tryKiroCliToken(dbPath, "kirocli:external-idp:token", "external-idp");
+    expect(result?.authMethod).toBe("external-idp");
+    expect(result?.access).toBe("idp-access");
+    expect(result?.clientId).toBe("0oaEXAMPLE");
+    // No client secret: the OIDC app is a public PKCE client
+    expect(result?.clientSecret).toBe("");
+    // Records carry no region, so fall back to the default
+    expect(result?.region).toBe("us-east-1");
+  });
+
+  it("carries client_id and token_endpoint through the refresh string", () => {
+    const dbPath = makeExternalIdpDb({
+      ...baseToken,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    });
+    const result = tryKiroCliToken(dbPath, "kirocli:external-idp:token", "external-idp");
+    expect(result?.refresh).toBe(
+      "idp-refresh|0oaEXAMPLE|https://example.okta.com/oauth2/default/v1/token|external-idp",
+    );
+  });
+
+  it("derives the token endpoint from issuer_url when absent", () => {
+    const { token_endpoint: _omitted, ...withoutEndpoint } = baseToken;
+    const dbPath = makeExternalIdpDb({
+      ...withoutEndpoint,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    });
+    const result = tryKiroCliToken(dbPath, "kirocli:external-idp:token", "external-idp");
+    expect(result?.refresh.split("|")[2]).toBe("https://example.okta.com/oauth2/default/v1/token");
+  });
+
+  it("skips an expired token unless expired tokens are allowed", () => {
+    const dbPath = makeExternalIdpDb({
+      ...baseToken,
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    });
+    expect(tryKiroCliToken(dbPath, "kirocli:external-idp:token", "external-idp")).toBeUndefined();
+    expect(tryKiroCliToken(dbPath, "kirocli:external-idp:token", "external-idp", true)?.access).toBe("idp-access");
+  });
+
+  it("is returned by the credential probe order when it is the only stored token", () => {
+    const dbPath = makeExternalIdpDb({
+      ...baseToken,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    });
+    expect(tryKiroCliToken(dbPath, "kirocli:odic:token", "idc")).toBeUndefined();
+    expect(tryKiroCliToken(dbPath, "kirocli:social:token", "desktop")).toBeUndefined();
+    expect(tryKiroCliToken(dbPath, "kirocli:external-idp:token", "external-idp")?.authMethod).toBe("external-idp");
+  });
+});
+
 describe("Feature 4: kiro-cli Credential Fallback", () => {
   describe("getKiroCliDbPath", () => {
     it("returns undefined when database does not exist", () => {

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -34,6 +34,27 @@ describe("Kiro management control plane", () => {
     expect(JSON.parse(request.body)).toEqual({});
   });
 
+  it("sends tokentype: EXTERNAL_IDP for external IdP tokens and omits it otherwise", async () => {
+    const externalIdpToken = [
+      Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url"),
+      Buffer.from(JSON.stringify({ aud: "api://kiro" })).toString("base64url"),
+      "signature",
+    ].join(".");
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ profiles: [{ arn: profileArn }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resolveKiroProfileArn({ accessToken: externalIdpToken, region: "us-east-1" });
+    expect(fetchMock.mock.calls[0][1].headers.tokentype).toBe("EXTERNAL_IDP");
+
+    resetKiroProfileArnCache();
+    await resolveKiroProfileArn(auth);
+    expect(fetchMock.mock.calls[1][1].headers.tokentype).toBeUndefined();
+  });
+
   it("returns the current catalog shape, including Fable metadata", async () => {
     const fable = {
       modelId: "claude-fable-5",

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -67,6 +67,80 @@ describe("Feature 3: OAuth — Token Refresh", () => {
       vi.unstubAllGlobals();
     });
 
+    it("refreshes external IdP tokens against the customer token endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "idp_at", refresh_token: "idp_rt2", expires_in: 3600 }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tokenEndpoint = "https://example.okta.com/oauth2/default/v1/token";
+      const creds = await refreshKiroToken({
+        refresh: `idp_rt|0oaEXAMPLE|${tokenEndpoint}|external-idp`,
+        access: "old",
+        expires: 0,
+        region: "us-east-1",
+      } as KiroCredentials);
+
+      expect(creds.access).toBe("idp_at");
+      expect(creds.refresh).toBe(`idp_rt2|0oaEXAMPLE|${tokenEndpoint}|external-idp`);
+      expect((creds as KiroCredentials).authMethod).toBe("external-idp");
+      expect((creds as KiroCredentials).clientSecret).toBe("");
+
+      const [url, request] = mockFetch.mock.calls[0];
+      expect(url).toBe(tokenEndpoint);
+      expect(request.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+      const body = new URLSearchParams(request.body);
+      expect(body.get("grant_type")).toBe("refresh_token");
+      expect(body.get("client_id")).toBe("0oaEXAMPLE");
+      expect(body.get("refresh_token")).toBe("idp_rt");
+      expect(body.get("client_secret")).toBeNull();
+      vi.unstubAllGlobals();
+    });
+
+    it("reuses the previous refresh token when the IdP does not rotate it", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: "idp_at", expires_in: 3600 }),
+        }),
+      );
+      const creds = await refreshKiroToken({
+        refresh: "idp_rt|cid|https://idp.example/token|external-idp",
+        access: "old",
+        expires: 0,
+      } as KiroCredentials);
+      expect(creds.refresh).toBe("idp_rt|cid|https://idp.example/token|external-idp");
+      vi.unstubAllGlobals();
+    });
+
+    it("throws on external IdP token refresh failure", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({ ok: false, status: 400 }));
+      await expect(
+        refreshKiroToken({
+          refresh: "idp_rt|cid|https://idp.example/token|external-idp",
+          access: "old",
+          expires: 0,
+        } as KiroCredentials),
+      ).rejects.toThrow("External IdP token refresh failed: 400");
+      vi.unstubAllGlobals();
+    });
+
+    it("throws when the external IdP refresh string carries no token endpoint", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+      await expect(
+        refreshKiroToken({
+          refresh: "idp_rt|cid||external-idp",
+          access: "old",
+          expires: 0,
+        } as KiroCredentials),
+      ).rejects.toThrow("External IdP token refresh: missing token endpoint");
+      expect(mockFetch).not.toHaveBeenCalled();
+      vi.unstubAllGlobals();
+    });
+
     it("throws on desktop token refresh failure", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({ ok: false, status: 401 }));
       await expect(

--- a/test/token-type.test.ts
+++ b/test/token-type.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isExternalIdpAccessToken, kiroTokenTypeHeaders } from "../src/token-type.js";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url").replace(/=+$/, "");
+  return `${encode({ alg: "RS256", kid: "test" })}.${encode(payload)}.signature`;
+}
+
+describe("isExternalIdpAccessToken", () => {
+  it("recognises an external IdP token by its api://kiro audience", () => {
+    const token = makeJwt({
+      iss: "https://example.okta.com/oauth2/default",
+      aud: "api://kiro",
+      scp: ["codewhisperer:conversations", "codewhisperer:completions"],
+    });
+    expect(isExternalIdpAccessToken(token)).toBe(true);
+  });
+
+  it("rejects a JWT issued for a different audience", () => {
+    expect(isExternalIdpAccessToken(makeJwt({ aud: "https://example.com" }))).toBe(false);
+  });
+
+  it("rejects the opaque tokens AWS SSO and Kiro desktop issue", () => {
+    expect(isExternalIdpAccessToken("aoaEXAMPLEopaquessotoken")).toBe(false);
+  });
+
+  it("rejects malformed input without throwing", () => {
+    expect(isExternalIdpAccessToken(undefined)).toBe(false);
+    expect(isExternalIdpAccessToken("")).toBe(false);
+    expect(isExternalIdpAccessToken("not.a.jwt")).toBe(false);
+  });
+});
+
+describe("kiroTokenTypeHeaders", () => {
+  it("adds tokentype: EXTERNAL_IDP for external IdP tokens", () => {
+    expect(kiroTokenTypeHeaders(makeJwt({ aud: "api://kiro" }))).toEqual({ tokentype: "EXTERNAL_IDP" });
+  });
+
+  it("adds no header for AWS SSO and desktop tokens", () => {
+    expect(kiroTokenTypeHeaders("aoaEXAMPLEopaquessotoken")).toEqual({});
+    expect(kiroTokenTypeHeaders(undefined)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

kiro-cli stores an enterprise OIDC session under `kirocli:external-idp:token`, which the credential cascade never probed. For users whose org logs in through an external IdP (e.g. Okta) that is the *only* key in the database, so `getKiroCliCredentials` returned `undefined` and pi reported "No API key found for kiro" despite a working kiro-cli session.

Reading the key turned out to be necessary but not sufficient. Kiro rejects an external IdP bearer token with 403 unless the request carries `tokentype: EXTERNAL_IDP`:

```
management.us-east-1.kiro.dev/List-Available-Profiles  -> 403 {"message":"Invalid token"}
runtime.us-east-1.kiro.dev/generateAssistantResponse   -> 403 {"message":"The bearer token included in the request is invalid."}
```

kiro-cli adds that header on every call via a `TokenTypeInterceptor { auth_mode: ExternalIdp }` (visible in its `Q_LOG_LEVEL=trace` output). Adding only that header, with an otherwise identical request, flips ListAvailableProfiles from 403 to 200.

## Changes

- Probe `kirocli:external-idp:token` after the idc and social keys, and add an `external-idp` auth method.
- Refresh as a public PKCE client against the tenant's own `token_endpoint`: form-encoded `grant_type`/`client_id`/`refresh_token`, snake_case response, no client secret — matching kiro-cli. The endpoint is per-tenant and not derivable from a region, so it is carried in the refresh string: `refreshToken|clientId|tokenEndpoint|external-idp`.
- New `src/token-type.ts` sends `tokentype: EXTERNAL_IDP` on management and runtime requests, detected from the token's `aud: "api://kiro"` claim. AWS SSO and desktop tokens are opaque strings, so they never match and never carry the header.
- Write-back no longer adds `region`/`profile_arn` to the stored record; kiro-cli's `ExternalIdpToken` struct has neither field, and injecting keys it never wrote risks its own deserialization.
- External IdP records carry no profile ARN, which is fine — `resolveKiroProfileArn` discovers it via ListAvailableProfiles.

## Testing

`npm run check`, `biome check`, and `npm test` all pass locally (22 files, 493 tests), including 23 new tests:

- `test/token-type.test.ts` — audience detection, opaque-token and malformed-input rejection.
- `test/kiro-cli.test.ts` — five external-IdP cases against real sqlite fixtures: record read, refresh-string encoding, `issuer_url` endpoint fallback, expiry handling, and probe order when it is the only stored token.
- `test/oauth.test.ts` — four refresh-branch cases: happy path with form-encoded body assertions, refresh-token reuse when the IdP does not rotate, HTTP failure, and the missing-endpoint guard.
- `test/management.test.ts` — header present for an `api://kiro` JWT, absent otherwise.

Verified end to end on a real Okta-backed tenant: built the branch, installed the bundle over the pi extension, and `pi --provider kiro --model claude-haiku-4-5 -p` completed a request. Before the change the same setup could not authenticate at all.

One caveat worth flagging: the Okta refresh branch is unit-tested against a stubbed `fetch` rather than a live rotation. I avoided exercising it for real because the tenant rotates refresh tokens, and a rotation outside kiro-cli's knowledge would have invalidated its stored copy and forced a re-login. If you would rather not carry that code path, the alternative is to delegate refresh for `external-idp` to the existing `refreshViaKiroCli` (`kiro-cli debug refresh-auth-token`), which already handles this natively and rewrites the DB row — happy to switch it.

`CHANGELOG.md` is untouched, since `RELEASE.md` describes changelog edits as part of release prep rather than per-feature PRs. Glad to add an entry if you prefer one per PR.
