### PR TITLE
feat: OAuth rework rebased (interactive login, API key, PKCE) — integration of #94

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerProvider("kiro", {
     baseUrl: getKiroEndpoints("us-east-1").runtime,
     api: "kiro-api",
+    apiKey: "$KIRO_API_KEY",
     models: kiroModels,
     refreshModels: refreshKiroModels,
     oauth: {

--- a/src/kiro-cli.ts
+++ b/src/kiro-cli.ts
@@ -253,6 +253,7 @@ const TOKEN_KEY_BY_AUTH_METHOD: Record<KiroAuthMethod, string[]> = {
   idc: ["kirocli:odic:token", "codewhisperer:odic:token"],
   desktop: ["kirocli:social:token"],
   "external-idp": [EXTERNAL_IDP_TOKEN_KEY],
+  apikey: [],
 };
 
 export function saveKiroCliCredentials(creds: KiroCredentials): void {

--- a/src/login-ui.ts
+++ b/src/login-ui.ts
@@ -6,14 +6,18 @@
 // Phase 1: SelectList — pick login method (Builder ID / IdC / Google / GitHub)
 // Phase 2: Input — enter IAM Identity Center start URL (only for option 2)
 
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 import { DynamicBorder, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Container, Input, type SelectItem, SelectList, Text } from "@earendil-works/pi-tui";
 
 export type LoginChoice =
+  | { method: "cached" }
+  | { method: "personal" }
   | { method: "builder-id" }
-  | { method: "idc"; startUrl: string }
   | { method: "google" }
   | { method: "github" }
+  | { method: "idc"; startUrl: string; region?: string }
+  | { method: "apikey"; apiKey: string }
   | null; // cancelled
 
 let _ctx: ExtensionContext | undefined;
@@ -22,11 +26,15 @@ export function setExtensionContext(ctx: ExtensionContext) {
   _ctx = ctx;
 }
 
+export function hasExtensionContext(): boolean {
+  return _ctx !== undefined;
+}
+
 /**
  * Show the login method selection UI using pi's native TUI components.
  * Returns the user's choice or null if cancelled.
  */
-export async function showLoginUI(): Promise<LoginChoice> {
+export async function showLoginUI(hasCached?: boolean): Promise<LoginChoice> {
   if (!_ctx) return null;
   const ctx = _ctx;
 
@@ -35,14 +43,24 @@ export async function showLoginUI(): Promise<LoginChoice> {
   // which then swallows onProgress/onAuth output (issue #90).
   return ctx.ui.custom<LoginChoice>(
     (tui, theme, _kb, done) => {
-      const items: SelectItem[] = [
-        { value: "builder-id", label: "Builder ID", description: "AWS Builder ID (default)" },
-        { value: "idc", label: "Your organization", description: "IAM Identity Center (SSO)" },
-        { value: "google", label: "Google", description: "Social login via kiro-cli" },
-        { value: "github", label: "GitHub", description: "Social login via kiro-cli" },
-      ];
+      const mainItems: SelectItem[] = [];
+      if (hasCached) {
+        mainItems.push({
+          value: "cached",
+          label: "Use existing credentials",
+          description: "Use cached/IDE credentials",
+        });
+      }
+      mainItems.push(
+        { value: "apikey", label: "API Key", description: "Use a KIRO_API_KEY (ksk_...)" },
+        { value: "personal", label: "Web Login", description: "Sign in via browser (Google, GitHub, Builder ID)" },
+        { value: "idc", label: "Device Code", description: "IAM Identity Center" },
+      );
 
-      let phase: "select" | "url" = "select";
+      let phase: "select" | "url" | "region" | "apikey" = "select";
+      let enteredStartUrl = "";
+      let enteredApiKey = "";
+
       const container = new Container();
       const border = new DynamicBorder((s: string) => theme.fg("accent", s));
       const title = new Text(theme.fg("accent", theme.bold("Kiro Login")), 1, 0);
@@ -50,7 +68,7 @@ export async function showLoginUI(): Promise<LoginChoice> {
       const borderBottom = new DynamicBorder((s: string) => theme.fg("accent", s));
 
       // Phase 1: SelectList
-      const selectList = new SelectList(items, items.length, {
+      const selectList = new SelectList(mainItems, mainItems.length, {
         selectedPrefix: (t: string) => theme.fg("accent", t),
         selectedText: (t: string) => theme.fg("accent", t),
         description: (t: string) => theme.fg("muted", t),
@@ -61,8 +79,12 @@ export async function showLoginUI(): Promise<LoginChoice> {
       selectList.onSelect = (item) => {
         if (item.value === "idc") {
           switchToUrlInput();
+        } else if (item.value === "apikey") {
+          switchToApiKeyInput();
+        } else if (item.value === "personal") {
+          done({ method: "personal" });
         } else {
-          done({ method: item.value as "builder-id" | "google" | "github" });
+          done({ method: "cached" });
         }
       };
       selectList.onCancel = () => done(null);
@@ -75,15 +97,61 @@ export async function showLoginUI(): Promise<LoginChoice> {
       urlInput.onSubmit = (value) => {
         const trimmed = value.trim();
         if (trimmed?.startsWith("http")) {
-          done({ method: "idc", startUrl: trimmed });
+          enteredStartUrl = trimmed;
+          switchToRegionInput();
         }
       };
       urlInput.onEscape = () => {
         switchToSelect();
       };
 
+      // Phase 3: Region Input
+      const regionLabel = new Text("SSO Region (e.g. us-east-1, or blank to auto-detect)", 1, 0);
+      const regionInput = new Input();
+      const regionHint = new Text(theme.fg("dim", "enter submit • esc back"), 1, 0);
+
+      regionInput.onSubmit = (value) => {
+        const region = value.trim();
+        done({ method: "idc", startUrl: enteredStartUrl, region: region || undefined });
+      };
+      regionInput.onEscape = () => {
+        switchToUrlInput();
+      };
+
+      // Phase 3b: API Key Input
+      const apiKeyLabel = new Text("Enter your Kiro API key (from app.kiro.dev → API Keys)", 1, 0);
+      const apiKeyInput = new Input();
+      const apiKeyHint = new Text(theme.fg("dim", "enter submit • esc back"), 1, 0);
+      const apiKeyFormatHint = new Text(theme.fg("muted", "Format: ksk_..."), 1, 0);
+
+      apiKeyInput.onSubmit = (value) => {
+        const trimmed = value.trim();
+        if (trimmed?.startsWith("ksk_")) {
+          enteredApiKey = trimmed;
+          done({ method: "apikey", apiKey: enteredApiKey });
+        }
+      };
+      apiKeyInput.onEscape = () => {
+        switchToSelect();
+      };
+
+      function switchToApiKeyInput() {
+        phase = "apikey";
+        container.clear();
+        container.addChild(border);
+        container.addChild(new Text(theme.fg("accent", theme.bold("API Key Authentication")), 1, 0));
+        container.addChild(apiKeyLabel);
+        container.addChild(apiKeyFormatHint);
+        container.addChild(apiKeyInput);
+        container.addChild(apiKeyHint);
+        container.addChild(borderBottom);
+        tui.requestRender();
+      }
+
       function switchToUrlInput() {
         phase = "url";
+        urlInput.setValue("");
+        regionInput.setValue("");
         container.clear();
         container.addChild(border);
         container.addChild(new Text(theme.fg("accent", theme.bold("IAM Identity Center")), 1, 0));
@@ -94,9 +162,23 @@ export async function showLoginUI(): Promise<LoginChoice> {
         tui.requestRender();
       }
 
+      function switchToRegionInput() {
+        phase = "region";
+        container.clear();
+        container.addChild(border);
+        container.addChild(new Text(theme.fg("accent", theme.bold("IAM Identity Center Region")), 1, 0));
+        container.addChild(regionLabel);
+        container.addChild(regionInput);
+        container.addChild(regionHint);
+        container.addChild(borderBottom);
+        tui.requestRender();
+      }
+
       function switchToSelect() {
         phase = "select";
         urlInput.setValue("");
+        regionInput.setValue("");
+        apiKeyInput.setValue("");
         container.clear();
         container.addChild(border);
         container.addChild(title);
@@ -119,8 +201,12 @@ export async function showLoginUI(): Promise<LoginChoice> {
         handleInput(data: string) {
           if (phase === "select") {
             selectList.handleInput(data);
-          } else {
+          } else if (phase === "url") {
             urlInput.handleInput(data);
+          } else if (phase === "region") {
+            regionInput.handleInput(data);
+          } else if (phase === "apikey") {
+            apiKeyInput.handleInput(data);
           }
           tui.requestRender();
         },
@@ -128,4 +214,92 @@ export async function showLoginUI(): Promise<LoginChoice> {
     },
     { overlay: true },
   );
+}
+
+/**
+ * Show a waiting UI wrapper with an Escape return loop logic.
+ * The user can press Escape or 'q' to abort the current login flow immediately.
+ */
+export async function showWaitingUI(
+  outerCallbacks: OAuthLoginCallbacks,
+  _choice: Exclude<LoginChoice, null>,
+  runAuth: (mergedCallbacks: OAuthLoginCallbacks) => Promise<OAuthCredentials>,
+): Promise<OAuthCredentials | null> {
+  if (!_ctx) {
+    return runAuth(outerCallbacks);
+  }
+  const ctx = _ctx;
+
+  return ctx.ui.custom<OAuthCredentials | null>((tui, theme, _kb, done) => {
+    const container = new Container();
+    const border = new DynamicBorder((s: string) => theme.fg("accent", s));
+    const title = new Text(theme.fg("accent", theme.bold("Kiro Login - Authorization")), 1, 0);
+    const borderBottom = new DynamicBorder((s: string) => theme.fg("accent", s));
+
+    const statusText = new Text("Initiating login flow...", 1, 0);
+    const urlText = new Text("", 1, 0);
+    const instructionsText = new Text("", 1, 0);
+    const hint = new Text(theme.fg("dim", "esc cancel / back"), 1, 0);
+
+    container.addChild(border);
+    container.addChild(title);
+    container.addChild(statusText);
+    container.addChild(urlText);
+    container.addChild(instructionsText);
+    container.addChild(hint);
+    container.addChild(borderBottom);
+
+    const abortCtrl = new AbortController();
+    let onAuthCalled = false;
+
+    const mergedCallbacks: OAuthLoginCallbacks = {
+      ...outerCallbacks,
+      onProgress: (msg: string) => {
+        outerCallbacks.onProgress?.(msg);
+        statusText.setText(msg);
+        tui.requestRender();
+      },
+      onAuth: (info: { url: string; instructions?: string }) => {
+        if (!onAuthCalled) {
+          onAuthCalled = true;
+          outerCallbacks.onAuth?.(info);
+        }
+        urlText.setText(`URL: ${info.url}`);
+        instructionsText.setText(info.instructions || "");
+        tui.requestRender();
+      },
+      signal: abortCtrl.signal,
+    };
+
+    runAuth(mergedCallbacks).then(
+      (creds) => {
+        done(creds);
+      },
+      (err) => {
+        if (abortCtrl.signal.aborted) {
+          done(null);
+        } else {
+          statusText.setText(theme.fg("warning", `Error: ${err.message || err}`));
+          tui.requestRender();
+          setTimeout(() => done(null), 3000);
+        }
+      },
+    );
+
+    return {
+      render(width: number) {
+        return container.render(width);
+      },
+      invalidate() {
+        container.invalidate();
+      },
+      handleInput(data: string) {
+        // Escape key (standalone 0x1B) or 'q' to cancel
+        if ((data.length === 1 && data.charCodeAt(0) === 0x1b) || data === "q") {
+          abortCtrl.abort();
+          done(null);
+        }
+      },
+    };
+  });
 }

--- a/src/login.ts
+++ b/src/login.ts
@@ -14,10 +14,25 @@
 // region automatically via resolveApiRegion() in models.ts.
 
 import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import http from "node:http";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 import { formatSafeError } from "./debug.js";
-import { showLoginUI } from "./login-ui.js";
-import { BUILDER_ID_START_URL, type KiroAuthMethod, type KiroCredentials, SSO_SCOPES } from "./oauth.js";
+import { hasExtensionContext, showLoginUI, showWaitingUI } from "./login-ui.js";
+import {
+  BUILDER_ID_PROFILE_ARN,
+  BUILDER_ID_START_URL,
+  type KiroAuthMethod,
+  type KiroCredentials,
+  kiroUserAgent,
+  loginKiroWithApiKey,
+  SSO_SCOPES,
+} from "./oauth.js";
+
+const oidcHeaders = (): Record<string, string> => ({
+  "Content-Type": "application/json",
+  ...kiroUserAgent("ssooidc", "E"),
+});
 
 type PromptFn = (p: { message: string; placeholder?: string; allowEmpty?: boolean }) => Promise<string>;
 
@@ -70,21 +85,52 @@ type DeviceAuth = {
  * This avoids pi's stacked-input bug where sequential onPrompt calls
  * render simultaneously with mirrored cursors.
  */
-export async function interactiveLogin(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-  // Try native TUI component first (requires ctx from session_start)
-  const choice = await showLoginUI();
+export async function interactiveLogin(
+  callbacks: OAuthLoginCallbacks,
+  hasCached?: boolean,
+): Promise<OAuthCredentials | "use-cached-credentials"> {
+  while (true) {
+    const choice = await showLoginUI(hasCached);
 
-  if (choice) {
-    switch (choice.method) {
-      case "builder-id":
-        return runDeviceCodeFlow(callbacks, BUILDER_ID_START_URL, "us-east-1");
-      case "idc":
-        return runDeviceCodeFlowWithRegionDetection(callbacks, choice.startUrl);
-      case "google":
-        return loginViaKiroCli(callbacks, "google");
-      case "github":
-        return loginViaKiroCli(callbacks, "github");
+    if (choice) {
+      if (choice.method === "cached") {
+        return "use-cached-credentials";
+      }
+
+      const runAuth = async (mergedCallbacks: OAuthLoginCallbacks) => {
+        switch (choice.method) {
+          case "builder-id":
+            return runDeviceCodeFlow(mergedCallbacks, BUILDER_ID_START_URL, "us-east-1");
+          case "google":
+            return loginViaKiroCli(mergedCallbacks, "google");
+          case "github":
+            return loginViaKiroCli(mergedCallbacks, "github");
+          case "personal":
+            return runSocialLoginFlow(mergedCallbacks);
+          case "idc":
+            if (choice.region) {
+              return runDeviceCodeFlow(mergedCallbacks, choice.startUrl, choice.region);
+            }
+            return runDeviceCodeFlowWithRegionDetection(mergedCallbacks, choice.startUrl);
+          case "apikey":
+            return loginKiroWithApiKey(mergedCallbacks, choice.apiKey);
+          default:
+            throw new Error("Unknown login method");
+        }
+      };
+
+      const creds = await showWaitingUI(callbacks, choice, runAuth);
+      if (creds) {
+        return creds;
+      }
+      // If cancelled/failed inside the waiting UI, loop back to show main menu again
+      continue;
     }
+
+    if (hasExtensionContext()) {
+      throw new Error("Login cancelled");
+    }
+    break;
   }
 
   // Fallback: single onPrompt (ctx not available, e.g. first run before session_start)
@@ -118,9 +164,9 @@ async function tryRegisterAndAuthorize(
   const regResp = await fetch(`${oidcEndpoint}/client/register`, {
     method: "POST",
     signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+    headers: oidcHeaders(),
     body: JSON.stringify({
-      clientName: "pi-cli",
+      clientName: "Kiro CLI",
       clientType: "public",
       scopes: SSO_SCOPES,
       grantTypes: ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
@@ -132,7 +178,7 @@ async function tryRegisterAndAuthorize(
   const devResp = await fetch(`${oidcEndpoint}/device_authorization`, {
     method: "POST",
     signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+    headers: oidcHeaders(),
     body: JSON.stringify({ clientId, clientSecret, startUrl }),
   });
   if (!devResp.ok) return null;
@@ -150,7 +196,15 @@ async function runDeviceCodeFlow(
 ): Promise<OAuthCredentials> {
   const result = await tryRegisterAndAuthorize(startUrl, region);
   if (!result) throw new Error(`Device authorization failed in ${region}`);
-  return pollDeviceCode(callbacks, result.clientId, result.clientSecret, region, result.oidcEndpoint, result.devAuth);
+  return pollDeviceCode(
+    callbacks,
+    result.clientId,
+    result.clientSecret,
+    region,
+    result.oidcEndpoint,
+    result.devAuth,
+    startUrl,
+  );
 }
 
 /**
@@ -175,6 +229,7 @@ async function runDeviceCodeFlowWithRegionDetection(
         region,
         result.oidcEndpoint,
         result.devAuth,
+        startUrl,
       );
     }
   }
@@ -195,6 +250,7 @@ async function pollDeviceCode(
   region: string,
   oidcEndpoint: string,
   devAuth: DeviceAuth,
+  startUrl?: string,
 ): Promise<OAuthCredentials> {
   (callbacks as unknown as { onAuth: (info: { url: string; instructions: string }) => void }).onAuth({
     url: devAuth.verificationUriComplete,
@@ -211,7 +267,7 @@ async function pollDeviceCode(
 
     const tokResp = await fetch(`${oidcEndpoint}/token`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+      headers: oidcHeaders(),
       body: JSON.stringify({
         clientId,
         clientSecret,
@@ -237,6 +293,8 @@ async function pollDeviceCode(
             clientSecret,
             region,
             authMethod: "idc" as KiroAuthMethod,
+            startUrl,
+            ...(startUrl === BUILDER_ID_START_URL ? { profileArn: BUILDER_ID_PROFILE_ARN } : {}),
           } satisfies KiroCredentials;
         }
         break;
@@ -250,6 +308,208 @@ async function pollDeviceCode(
     }
   }
   throw new Error("Authorization timed out");
+}
+
+function generatePkce() {
+  const codeVerifier = crypto.randomBytes(32).toString("base64url");
+  const codeChallenge = crypto.createHash("sha256").update(codeVerifier).digest("base64url");
+  return { codeVerifier, codeChallenge };
+}
+
+/**
+ * Social login flow with PKCE using a local localhost server callback.
+ */
+export async function runSocialLoginFlow(
+  callbacks: OAuthLoginCallbacks,
+  provider?: "google" | "github",
+): Promise<OAuthCredentials> {
+  const region = "us-east-1";
+  const state = crypto.randomBytes(16).toString("hex");
+  const { codeVerifier, codeChallenge } = generatePkce();
+  const redirectUri = `http://localhost:3128`;
+
+  const authUrl = `https://app.kiro.dev/signin?state=${state}&code_challenge=${codeChallenge}&code_challenge_method=S256&redirect_uri=${encodeURIComponent(redirectUri)}&redirect_from=kirocli${provider ? `&login_option=${provider}` : ""}`;
+
+  return new Promise<OAuthCredentials>((resolve, reject) => {
+    let server: http.Server | undefined;
+    const signal = getSignal(callbacks);
+
+    const cleanup = () => {
+      if (server) {
+        server.close();
+        server = undefined;
+      }
+    };
+
+    if (signal?.aborted) {
+      return reject(signal.reason);
+    }
+
+    signal?.addEventListener("abort", () => {
+      cleanup();
+      reject(signal.reason);
+    });
+
+    server = http.createServer(async (req, res) => {
+      try {
+        const reqUrl = new URL(req.url || "", `http://${req.headers.host}`);
+        const allowedPaths = ["/", "/oauth/callback", "/signin/callback"];
+        if (!allowedPaths.includes(reqUrl.pathname)) {
+          res.writeHead(404);
+          res.end("Not Found");
+          return;
+        }
+
+        const stateParam = reqUrl.searchParams.get("state");
+
+        if (stateParam !== state) {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end("<h3>Authentication failed: invalid state</h3>");
+          cleanup();
+          reject(new Error("State mismatch"));
+          return;
+        }
+
+        const issuerUrl = reqUrl.searchParams.get("issuer_url");
+        if (issuerUrl) {
+          const idcRegion = reqUrl.searchParams.get("idc_region") || "us-east-1";
+
+          const result = await tryRegisterAndAuthorize(issuerUrl, idcRegion);
+          if (!result) {
+            res.writeHead(500, { "Content-Type": "text/html" });
+            res.end("<h3>Failed to initiate AWS SSO authorization</h3>");
+            cleanup();
+            reject(new Error(`Device authorization failed in ${idcRegion}`));
+            return;
+          }
+
+          res.writeHead(302, {
+            Location: result.devAuth.verificationUriComplete,
+          });
+          res.end();
+
+          cleanup();
+
+          try {
+            const idcCreds = await pollDeviceCode(
+              callbacks,
+              result.clientId,
+              result.clientSecret,
+              idcRegion,
+              result.oidcEndpoint,
+              result.devAuth,
+              issuerUrl,
+            );
+            resolve(idcCreds);
+          } catch (err) {
+            reject(err);
+          }
+          return;
+        }
+
+        const codeParam = reqUrl.searchParams.get("code");
+
+        if (!codeParam) {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end("<h3>Authentication failed: missing authorization code</h3>");
+          cleanup();
+          reject(new Error("Missing authorization code"));
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(`
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>Kiro Sign In</title>
+            <style>
+              body { font-family: -apple-system, sans-serif; text-align: center; padding: 50px; background-color: #f9f9f9; }
+              .card { background: white; padding: 30px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); display: inline-block; }
+              h2 { color: #2ecc71; }
+            </style>
+          </head>
+          <body>
+            <div class="card">
+              <h2>Sign In Successful!</h2>
+              <p>You have successfully logged in to Kiro CLI. You can now close this tab.</p>
+            </div>
+          </body>
+          </html>
+        `);
+
+        cleanup();
+
+        getProgress(callbacks)?.(`Exchanging auth code for tokens...`);
+        const tokenUrl = `https://prod.${region}.auth.desktop.kiro.dev/oauth/token`;
+        const loginOption = reqUrl.searchParams.get("login_option");
+        const actualRedirectUri = `http://localhost:3128${reqUrl.pathname === "/" ? "" : reqUrl.pathname}${loginOption ? `?login_option=${loginOption}` : ""}`;
+        const response = await fetch(tokenUrl, {
+          method: "POST",
+          headers: oidcHeaders(),
+          body: JSON.stringify({
+            code: codeParam,
+            code_verifier: codeVerifier,
+            redirect_uri: actualRedirectUri,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Token exchange failed: ${response.status} ${response.statusText}`);
+        }
+
+        const data = (await response.json()) as {
+          accessToken: string;
+          refreshToken?: string;
+          expiresIn: number;
+          profileArn?: string;
+        };
+
+        if (!data.accessToken) {
+          throw new Error("Missing accessToken in response");
+        }
+
+        const creds = {
+          refresh: `${data.refreshToken || ""}|desktop`,
+          access: data.accessToken,
+          expires: Date.now() + data.expiresIn * 1000 - 5 * 60 * 1000,
+          clientId: "",
+          clientSecret: "",
+          region,
+          authMethod: "desktop" as const,
+          profileArn: data.profileArn,
+        };
+
+        try {
+          const { saveKiroCliCredentials } = await import("./kiro-cli.js");
+          saveKiroCliCredentials(creds);
+        } catch {
+          // Ignore write errors
+        }
+
+        getProgress(callbacks)?.("Google/GitHub login successful");
+        resolve(creds);
+      } catch (err) {
+        cleanup();
+        reject(err);
+      }
+    });
+
+    server.on("error", (err) => {
+      cleanup();
+      reject(new Error(`Failed to start local OAuth server on port 3128: ${err.message}`));
+    });
+
+    server.listen(3128, () => {
+      getProgress(callbacks)?.(`Please complete login in your browser...`);
+      (callbacks as unknown as { onAuth: (info: { url: string; instructions: string }) => void }).onAuth({
+        url: authUrl,
+        instructions: provider
+          ? `Click to sign in via ${provider === "google" ? "Google" : "GitHub"}.`
+          : "Click to sign in with your preferred account.",
+      });
+    });
+  });
 }
 
 /**

--- a/src/management.ts
+++ b/src/management.ts
@@ -4,6 +4,7 @@
 import { createHash } from "node:crypto";
 import { debugLog, redactSensitiveText } from "./debug.js";
 import { getKiroEndpoints } from "./endpoints.js";
+import { kiroAuthHeaders } from "./oauth.js";
 import { kiroTokenTypeHeaders } from "./token-type.js";
 
 const LIST_PROFILES_PATH = "List-Available-Profiles";
@@ -102,7 +103,7 @@ async function requestManagement<TResponse>(
     method,
     headers: {
       Accept: "application/json",
-      Authorization: `Bearer ${auth.accessToken}`,
+      ...kiroAuthHeaders(auth.accessToken),
       ...kiroTokenTypeHeaders(auth.accessToken),
     },
   };
@@ -295,7 +296,7 @@ export async function getUsageLimits<TResponse>(
       method: "GET",
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${auth.accessToken}`,
+        ...kiroAuthHeaders(auth.accessToken),
         ...kiroTokenTypeHeaders(auth.accessToken),
         "User-Agent": "pi-provider-kiro",
       },

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -15,6 +15,7 @@ import { interactiveLogin, loginViaKiroCli } from "./login.js";
 
 export const SSO_OIDC_ENDPOINT = "https://oidc.us-east-1.amazonaws.com";
 export const BUILDER_ID_START_URL = "https://view.awsapps.com/start";
+export const BUILDER_ID_PROFILE_ARN = "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX";
 export const KIRO_DESKTOP_REFRESH_URL = "https://prod.{region}.auth.desktop.kiro.dev/refreshToken";
 export const SSO_SCOPES = [
   "codewhisperer:completions",
@@ -24,7 +25,7 @@ export const SSO_SCOPES = [
   "codewhisperer:taskassist",
 ];
 
-export type KiroAuthMethod = "idc" | "desktop" | "external-idp";
+export type KiroAuthMethod = "idc" | "desktop" | "external-idp" | "apikey";
 export type KiroLoginMethod = "auto" | "builder-id" | "google" | "github";
 
 export interface KiroCredentials extends OAuthCredentials {
@@ -34,6 +35,87 @@ export interface KiroCredentials extends OAuthCredentials {
   authMethod: KiroAuthMethod;
   /** Required for Google/GitHub social profiles; ListAvailableProfiles may return empty for these tokens. */
   profileArn?: string;
+  startUrl?: string;
+  isEnterprise?: boolean;
+}
+
+export const KIRO_DESKTOP_USER_AGENT = "Kiro-Desktop/0.2.13 (darwin; arm64)";
+
+export function kiroUserAgent(service: string, sdkVersion: string): Record<string, string> {
+  return {
+    "User-Agent": `aws-sdk-js/3.714.0 os/macos/24.3.0 lang/js md/nodejs/22.14.0 api/${service}/3.714.0 exec-env/kiro-cli/2.7.0 m/E`,
+    "amz-sdk-invocation-id": "00000000-0000-0000-0000-000000000000",
+    "amz-sdk-request": `attempt=1; max=${sdkVersion}`,
+  };
+}
+
+export function kiroAuthHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  if (isApiKey(token)) {
+    headers.tokentype = "API_KEY";
+  }
+  return headers;
+}
+
+export function isApiKey(token: string): boolean {
+  return token.startsWith("ksk_");
+}
+
+export async function loginKiroWithApiKey(callbacks: OAuthLoginCallbacks, apiKey: string): Promise<OAuthCredentials> {
+  if (!apiKey.startsWith("ksk_")) {
+    throw new Error("Invalid API key format. Kiro API keys start with 'ksk_'.");
+  }
+
+  (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.("Validating API key...");
+
+  const { resolveApiRegion } = await import("./endpoints.js");
+  // API keys are issued for the us-east-1 control plane.
+  const region = "us-east-1";
+  const apiRegion = resolveApiRegion(region);
+  const managementUrl = `https://management.${apiRegion}.kiro.dev/`;
+
+  // GetProfile with an empty body returns the API key's own profile.
+  const resp = await fetch(managementUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-amz-json-1.0",
+      "X-Amz-Target": "AmazonCodeWhispererService.GetProfile",
+      ...kiroAuthHeaders(apiKey),
+      ...kiroUserAgent("codewhispererruntime", "F,C"),
+    },
+    body: "{}",
+  });
+
+  if (!resp.ok) {
+    let detail = "";
+    try {
+      detail = await resp.text();
+    } catch {
+      detail = "";
+    }
+    if (resp.status === 401 || resp.status === 403 || /Invalid token/i.test(detail)) {
+      throw new Error("API key was rejected by Kiro. Check that the key is valid and not expired.");
+    }
+    throw new Error(`Kiro GetProfile failed: ${resp.status} ${resp.statusText} ${detail}`.trim());
+  }
+
+  const data = (await resp.json()) as { profile?: { arn?: string } };
+  const profileArn = data.profile?.arn;
+
+  const kiroCreds: KiroCredentials = {
+    access: apiKey,
+    refresh: `${apiKey}|apikey`,
+    expires: Date.now() + 365 * 24 * 60 * 60 * 1000,
+    clientId: "",
+    clientSecret: "",
+    region,
+    authMethod: "apikey",
+    ...(profileArn ? { profileArn } : {}),
+  };
+
+  return kiroCreds;
 }
 
 /**
@@ -66,26 +148,48 @@ async function loginKiroInternal(
   callbacks: OAuthLoginCallbacks,
   preferredMethod: KiroLoginMethod = "auto",
 ): Promise<OAuthCredentials> {
-  const { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, saveKiroCliCredentials, getKiroCliSocialToken } =
-    await import("./kiro-cli.js");
+  const { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, getKiroCliSocialToken } = await import(
+    "./kiro-cli.js"
+  );
 
   // If user explicitly wants social login, delegate to kiro-cli
   if (preferredMethod === "google" || preferredMethod === "github") {
     return loginViaKiroCli(callbacks, preferredMethod);
   }
 
-  // 1. Kiro IDE token (~/.aws/sso/cache/kiro-auth-token.json)
-  //    Checked first because the IDE keeps it continuously fresh and it already
-  //    covers IAM Identity Center logins — no extra prompts needed.
   const ideCreds = getKiroIdeCredentials();
-  if (ideCreds && (preferredMethod === "auto" || preferredMethod === "builder-id")) {
+  const cliCreds = getKiroCliSocialToken() || getKiroCliCredentials();
+  const expiredIdeCreds = getKiroIdeCredentialsAllowExpired();
+  const expiredCreds = getKiroCliCredentialsAllowExpired();
+
+  const hasCached = Boolean(ideCreds || cliCreds || expiredIdeCreds || expiredCreds);
+
+  const { interactiveLogin } = await import("./login.js");
+  const result = await interactiveLogin(callbacks, hasCached);
+
+  if (result !== "use-cached-credentials") {
+    return result;
+  }
+
+  // User chose to use cached credentials from the TUI menu
+  return useCachedCascade(callbacks, preferredMethod);
+}
+
+async function useCachedCascade(
+  callbacks: OAuthLoginCallbacks,
+  preferredMethod: KiroLoginMethod = "auto",
+): Promise<OAuthCredentials> {
+  const { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, saveKiroCliCredentials, getKiroCliSocialToken } =
+    await import("./kiro-cli.js");
+
+  const ideCreds = getKiroIdeCredentials();
+  if (ideCreds) {
     (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
       "Using existing Kiro IDE credentials",
     );
     return ideCreds;
   }
 
-  // 2. kiro-cli DB credentials (social / Builder ID / IdC)
   let cliCreds = getKiroCliSocialToken();
   if (!cliCreds) {
     cliCreds = getKiroCliCredentials();
@@ -93,7 +197,10 @@ async function loginKiroInternal(
 
   if (
     cliCreds &&
-    (preferredMethod === "auto" || cliCreds.authMethod === "idc" || cliCreds.authMethod === "external-idp")
+    (preferredMethod === "auto" ||
+      cliCreds.authMethod === "idc" ||
+      cliCreds.authMethod === "external-idp" ||
+      cliCreds.authMethod === "apikey")
   ) {
     (callbacks as unknown as { onProgress?: (msg: string) => void }).onProgress?.(
       cliCreds.authMethod === "desktop"
@@ -105,7 +212,6 @@ async function loginKiroInternal(
     return cliCreds;
   }
 
-  // 3. Expired IDE token — attempt a silent AWS OIDC refresh
   const expiredIdeCreds = getKiroIdeCredentialsAllowExpired();
   if (expiredIdeCreds) {
     try {
@@ -114,11 +220,10 @@ async function loginKiroInternal(
       );
       return await refreshKiroTokenDirect(expiredIdeCreds);
     } catch {
-      // Fall through to kiro-cli refresh
+      // Ignore
     }
   }
 
-  // 4. Expired kiro-cli credentials — attempt a silent refresh
   const expiredCreds = getKiroCliCredentialsAllowExpired();
   if (expiredCreds) {
     try {
@@ -129,12 +234,11 @@ async function loginKiroInternal(
       saveKiroCliCredentials(refreshed as KiroCredentials);
       return refreshed;
     } catch {
-      // Refresh failed, fall through to device code flow
+      // Ignore
     }
   }
 
-  // Fall back to interactive login (Feature 10)
-  return interactiveLogin(callbacks);
+  throw new Error("No valid cached credentials found");
 }
 
 /**
@@ -168,6 +272,12 @@ export async function refreshKiroToken(credentials: OAuthCredentials): Promise<O
 async function refreshKiroTokenInternal(credentials: OAuthCredentials): Promise<OAuthCredentials> {
   const { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, saveKiroCliCredentials, getKiroCliSocialToken } =
     await import("./kiro-cli.js");
+
+  // API key credentials are long-lived bearer tokens — there is nothing to
+  // refresh. Return them unchanged so the same key keeps being used.
+  if ((credentials as KiroCredentials).authMethod === "apikey" || isApiKey(credentials.access)) {
+    return credentials;
+  }
 
   // Layer 0: Kiro IDE token — freshest source, covers IAM Identity Center
   const ideCreds = getKiroIdeCredentials();
@@ -228,12 +338,17 @@ async function refreshKiroTokenDirect(credentials: OAuthCredentials): Promise<OA
   const authMethod = (parts[parts.length - 1] ?? "idc") as KiroAuthMethod;
   const region = (credentials as KiroCredentials).region || "us-east-1";
 
+  if (authMethod === "apikey") {
+    // API keys are long-lived bearer tokens — no refresh needed.
+    return credentials;
+  }
+
   if (authMethod === "desktop") {
     // Kiro desktop app tokens use a different refresh endpoint
     const url = KIRO_DESKTOP_REFRESH_URL.replace("{region}", region);
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+      headers: { "Content-Type": "application/json", "User-Agent": KIRO_DESKTOP_USER_AGENT },
       body: JSON.stringify({ refreshToken }),
     });
     if (!response.ok) throw new Error(`Desktop token refresh failed: ${response.status}`);
@@ -253,6 +368,7 @@ async function refreshKiroTokenDirect(credentials: OAuthCredentials): Promise<OA
       region,
       authMethod: "desktop" as KiroAuthMethod,
       profileArn: data.profileArn || (credentials as KiroCredentials).profileArn,
+      startUrl: (credentials as KiroCredentials).startUrl,
     };
   }
 
@@ -303,7 +419,10 @@ async function refreshKiroTokenDirect(credentials: OAuthCredentials): Promise<OA
   const ssoEndpoint = `https://oidc.${region}.amazonaws.com`;
   const response = await fetch(`${ssoEndpoint}/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+    headers: {
+      "Content-Type": "application/json",
+      ...kiroUserAgent("ssooidc", "E"),
+    },
     body: JSON.stringify({ clientId, clientSecret, refreshToken, grantType: "refresh_token" }),
   });
   if (!response.ok) throw new Error(`Token refresh failed: ${response.status}`);
@@ -316,5 +435,8 @@ async function refreshKiroTokenDirect(credentials: OAuthCredentials): Promise<OA
     clientSecret: clientSecret,
     region,
     authMethod: "idc" as KiroAuthMethod,
+    profileArn: (credentials as KiroCredentials).profileArn,
+    startUrl: (credentials as KiroCredentials).startUrl,
+    isEnterprise: (credentials as KiroCredentials).isEnterprise,
   };
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -47,6 +47,7 @@ import {
   resolveKiroProfileArn,
 } from "./management.js";
 import { resolveKiroModel } from "./models.js";
+import { kiroAuthHeaders } from "./oauth.js";
 import {
   capacityRetryConfig,
   exponentialBackoff,
@@ -584,7 +585,7 @@ export function streamKiro(
             headers: {
               "Content-Type": "application/json",
               Accept: "application/vnd.amazon.eventstream",
-              Authorization: `Bearer ${accessToken}`,
+              ...kiroAuthHeaders(accessToken),
               ...kiroTokenTypeHeaders(accessToken),
               "x-amzn-codewhisperer-optout": "true",
               "amz-sdk-invocation-id": crypto.randomUUID(),

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -18,6 +18,10 @@ vi.mock("node:child_process", () => ({ execFileSync: vi.fn() }));
 vi.mock("../src/login-ui.js", () => ({
   showLoginUI: vi.fn(() => Promise.resolve(null)),
   setExtensionContext: vi.fn(),
+  hasExtensionContext: vi.fn(() => false),
+  showWaitingUI: vi.fn((_callbacks: unknown, _choice: unknown, runAuth: (c: unknown) => unknown) =>
+    runAuth(_callbacks),
+  ),
 }));
 
 function makeCallbacks(...responses: string[]): OAuthLoginCallbacks & { onAuth: ReturnType<typeof vi.fn> } {
@@ -256,7 +260,7 @@ describe("Feature 10: Interactive Login", () => {
             json: () => Promise.resolve({ accessToken: "at", refreshToken: "rt", expiresIn: 3600 }),
           }),
       );
-      expect((await interactiveLogin(makeCallbacks(""))).access).toBe("at");
+      expect(((await interactiveLogin(makeCallbacks(""))) as KiroCredentials).access).toBe("at");
       vi.unstubAllGlobals();
     });
   });

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -242,4 +242,29 @@ describe("Feature 3: OAuth — Token Refresh", () => {
       vi.unstubAllGlobals();
     });
   });
+
+  describe("loginKiroWithApiKey", () => {
+    it("validates Kiro API key format", async () => {
+      const { loginKiroWithApiKey } = await import("../src/oauth.js");
+      await expect(loginKiroWithApiKey({} as any, "invalid_key")).rejects.toThrow("Invalid API key format");
+    });
+
+    it("fetches profile with GetProfile and returns apikey credentials", async () => {
+      const { loginKiroWithApiKey } = await import("../src/oauth.js");
+      const mockFetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profile: { arn: "arn:aws:codewhisperer:us-east-1:123:profile/api-key" } }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const creds = await loginKiroWithApiKey({ onProgress: vi.fn() } as any, "ksk_test_key_12345");
+      expect(creds.access).toBe("ksk_test_key_12345");
+      expect(creds.refresh).toBe("ksk_test_key_12345|apikey");
+      expect((creds as KiroCredentials).authMethod).toBe("apikey");
+      expect((creds as KiroCredentials).profileArn).toBe("arn:aws:codewhisperer:us-east-1:123:profile/api-key");
+      expect(mockFetch.mock.calls[0][1].headers.tokentype).toBe("API_KEY");
+
+      vi.unstubAllGlobals();
+    });
+  });
 });


### PR DESCRIPTION
Rebase/integration of #94 (simonsmh OAuth rework) onto current main, incl. #134 external-IdP auth.

**Resolution is a manual union, not an auto-merge:** `git merge-tree` of #94's original head `a07b8dd` onto `38889c8` conflicts in 6 files (kiro-cli, login, login-ui, management, oauth, stream); this branch resolves them as a union — `KiroAuthMethod = idc | desktop | external-idp | apikey`; `kiroAuthHeaders` + `kiroTokenTypeHeaders` coexist at every call site (verified in-tree). Carries forward the #90 `overlay: true` fix and probe timeout guards.

**Gate:** tsc ×2, biome 54, vitest 495/495 (22 files), build PASS — verified at head `1bb56e0` (maintainer tick 2026-08-28). In-repo CI `test` SUCCESS on this head (run 33134008571); fork-PR dispatch gap does not apply (same-repo branch).

Merge decision stays human-gated; after merge, close #94 as superseded by this integration (maintainer tick 2026-08-28).