### PR TITLE
fix(stream): bound Kiro response waits and throttles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ Raw bytes → `parseKiroEvents()` → typed `KiroStreamEvent` → `ThinkingTagPa
 ### Retry with Reduction
 On 413/too-large: error propagated immediately to the caller (no retry). The caller is responsible for handling context overflow (e.g., compaction or history trimming), matching kiro-cli behavior.
 
+HTTP 429 is provider-retried only when its JSON `reason` is exactly `USER_REQUEST_RATE_EXCEEDED`; server wait hints and the 10-second fallback/cap are owned by `src/retry.ts`. Other generic 429/5xx responses remain owned by Pi's outer retry layer.
+
 ### Credential Cascade
 1. kiro-cli SQLite DB — checks social token first (`kirocli:social:token`), then IDC token, then external IdP token (`kirocli:external-idp:token`)
 2. OAuth device code flow (interactive, opens browser)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,10 @@ npm run test:watch # vitest (watch mode)
 - Output token count is estimated (`content.length / 4`), not from the API
 - `contextUsagePercentage` is the only usage metric Kiro provides; input tokens are back-calculated
 - Social login (Google/GitHub) requires `kiro-cli` to be installed — pi delegates the auth flow to it
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/chsong/.pi/agent/vendor/pi-provider-kiro/node_modules

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -7,6 +7,8 @@ import { kiroModels } from "./models.js";
 // and 5-minute stalled stream grace period. 90s matches the TUI's
 // INITIAL_RESPONSE_TIMEOUT_MS for the first event from the backend.
 export const FIRST_TOKEN_TIMEOUT = 90_000;
+/** Maximum wait for the runtime endpoint to return HTTP response headers. */
+export const REQUEST_HEADER_TIMEOUT = 90_000;
 
 export function firstTokenTimeoutForModel(modelId: string): number {
   // Allow test overrides via retryConfig.firstTokenTimeoutMs
@@ -20,6 +22,7 @@ export function firstTokenTimeoutForModel(modelId: string): number {
 // Mutable config for values that tests need to override
 export const retryConfig = {
   firstTokenTimeoutMs: FIRST_TOKEN_TIMEOUT,
+  requestHeaderTimeoutMs: REQUEST_HEADER_TIMEOUT,
 };
 
 export function exponentialBackoff(attempt: number, baseMs: number, maxMs: number): number {

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -30,6 +30,81 @@ export function exponentialBackoff(attempt: number, baseMs: number, maxMs: numbe
 }
 
 export const MAX_RETRY_DELAY = 10_000;
+/** Fallback used when a request-window response carries no valid server hint. */
+export const REQUEST_RATE_FALLBACK_DELAY_MS = 10_000;
+
+/** Pull the service's exact JSON `reason` field without retaining or returning the body. */
+export function extractKiroReason(errorText: string): string | undefined {
+  if (!errorText) return undefined;
+  try {
+    const parsed = JSON.parse(errorText) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const reason = (parsed as { reason?: unknown }).reason;
+    return typeof reason === "string" && reason.length > 0 ? reason : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read a server-advertised wait in milliseconds.
+ *
+ * `retry-after-ms` is milliseconds, numeric `retry-after` and
+ * `x-ratelimit-reset-after` are seconds, and an HTTP-date `retry-after` is
+ * relative to `nowMs`. Each header is an independent candidate, so an invalid
+ * earlier value does not hide a valid later one. A past HTTP date means retry
+ * now.
+ */
+export function parseRetryAfterMs(headers: Headers | undefined, nowMs: number = Date.now()): number | undefined {
+  const get = headers?.get?.bind(headers);
+  if (!get) return undefined;
+
+  const milliseconds = nonNegativeNumber(get("retry-after-ms"));
+  if (milliseconds !== undefined) return Math.round(milliseconds);
+
+  const retryAfter = get("retry-after");
+  if (retryAfter !== null && retryAfter.trim() !== "") {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds)) {
+      // Numeric Retry-After is delay-seconds, never a date. In particular,
+      // do not let Date.parse reinterpret a negative delay as a year.
+      if (seconds >= 0) {
+        const delayMs = seconds * 1000;
+        if (Number.isFinite(delayMs)) return Math.round(delayMs);
+      }
+    } else {
+      const dateMs = Date.parse(retryAfter);
+      if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - nowMs);
+    }
+  }
+
+  const resetAfterSeconds = nonNegativeNumber(get("x-ratelimit-reset-after"));
+  if (resetAfterSeconds !== undefined) {
+    const delayMs = resetAfterSeconds * 1000;
+    if (Number.isFinite(delayMs)) return Math.round(delayMs);
+  }
+
+  return undefined;
+}
+
+export function resolveRequestRateRetryDelay(
+  headers: Headers | undefined,
+  nowMs: number = Date.now(),
+): { delayMs: number; advertisedDelayMs?: number; capped: boolean } {
+  const advertisedDelayMs = parseRetryAfterMs(headers, nowMs);
+  const requestedDelayMs = advertisedDelayMs ?? REQUEST_RATE_FALLBACK_DELAY_MS;
+  return {
+    delayMs: Math.min(requestedDelayMs, MAX_RETRY_DELAY),
+    ...(advertisedDelayMs !== undefined ? { advertisedDelayMs } : {}),
+    capped: requestedDelayMs > MAX_RETRY_DELAY,
+  };
+}
+
+function nonNegativeNumber(value: string | null): number | undefined {
+  if (value === null || value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
 
 /**
  * Machine reason codes returned by the Kiro API, plus the one prose marker the
@@ -50,6 +125,8 @@ export const KIRO_REASON_CODES = Object.freeze({
   MONTHLY_REQUEST_COUNT: "MONTHLY_REQUEST_COUNT",
   /** Model capacity temporarily unavailable — transient, worth retrying. */
   INSUFFICIENT_MODEL_CAPACITY: "INSUFFICIENT_MODEL_CAPACITY",
+  /** Short-window request throttle — retry only within the provider budget. */
+  USER_REQUEST_RATE_EXCEEDED: "USER_REQUEST_RATE_EXCEEDED",
   /**
    * Generic request-validation rejection, returned for a malformed body of any
    * size (empty `content`, history referencing tools absent from the catalog).

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -56,6 +56,7 @@ import {
   isNonRetryableBodyError,
   isTooBigError,
   MAX_RETRY_DELAY,
+  retryConfig,
 } from "./retry.js";
 import { ThinkingTagParser } from "./thinking-parser.js";
 import { kiroTokenTypeHeaders } from "./token-type.js";
@@ -110,16 +111,55 @@ function logCapacityEvent(message: string): void {
 function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) return Promise.reject(signal.reason);
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        reject(signal.reason);
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(signal?.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+function createResponseHeaderDeadline(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): {
+  signal: AbortSignal;
+  didTimeout: () => boolean;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout>;
+  const onCallerAbort = () => {
+    clearTimeout(timer);
+    callerSignal?.removeEventListener("abort", onCallerAbort);
+    controller.abort(callerSignal?.reason);
+  };
+  timer = setTimeout(() => {
+    timedOut = true;
+    callerSignal?.removeEventListener("abort", onCallerAbort);
+    controller.abort(new DOMException("Kiro response headers timeout", "TimeoutError"));
+  }, timeoutMs);
+
+  if (callerSignal?.aborted) {
+    onCallerAbort();
+  } else {
+    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    didTimeout: () => timedOut,
+    cleanup: () => {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+    },
+  };
 }
 
 interface KiroRequest {
@@ -304,7 +344,7 @@ export function streamKiro(
       let retryCount = 0;
       const maxRetries = 3;
       const conversationId = options?.sessionId ?? crypto.randomUUID();
-      while (retryCount <= maxRetries) {
+      requestLoop: while (retryCount <= maxRetries) {
         if (options?.signal?.aborted) throw options.signal.reason;
         const effectiveSystemPrompt = systemPrompt;
         // Relocate a tool result that arrived behind a later assistant turn than
@@ -581,23 +621,44 @@ export function streamKiro(
             toolResultCount: wireUimc?.toolResults?.length ?? 0,
             request,
           });
-          response = await fetch(endpoint, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "application/vnd.amazon.eventstream",
-              ...kiroAuthHeaders(accessToken),
-              ...kiroTokenTypeHeaders(accessToken),
-              "x-amzn-codewhisperer-optout": "true",
-              "amz-sdk-invocation-id": crypto.randomUUID(),
-              "amz-sdk-request": "attempt=1; max=1",
-              "x-amzn-kiro-agent-mode": "vibe",
-              "x-amz-user-agent": ua,
-              "user-agent": ua,
-            },
-            body: JSON.stringify(request),
-            signal: options?.signal,
-          });
+          const responseHeaderDeadline = createResponseHeaderDeadline(
+            options?.signal,
+            retryConfig.requestHeaderTimeoutMs,
+          );
+          let responseHeadersTimedOut = false;
+          try {
+            response = await fetch(endpoint, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "application/vnd.amazon.eventstream",
+                ...kiroAuthHeaders(accessToken),
+                ...kiroTokenTypeHeaders(accessToken),
+                "x-amzn-codewhisperer-optout": "true",
+                "amz-sdk-invocation-id": crypto.randomUUID(),
+                "amz-sdk-request": "attempt=1; max=1",
+                "x-amzn-kiro-agent-mode": "vibe",
+                "x-amz-user-agent": ua,
+                "user-agent": ua,
+              },
+              body: JSON.stringify(request),
+              signal: responseHeaderDeadline.signal,
+            });
+          } catch (error) {
+            if (!responseHeaderDeadline.didTimeout() || options?.signal?.aborted) throw error;
+            responseHeadersTimedOut = true;
+          } finally {
+            responseHeaderDeadline.cleanup();
+          }
+          if (responseHeadersTimedOut) {
+            if (retryCount >= maxRetries) {
+              throw new Error("Kiro API error: response headers timeout after max retries");
+            }
+            retryCount++;
+            const delayMs = exponentialBackoff(retryCount - 1, 1000, MAX_RETRY_DELAY);
+            await abortableDelay(delayMs, options?.signal);
+            continue requestLoop;
+          }
           if (!response.ok) {
             let errText = "";
             try {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -51,11 +51,14 @@ import { kiroAuthHeaders } from "./oauth.js";
 import {
   capacityRetryConfig,
   exponentialBackoff,
+  extractKiroReason,
   firstTokenTimeoutForModel,
   isCapacityError,
   isNonRetryableBodyError,
   isTooBigError,
+  KIRO_REASON_CODES,
   MAX_RETRY_DELAY,
+  resolveRequestRateRetryDelay,
   retryConfig,
 } from "./retry.js";
 import { ThinkingTagParser } from "./thinking-parser.js";
@@ -667,7 +670,17 @@ export function streamKiro(
               errText = "";
             }
             const safeStatusText = redactSensitiveText(response.statusText);
-            debugLog("response.error", { status: response.status, statusText: safeStatusText, body: errText });
+            const reasonCode = extractKiroReason(errText);
+            const isRequestRateExceeded =
+              response.status === 429 &&
+              reasonCode === KIRO_REASON_CODES.USER_REQUEST_RATE_EXCEEDED &&
+              !isNonRetryableBodyError(errText) &&
+              !isCapacityError(errText);
+            debugLog("response.error", {
+              status: response.status,
+              statusText: safeStatusText,
+              ...(isRequestRateExceeded ? { reasonCode } : { body: errText }),
+            });
             // Retry transient capacity errors with longer backoff
             if (isCapacityError(errText) && capacityRetryCount < capacityRetryConfig.maxRetries) {
               capacityRetryCount++;
@@ -681,6 +694,25 @@ export function streamKiro(
               logCapacityEvent(
                 `INSUFFICIENT_MODEL_CAPACITY — exhausted ${capacityRetryConfig.maxRetries} retries, giving up`,
               );
+            }
+            if (isRequestRateExceeded) {
+              if (retryCount >= maxRetries) {
+                throw new Error(
+                  `Kiro API error: request window retry budget exhausted (${KIRO_REASON_CODES.USER_REQUEST_RATE_EXCEEDED})`,
+                );
+              }
+              retryCount++;
+              const retryDelay = resolveRequestRateRetryDelay(response.headers);
+              debugLog("request.rateWindowRetry", {
+                attempt: retryCount,
+                maxRetries,
+                delayMs: retryDelay.delayMs,
+                advertisedDelayMs: retryDelay.advertisedDelayMs,
+                capped: retryDelay.capped,
+                reasonCode,
+              });
+              await abortableDelay(retryDelay.delayMs, options?.signal);
+              continue requestLoop;
             }
             if (response.status === 403 && !isCapacityError(errText) && retryCount < maxRetries) {
               retryCount++;

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   CAPACITY_PATTERN,
   exponentialBackoff,
+  extractKiroReason,
   FIRST_TOKEN_TIMEOUT,
   isCapacityError,
   isNonRetryableBodyError,
@@ -12,6 +13,9 @@ import {
   KIRO_REASON_CODES,
   MAX_RETRY_DELAY,
   NON_RETRYABLE_BODY_PATTERNS,
+  parseRetryAfterMs,
+  REQUEST_RATE_FALLBACK_DELAY_MS,
+  resolveRequestRateRetryDelay,
   retryConfig,
   TOO_BIG_PATTERNS,
 } from "../src/retry.js";
@@ -50,6 +54,7 @@ describe("KIRO_REASON_CODES", () => {
       INPUT_TOO_LONG: "Input is too long",
       MONTHLY_REQUEST_COUNT: "MONTHLY_REQUEST_COUNT",
       INSUFFICIENT_MODEL_CAPACITY: "INSUFFICIENT_MODEL_CAPACITY",
+      USER_REQUEST_RATE_EXCEEDED: "USER_REQUEST_RATE_EXCEEDED",
       REQUEST_BODY_INVALID: "REQUEST_BODY_INVALID",
     });
   });
@@ -76,6 +81,58 @@ describe("KIRO_REASON_CODES", () => {
     expect(TOO_BIG_PATTERNS).not.toContain(KIRO_REASON_CODES.REQUEST_BODY_INVALID);
     expect(NON_RETRYABLE_BODY_PATTERNS).not.toContain(KIRO_REASON_CODES.REQUEST_BODY_INVALID);
     expect(isTooBigError(400, KIRO_REASON_CODES.REQUEST_BODY_INVALID)).toBe(false);
+  });
+});
+
+describe("request-window retry classification", () => {
+  it("reads only an exact JSON reason field", () => {
+    expect(extractKiroReason('{"message":"slow down","reason":"USER_REQUEST_RATE_EXCEEDED"}')).toBe(
+      KIRO_REASON_CODES.USER_REQUEST_RATE_EXCEEDED,
+    );
+    expect(extractKiroReason('{"reasonCode":"USER_REQUEST_RATE_EXCEEDED"}')).toBeUndefined();
+    expect(extractKiroReason("USER_REQUEST_RATE_EXCEEDED")).toBeUndefined();
+    expect(extractKiroReason('{"reason":123}')).toBeUndefined();
+    expect(extractKiroReason("not json")).toBeUndefined();
+  });
+
+  it("parses each supported header with explicit units", () => {
+    expect(parseRetryAfterMs(new Headers({ "retry-after-ms": "1500" }))).toBe(1500);
+    expect(parseRetryAfterMs(new Headers({ "retry-after": "1.5" }))).toBe(1500);
+    expect(parseRetryAfterMs(new Headers({ "x-ratelimit-reset-after": "1.5" }))).toBe(1500);
+
+    const now = Date.parse("2026-08-29T00:00:00Z");
+    expect(parseRetryAfterMs(new Headers({ "retry-after": "Sat, 29 Aug 2026 00:00:02 GMT" }), now)).toBe(2000);
+  });
+
+  it("lets a later valid header win after malformed or negative candidates", () => {
+    expect(
+      parseRetryAfterMs(
+        new Headers({
+          "retry-after-ms": "not-a-number",
+          "retry-after": "-5",
+          "x-ratelimit-reset-after": "2",
+        }),
+      ),
+    ).toBe(2000);
+    expect(parseRetryAfterMs(new Headers({ "retry-after-ms": "Infinity" }))).toBeUndefined();
+    expect(parseRetryAfterMs(new Headers({ "retry-after": "-1" }))).toBeUndefined();
+    expect(parseRetryAfterMs(new Headers({ "retry-after": "1e308", "x-ratelimit-reset-after": "2" }))).toBe(2000);
+    expect(parseRetryAfterMs(new Headers({ "x-ratelimit-reset-after": "1e308" }))).toBeUndefined();
+  });
+
+  it("treats an elapsed HTTP date as retry-now", () => {
+    const now = Date.parse("2026-08-29T00:00:00Z");
+    expect(parseRetryAfterMs(new Headers({ "retry-after": "Fri, 28 Aug 2026 23:59:59 GMT" }), now)).toBe(0);
+  });
+
+  it("falls back to 10 seconds and caps longer server hints at 10 seconds", () => {
+    expect(REQUEST_RATE_FALLBACK_DELAY_MS).toBe(10_000);
+    expect(resolveRequestRateRetryDelay(undefined)).toEqual({ delayMs: 10_000, capped: false });
+    expect(resolveRequestRateRetryDelay(new Headers({ "retry-after-ms": "15000" }))).toEqual({
+      delayMs: 10_000,
+      advertisedDelayMs: 15_000,
+      capped: true,
+    });
   });
 });
 

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2803,6 +2803,137 @@ describe("Feature 9: Streaming Integration", () => {
   });
 
   // =========================================================================
+  // Response-header timeout
+  // =========================================================================
+
+  it("times out a fetch that never returns response headers", async () => {
+    vi.useFakeTimers();
+    const originalTimeout = retryConfig.requestHeaderTimeoutMs;
+    retryConfig.requestHeaderTimeoutMs = 10;
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const eventsPromise = collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+      await vi.advanceTimersByTimeAsync(7_100);
+      const events = await eventsPromise;
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      const error = events.find((event) => event.type === "error");
+      expect(error?.type === "error" && error.error.errorMessage).toBe(
+        "Kiro API error: response headers timeout after max retries",
+      );
+    } finally {
+      retryConfig.requestHeaderTimeoutMs = originalTimeout;
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("preserves caller cancellation during the response-header wait", async () => {
+    const controller = new AbortController();
+    const removeListenerSpy = vi.spyOn(controller.signal, "removeEventListener");
+    let notifyFetchStarted: (() => void) | undefined;
+    const fetchStarted = new Promise<void>((resolve) => {
+      notifyFetchStarted = resolve;
+    });
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      notifyFetchStarted?.();
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const eventsPromise = collect(
+        streamKiro(makeModel(), makeContext(), { apiKey: "tok", signal: controller.signal }),
+      );
+      await fetchStarted;
+      controller.abort(new DOMException("cancelled by caller", "AbortError"));
+      const events = await eventsPromise;
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const error = events.find((event) => event.type === "error");
+      expect(error?.type === "error" && error.error.stopReason).toBe("aborted");
+      expect(error?.type === "error" && error.error.errorMessage).toContain("cancelled by caller");
+      expect(error?.type === "error" && error.error.errorMessage).not.toContain("response headers timeout");
+      expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      removeListenerSpy.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("clears the response-header timer and caller listener after headers arrive", async () => {
+    vi.useFakeTimers();
+    const originalTimeout = retryConfig.requestHeaderTimeoutMs;
+    retryConfig.requestHeaderTimeoutMs = 10;
+    const controller = new AbortController();
+    const removeListenerSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const fetchMock = mockFetchOk('{"content":"ok"}{"contextUsagePercentage":5}');
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const events = await collect(
+        streamKiro(makeModel(), makeContext(), { apiKey: "tok", signal: controller.signal }),
+      );
+      const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      const responseHeaderSignal = requestInit.signal as AbortSignal;
+
+      expect(events.find((event) => event.type === "done")).toBeDefined();
+      expect(responseHeaderSignal.aborted).toBe(false);
+      expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+      await vi.advanceTimersByTimeAsync(11);
+      expect(responseHeaderSignal.aborted).toBe(false);
+    } finally {
+      retryConfig.requestHeaderTimeoutMs = originalTimeout;
+      removeListenerSpy.mockRestore();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("retries a response-header timeout and succeeds", async () => {
+    vi.useFakeTimers();
+    const originalTimeout = retryConfig.requestHeaderTimeoutMs;
+    retryConfig.requestHeaderTimeoutMs = 10;
+    const successfulFetch = mockFetchOk('{"content":"ok"}{"contextUsagePercentage":5}');
+    const requestSignals: AbortSignal[] = [];
+    const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      requestSignals.push(init?.signal as AbortSignal);
+      if (requestSignals.length === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        });
+      }
+      return successfulFetch();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const eventsPromise = collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+      await vi.advanceTimersByTimeAsync(1_010);
+      const events = await eventsPromise;
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(requestSignals[0]?.reason).toMatchObject({ name: "TimeoutError" });
+      expect(requestSignals[1]?.aborted).toBe(false);
+      expect(events.find((event) => event.type === "done")).toBeDefined();
+      await vi.advanceTimersByTimeAsync(11);
+      expect(requestSignals[1]?.aborted).toBe(false);
+    } finally {
+      retryConfig.requestHeaderTimeoutMs = originalTimeout;
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  // =========================================================================
   // First-token timeout (Task 1.2)
   // =========================================================================
 
@@ -3228,6 +3359,9 @@ describe("Feature 9: Streaming Integration", () => {
   });
 
   it("does not retry repeated 429 responses inside the provider", async () => {
+    vi.useFakeTimers();
+    const originalTimeout = retryConfig.requestHeaderTimeoutMs;
+    retryConfig.requestHeaderTimeoutMs = 10;
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 429,
@@ -3236,15 +3370,24 @@ describe("Feature 9: Streaming Integration", () => {
     });
     vi.stubGlobal("fetch", mockFetch);
 
-    const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
-    const events = await collect(stream);
+    try {
+      const stream = streamKiro(makeModel(), makeContext(), { apiKey: "tok" });
+      const events = await collect(stream);
+      const requestInit = mockFetch.mock.calls[0]?.[1] as RequestInit;
+      const responseHeaderSignal = requestInit.signal as AbortSignal;
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const error = events.find((e) => e.type === "error");
-    expect(error).toBeDefined();
-    expect(error?.type === "error" && error.error.stopReason).toBe("error");
-
-    vi.unstubAllGlobals();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const error = events.find((e) => e.type === "error");
+      expect(error).toBeDefined();
+      expect(error?.type === "error" && error.error.stopReason).toBe("error");
+      await vi.advanceTimersByTimeAsync(11);
+      expect(responseHeaderSignal.aborted).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      retryConfig.requestHeaderTimeoutMs = originalTimeout;
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
   }, 15000);
 
   it("aborts promptly during 403 retry backoff delay", async () => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -8,7 +8,7 @@ import type {
   TextContent,
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
-import { isContextOverflow } from "@earendil-works/pi-ai/compat";
+import { isContextOverflow, isRetryableAssistantError } from "@earendil-works/pi-ai/compat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { validateKiroConversation, validateKiroToolStructure } from "../src/history-validator.js";
@@ -148,9 +148,9 @@ function encodeBody(body: string): Uint8Array {
   return concatMessages(...parseJsonObjects(body).map((o) => encodeEventMessage(o)));
 }
 
-function mockFetchOk(body: string) {
+function makeOkResponse(body: string): Response {
   const frames = encodeBody(body);
-  return vi.fn().mockResolvedValueOnce({
+  return {
     ok: true,
     body: {
       getReader: () => ({
@@ -162,7 +162,21 @@ function mockFetchOk(body: string) {
       }),
       cancel: async () => {},
     },
-  });
+  } as unknown as Response;
+}
+
+function mockFetchOk(body: string) {
+  return vi.fn().mockResolvedValueOnce(makeOkResponse(body));
+}
+
+function makeRequestRateResponse(headers?: Record<string, string>): Response {
+  return {
+    ok: false,
+    status: 429,
+    statusText: "Too Many Requests",
+    headers: new Headers(headers),
+    text: () => Promise.resolve('{"message":"Please wait before trying again","reason":"USER_REQUEST_RATE_EXCEEDED"}'),
+  } as unknown as Response;
 }
 
 function mockFetchChunked(chunks: string[]) {
@@ -2359,7 +2373,7 @@ describe("Feature 9: Streaming Integration", () => {
       ok: false,
       status: 429,
       statusText: "Too Many Requests",
-      text: () => Promise.resolve("MONTHLY_REQUEST_COUNT exceeded"),
+      text: () => Promise.resolve('{"message":"Monthly quota exhausted","reason":"MONTHLY_REQUEST_COUNT"}'),
     });
     vi.stubGlobal("fetch", mockFetch);
 
@@ -3048,7 +3062,136 @@ describe("Feature 9: Streaming Integration", () => {
   // Provider-level HTTP error handling
   // =========================================================================
 
-  it("propagates 429 immediately so pi-coding-agent can own outer retries", async () => {
+  it.each([
+    ["retry-after-ms milliseconds", { "retry-after-ms": "25" }, 25],
+    ["retry-after seconds", { "retry-after": "0.025" }, 25],
+    ["retry-after HTTP date", { "retry-after": "Sat, 29 Aug 2026 00:00:05 GMT" }, 5000],
+    ["x-ratelimit-reset-after seconds", { "x-ratelimit-reset-after": "0.025" }, 25],
+  ])("honors %s for exact USER_REQUEST_RATE_EXCEEDED and then succeeds", async (_name, headers, delayMs) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T00:00:00Z"));
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeRequestRateResponse(headers))
+      .mockResolvedValueOnce(makeOkResponse('{"content":"ok"}{"contextUsagePercentage":5}'));
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const eventsPromise = collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(delayMs - 1);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      const events = await eventsPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(events.find((event) => event.type === "done")).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it.each([
+    ["an absent hint", undefined],
+    [
+      "malformed, non-finite, and negative hints",
+      { "retry-after-ms": "not-a-number", "retry-after": "-1", "x-ratelimit-reset-after": "Infinity" },
+    ],
+  ])("uses the 10-second request-window fallback for %s", async (_name, headers) => {
+    vi.useFakeTimers();
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeRequestRateResponse(headers))
+      .mockResolvedValueOnce(makeOkResponse('{"content":"ok"}{"contextUsagePercentage":5}'));
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const eventsPromise = collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      const events = await eventsPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(events.find((event) => event.type === "done")).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("caps a longer server request-window hint at 10 seconds", async () => {
+    vi.useFakeTimers();
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeRequestRateResponse({ "retry-after-ms": "15000" }))
+      .mockResolvedValueOnce(makeOkResponse('{"content":"ok"}{"contextUsagePercentage":5}'));
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const eventsPromise = collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      const events = await eventsPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(events.find((event) => event.type === "done")).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("preserves caller cancellation during request-window backoff", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const mockFetch = vi.fn().mockResolvedValue(makeRequestRateResponse());
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const eventsPromise = collect(
+        streamKiro(makeModel(), makeContext(), { apiKey: "tok", signal: controller.signal }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort(new DOMException("cancelled by caller", "AbortError"));
+      const events = await eventsPromise;
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const error = events.find((event) => event.type === "error");
+      expect(error?.type === "error" && error.error.stopReason).toBe("aborted");
+      expect(error?.type === "error" && error.error.errorMessage).toContain("cancelled by caller");
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("exhausts the shared provider retry budget without starting a new Pi retry episode", async () => {
+    vi.useFakeTimers();
+    const mockFetch = vi.fn().mockResolvedValue(makeRequestRateResponse());
+    vi.stubGlobal("fetch", mockFetch);
+
+    try {
+      const eventsPromise = collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+      await vi.advanceTimersByTimeAsync(30_000);
+      const events = await eventsPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      const error = events.find((event) => event.type === "error");
+      expect(error?.type === "error" && error.error.errorMessage).toBe(
+        "Kiro API error: request window retry budget exhausted (USER_REQUEST_RATE_EXCEEDED)",
+      );
+      expect(error?.type === "error" && isRetryableAssistantError(error.error)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("propagates an unknown 429 immediately so pi-coding-agent can own outer retries", async () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

- add a configurable 90-second deadline for Kiro runtime response headers
- compose each header-wait abort signal with caller cancellation and clean timer/listener state on success, failure, abort, and retry
- retry provider-owned response-header timeouts through the existing shared three-retry budget while preserving the separate post-header first-token deadline
- recognize only HTTP 429 responses whose parsed JSON `reason` is exactly `USER_REQUEST_RATE_EXCEEDED` for provider-local request-window retries
- honor `retry-after-ms`, numeric/date `retry-after`, and `x-ratelimit-reset-after`; use a 10-second fallback and cap all waits at 10 seconds
- keep monthly quota/capacity handling unchanged and leave all other generic HTTP 429/5xx retry ownership with Pi's outer layer
- return a reason-preserving terminal request-window error after exhaustion that the installed Pi retry classifier does not classify as retryable
- add deterministic fake-transport coverage for header timeout/cleanup/cancellation/recovery/exhaustion and request-window hint parsing, cancellation, recovery, exhaustion, classifier behavior, and generic 429/5xx pass-through

No live Kiro/provider requests or credential, account, quota, profile, or global-configuration reads or changes were performed.

## Validation

- `pnpm exec vitest run test/retry.test.ts test/stream.test.ts -t 'request-window|USER_REQUEST_RATE_EXCEEDED|unknown 429|propagates 5xx|monthly quota'` — 15 passed, 142 skipped
- `pnpm test` — 511 passed across 22 files
- `pnpm exec tsc --noEmit` — passed
- `pnpm exec tsc --noEmit -p tsconfig.test.json` — passed
- `pnpm exec biome check .` — 54 files checked, no fixes
- `pnpm exec biome format .` — 54 files checked, no fixes
- `pnpm run build` — passed
- `npm pack --dry-run` — passed, 27-file package manifest
- `git diff --check` — passed
