### PR TITLE
feat(history): keep the newest bounded image for follow-ups

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -5,13 +5,34 @@ import type { KiroHistoryEntry, KiroToolSpec } from "./transform.js";
 export const HISTORY_LIMIT = 850000;
 /** The context window size (in tokens) that HISTORY_LIMIT was calibrated for. */
 export const HISTORY_LIMIT_CONTEXT_WINDOW = 200000;
+/** Maximum combined base64 characters retained for one historical image-bearing turn. */
+export const HISTORY_IMAGE_BASE64_LIMIT = 512 * 1024;
 
-/** Remove images from history entries — they've already been processed by the
- *  model in previous turns and re-sending them wastes context / causes 413s. */
-export function stripHistoryImages(history: KiroHistoryEntry[]): KiroHistoryEntry[] {
-  return history.map((entry) => {
-    if (!entry.userInputMessage?.images) return entry;
-    const { images, ...rest } = entry.userInputMessage;
+/**
+ * Keep at most the newest bounded image-bearing history entry.
+ *
+ * Older images are removed to bound request growth. If the newest image set is
+ * itself too large, remove it as well rather than substituting an older image
+ * that no longer matches a follow-up such as "look at that image again".
+ */
+export function stripHistoryImages(history: KiroHistoryEntry[], keepNewestBounded = true): KiroHistoryEntry[] {
+  let newestImageIndex = -1;
+  for (let index = history.length - 1; index >= 0; index--) {
+    if ((history[index]?.userInputMessage?.images?.length ?? 0) > 0) {
+      newestImageIndex = index;
+      break;
+    }
+  }
+
+  const newestImages = newestImageIndex >= 0 ? history[newestImageIndex]?.userInputMessage?.images : undefined;
+  const keepNewest =
+    keepNewestBounded &&
+    newestImages !== undefined &&
+    newestImages.reduce((size, image) => size + image.source.bytes.length, 0) <= HISTORY_IMAGE_BASE64_LIMIT;
+
+  return history.map((entry, index) => {
+    if (!entry.userInputMessage?.images || (index === newestImageIndex && keepNewest)) return entry;
+    const { images: _images, ...rest } = entry.userInputMessage;
     return { ...entry, userInputMessage: { ...rest } };
   });
 }
@@ -71,8 +92,8 @@ export function injectSyntheticToolCalls(history: KiroHistoryEntry[]): KiroHisto
   return result;
 }
 
-export function prepareHistory(history: KiroHistoryEntry[]): KiroHistoryEntry[] {
-  return injectSyntheticToolCalls(sanitizeHistory(stripHistoryImages(history)));
+export function prepareHistory(history: KiroHistoryEntry[], keepNewestBoundedImage = true): KiroHistoryEntry[] {
+  return injectSyntheticToolCalls(sanitizeHistory(stripHistoryImages(history, keepNewestBoundedImage)));
 }
 
 /** Fail before sending rather than silently discarding conversation context. */

--- a/src/models.ts
+++ b/src/models.ts
@@ -21,6 +21,8 @@ const DEFAULT_MAX_TOKENS = 8_192;
 const BASE_URL = getKiroEndpoints("us-east-1").runtime;
 const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 const REASONING_FAMILY_MARKERS = ["opus", "sonnet", "fable", "coder", "deepseek", "gpt", "glm", "qwen"];
+/** Non-Claude models whose Kiro runtime vision support has been verified end to end. */
+const VERIFIED_IMAGE_MODEL_IDS = new Set(["gpt-5.6-luna"]);
 
 type KiroTokenLimits = NonNullable<KiroCatalogModel["tokenLimits"]>;
 
@@ -454,6 +456,16 @@ function hasReasoningFamilyFallback(modelId: string): boolean {
   return normalizedId === "auto" || REASONING_FAMILY_MARKERS.some((marker) => normalizedId.includes(marker));
 }
 
+function hasVerifiedImageInput(kiroModelId: string): boolean {
+  return kiroModelId.startsWith("claude-") || VERIFIED_IMAGE_MODEL_IDS.has(kiroModelId.toLowerCase());
+}
+
+/** Correct capability metadata from older caches without rewriting the user's cache file. */
+function applyVerifiedCapabilities(model: KiroModel): KiroModel {
+  if (!hasVerifiedImageInput(model.kiroModelId) || model.input.includes("image")) return model;
+  return { ...model, input: ["text", "image"] };
+}
+
 function validateCatalogMetadata(model: KiroCatalogModel): {
   schema?: Record<string, unknown>;
   tokenLimits?: KiroTokenLimits;
@@ -526,7 +538,7 @@ export function mapKiroCatalogModels(catalogModels: KiroCatalogModel[], region: 
         (schema === undefined && hasReasoningFamilyFallback(id)),
       ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
       ...(thinking ? { thinking } : {}),
-      input: existing ? [...existing.input] : isClaude ? ["text", "image"] : ["text"],
+      input: existing ? [...existing.input] : hasVerifiedImageInput(kiroModelId) ? ["text", "image"] : ["text"],
       recoverTextToolCalls: isClaude ? false : undefined,
       cost: ZERO_COST,
       contextWindow: tokenLimits?.maxInputTokens ?? DEFAULT_CONTEXT_WINDOW,
@@ -555,7 +567,14 @@ export function loadCachedModelIds(): void {
 export function getCachedModels(region: string): KiroModel[] {
   const cache = readManagementCache();
   refreshKnownModelIds(cache);
-  return cache?.regions[region]?.models ?? kiroModels;
+  const models = cache?.regions[region]?.models ?? kiroModels;
+  let changed = false;
+  const corrected = models.map((model) => {
+    const result = applyVerifiedCapabilities(model);
+    if (result !== model) changed = true;
+    return result;
+  });
+  return changed ? corrected : models;
 }
 
 export function isCacheStale(region: string): boolean {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -363,7 +363,7 @@ export function streamKiro(
           currentMsgStartIdx,
         } = buildHistory(normalized, kiroModelId, effectiveSystemPrompt);
         // Preserve semantic context locally; Pi owns lossy compaction.
-        const history = prepareHistory(rawHistory);
+        const history = prepareHistory(rawHistory, model.input.includes("image"));
         const dynamicHistoryLimit = Math.floor((model.contextWindow / HISTORY_LIMIT_CONTEXT_WINDOW) * HISTORY_LIMIT);
         const toolResultLimit = TOOL_RESULT_LIMIT;
         const currentMessages = normalized.slice(currentMsgStartIdx);

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -3,6 +3,7 @@ import {
   addPlaceholderTools,
   assertHistoryWithinLimit,
   extractToolNamesFromHistory,
+  HISTORY_IMAGE_BASE64_LIMIT,
   HISTORY_LIMIT,
   HISTORY_LIMIT_CONTEXT_WINDOW,
   injectSyntheticToolCalls,
@@ -197,31 +198,30 @@ describe("Feature 6: History Management", () => {
   });
 
   describe("stripHistoryImages", () => {
-    it("removes images from user input messages in history", () => {
-      const h: KiroHistoryEntry[] = [
-        {
-          userInputMessage: {
-            content: "Look at this image",
-            modelId: "M",
-            origin: "KIRO_CLI",
-            images: [{ format: "png", source: { bytes: "base64data" } }],
-          },
-        },
-        assistantEntry("I see the image"),
-      ];
+    const imageEntry = (content: string, bytes: string): KiroHistoryEntry => ({
+      userInputMessage: {
+        content,
+        modelId: "M",
+        origin: "KIRO_CLI",
+        images: [{ format: "png", source: { bytes } }],
+      },
+    });
+
+    it("keeps only the newest image-bearing history entry", () => {
+      const h = [imageEntry("old", "old-image"), assistantEntry("old reply"), imageEntry("new", "new-image")];
       const stripped = stripHistoryImages(h);
+
       expect(stripped[0].userInputMessage?.images).toBeUndefined();
-      expect(stripped[0].userInputMessage?.content).toBe("Look at this image");
-      expect(stripped[1].assistantResponseMessage?.content).toBe("I see the image");
+      expect(stripped[0].userInputMessage?.content).toBe("old");
+      expect(stripped[2].userInputMessage?.images?.[0]?.source.bytes).toBe("new-image");
     });
 
     it("preserves entries without images unchanged", () => {
       const h: KiroHistoryEntry[] = [userEntry("hello"), assistantEntry("hi")];
-      const stripped = stripHistoryImages(h);
-      expect(stripped).toEqual(h);
+      expect(stripHistoryImages(h)).toEqual(h);
     });
 
-    it("removes images from tool result messages in history", () => {
+    it("keeps the newest bounded tool-result image and its tool payload", () => {
       const h: KiroHistoryEntry[] = [
         userEntry("go"),
         assistantEntry("ok", [{ name: "screenshot", toolUseId: "tc1", input: {} }]),
@@ -238,42 +238,53 @@ describe("Feature 6: History Management", () => {
         },
       ];
       const stripped = stripHistoryImages(h);
-      expect(stripped[2].userInputMessage?.images).toBeUndefined();
+      expect(stripped[2].userInputMessage?.images?.[0]?.source.bytes).toBe("screenshot-data");
       expect(stripped[2].userInputMessage?.userInputMessageContext?.toolResults).toHaveLength(1);
+    });
+
+    it("drops the newest image set when it exceeds the explicit byte bound", () => {
+      const stripped = stripHistoryImages([imageEntry("huge", "x".repeat(HISTORY_IMAGE_BASE64_LIMIT + 1))]);
+      expect(stripped[0].userInputMessage?.images).toBeUndefined();
+    });
+
+    it("strips every image when the active model is text-only", () => {
+      const stripped = stripHistoryImages([imageEntry("old", "old"), imageEntry("new", "new")], false);
+      expect(stripped.every((entry) => entry.userInputMessage?.images === undefined)).toBe(true);
     });
 
     it("does not mutate the original history array", () => {
       const images = [{ format: "png", source: { bytes: "data" } }];
-      const h: KiroHistoryEntry[] = [
-        {
-          userInputMessage: { content: "hi", modelId: "M", origin: "KIRO_CLI", images },
-        },
-      ];
+      const h: KiroHistoryEntry[] = [{ userInputMessage: { content: "hi", modelId: "M", origin: "KIRO_CLI", images } }];
       stripHistoryImages(h);
       expect(h[0].userInputMessage?.images).toEqual(images);
     });
   });
 
   describe("prepareHistory with images", () => {
-    it("strips images from prepared history", () => {
+    it("preserves only the newest bounded image in prepared history", () => {
       const h: KiroHistoryEntry[] = [
         {
           userInputMessage: {
-            content: "Look at this",
+            content: "Old image",
             modelId: "M",
             origin: "KIRO_CLI",
-            images: [{ format: "png", source: { bytes: "x".repeat(1000) } }],
+            images: [{ format: "png", source: { bytes: "old-image" } }],
           },
         },
-        assistantEntry("I see it"),
-        userEntry("thanks"),
-        assistantEntry("welcome"),
+        assistantEntry("I saw the old image"),
+        {
+          userInputMessage: {
+            content: "New image",
+            modelId: "M",
+            origin: "KIRO_CLI",
+            images: [{ format: "png", source: { bytes: "new-image" } }],
+          },
+        },
+        assistantEntry("I saw the new image"),
       ];
       const result = prepareHistory(h);
-      // All image data should be stripped from history
-      for (const entry of result) {
-        expect(entry.userInputMessage?.images).toBeUndefined();
-      }
+      expect(result[0].userInputMessage?.images).toBeUndefined();
+      expect(result[2].userInputMessage?.images?.[0]?.source.bytes).toBe("new-image");
     });
 
     it("removes a huge image before enforcing the limit", () => {
@@ -295,7 +306,7 @@ describe("Feature 6: History Management", () => {
       const resultSize = JSON.stringify(result).length;
       expect(() => assertHistoryWithinLimit(result, HISTORY_LIMIT)).not.toThrow();
       expect(resultSize).toBeLessThanOrEqual(HISTORY_LIMIT);
-      // Should still have entries (not wiped out)
+      expect(result[0].userInputMessage?.images).toBeUndefined();
       expect(result.length).toBeGreaterThan(0);
     });
   });

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -53,6 +53,12 @@ const catalogFixture: KiroCatalogModel[] = [
     additionalModelRequestFieldsSchema: effortSchema("reasoning", ["none", "low", "medium", "high", "xhigh", "max"]),
   },
   {
+    modelId: "gpt-5.6-luna",
+    displayName: "GPT 5.6 Luna",
+    tokenLimits: { maxInputTokens: 300_000, maxOutputTokens: 128_000 },
+    additionalModelRequestFieldsSchema: effortSchema("reasoning", ["none", "low", "medium", "high", "xhigh", "max"]),
+  },
+  {
     modelId: "claude-opus-4.8",
     displayName: "Catalog Opus 4.8",
     tokenLimits: { maxInputTokens: 900_000, maxOutputTokens: 100_000 },
@@ -164,11 +170,18 @@ describe("Feature 2: Model Definitions", () => {
       expect(mapped.find((model) => model.id === expected.id)).toMatchObject(expected);
     });
 
+    it("advertises verified Luna vision without broadening other non-Claude models", () => {
+      expect(mapped.find((model) => model.id === "gpt-5-6-luna")?.input).toEqual(["text", "image"]);
+      expect(mapped.find((model) => model.id === "openai-gpt-5-6")?.input).toEqual(["text"]);
+      expect(mapped.find((model) => model.id === "qwen3-coder-next")?.input).toEqual(["text"]);
+    });
+
     it("retains fresh schema and token metadata for a model also present in the bootstrap list", () => {
       const opus = mapped.find((model) => model.id === "claude-opus-4-8");
       expect(opus?.name).toBe("Catalog Opus 4.8");
-      expect(opus?.additionalModelRequestFieldsSchema).toEqual(catalogFixture[1].additionalModelRequestFieldsSchema);
-      expect(opus?.tokenLimits).toEqual(catalogFixture[1].tokenLimits);
+      const catalogOpus = catalogFixture.find((model) => model.modelId === "claude-opus-4.8");
+      expect(opus?.additionalModelRequestFieldsSchema).toEqual(catalogOpus?.additionalModelRequestFieldsSchema);
+      expect(opus?.tokenLimits).toEqual(catalogOpus?.tokenLimits);
       expect(opus?.contextWindow).not.toBe(kiroModels.find((model) => model.id === opus?.id)?.contextWindow);
     });
 
@@ -239,6 +252,26 @@ describe("Feature 2: Model Definitions", () => {
       expect(isCacheStale(TEST_REGION)).toBe(false);
     });
 
+    it("repairs stale Luna image metadata in memory without rewriting the cache", () => {
+      const [cachedLuna] = mapKiroCatalogModels([{ modelId: "gpt-5.6-luna" }], TEST_REGION);
+      cachedLuna.input = ["text"];
+      const serialized = JSON.stringify({
+        version: KIRO_MANAGEMENT_CACHE_VERSION,
+        source: KIRO_MANAGEMENT_CACHE_SOURCE,
+        regions: {
+          [TEST_REGION]: {
+            region: TEST_REGION,
+            fetchedAt: Date.now(),
+            models: [cachedLuna],
+          },
+        },
+      });
+      writeFileSync(KIRO_MANAGEMENT_CACHE_PATH, serialized, "utf-8");
+
+      expect(getCachedModels(TEST_REGION)[0]?.input).toEqual(["text", "image"]);
+      expect(readFileSync(KIRO_MANAGEMENT_CACHE_PATH, "utf-8")).toBe(serialized);
+    });
+
     it("ignores both the old Q cache path and an unversioned cache at the management path", () => {
       const legacyModels = [{ ...kiroModels[0], id: "legacy-only", kiroModelId: "legacy-only" }];
       const legacyCache = JSON.stringify({ [TEST_REGION]: legacyModels });
@@ -288,7 +321,7 @@ describe("Feature 2: Model Definitions", () => {
       expect(kiroModels.find((model) => model.id === "minimax-m2-1")?.reasoning).toBe(false);
     });
 
-    it("uses image input for Claude and text input for other concrete models", () => {
+    it("uses image input for Claude and text input for other concrete bootstrap models", () => {
       const claudeModels = kiroModels.filter((model) => model.id.startsWith("claude-"));
       const nonClaudeModels = kiroModels.filter((model) => !model.id.startsWith("claude-") && model.id !== "auto");
       expect(claudeModels.every((model) => model.input.includes("text") && model.input.includes("image"))).toBe(true);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1227,7 +1227,7 @@ describe("Feature 9: Streaming Integration", () => {
   // Images in history don't break session (regression)
   // =========================================================================
 
-  it("strips images from history entries so they don't bloat the request", async () => {
+  it("keeps the newest bounded image in history for follow-up recognition", async () => {
     const imageContent: ImageContent = { type: "image", data: "x".repeat(100000), mimeType: "image/png" };
     const context: Context = {
       systemPrompt: "You are helpful",
@@ -1256,11 +1256,9 @@ describe("Feature 9: Streaming Integration", () => {
     expect(done).toBeDefined();
     expect(done?.type === "done" && done.message.stopReason).toBe("stop");
 
-    // History should NOT contain the image base64 data
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     const historyStr = JSON.stringify(body.conversationState.history ?? []);
-    expect(historyStr).not.toContain("x".repeat(1000));
-    // But the history entry text should still be there
+    expect(historyStr).toContain("x".repeat(1000));
     expect(historyStr).toContain("Look at this");
 
     vi.unstubAllGlobals();
@@ -4337,6 +4335,85 @@ describe("Feature 9: Streaming Integration", () => {
     expect(toolUseId).toBe(toolResultId);
     expect(toolUseId).toMatch(/^[a-zA-Z0-9_.:-]{1,64}$/);
     expect(toolUseId).not.toBe(openAiToolCallId);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("strips historical images when the active model is text-only", async () => {
+    const imageContent: ImageContent = { type: "image", data: "image-data", mimeType: "image/png" };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Look" }, imageContent], timestamp: ts },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I saw it" }],
+          api: "kiro-api",
+          provider: "kiro",
+          model: "gpt-text-only",
+          usage: zeroUsage,
+          stopReason: "stop",
+          timestamp: ts,
+        } as AssistantMessage,
+        { role: "user", content: "Describe it again", timestamp: ts },
+      ],
+    };
+    const mockFetch = mockFetchOk('{"content":"No image available"}{"contextUsagePercentage":5}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    await collect(streamKiro(makeModel({ input: ["text"] }), context, { apiKey: "tok" }));
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(JSON.stringify(body.conversationState.history ?? [])).not.toContain("image-data");
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps only the newest bounded historical image", async () => {
+    const largeImage: ImageContent = { type: "image", data: "y".repeat(500000), mimeType: "image/jpeg" };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Image 1" }, largeImage], timestamp: ts },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Got it" }],
+          api: "kiro-api",
+          provider: "kiro",
+          model: "claude-sonnet-4-5",
+          usage: zeroUsage,
+          stopReason: "stop",
+          timestamp: ts,
+        } as AssistantMessage,
+        { role: "user", content: [{ type: "text", text: "Image 2" }, largeImage], timestamp: ts },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Got that too" }],
+          api: "kiro-api",
+          provider: "kiro",
+          model: "claude-sonnet-4-5",
+          usage: zeroUsage,
+          stopReason: "stop",
+          timestamp: ts,
+        } as AssistantMessage,
+        { role: "user", content: "Describe both images", timestamp: ts },
+      ],
+    };
+    const mockFetch = mockFetchOk('{"content":"Both were photos."}{"contextUsagePercentage":5}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel(), context, { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const imageEntries = (body.conversationState.history ?? []).filter(
+      (entry: KiroHistoryEntry) => (entry.userInputMessage?.images?.length ?? 0) > 0,
+    );
+    expect(imageEntries).toHaveLength(1);
+    expect(imageEntries[0].userInputMessage.images[0].source.bytes).toHaveLength(500000);
+    expect(JSON.stringify(body).length).toBeLessThan(850000);
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Problem

History images were stripped wholesale to bound request growth. That broke the most ordinary follow-up: "look at that image again" reached the model with no image attached, because the only copy lived in a turn that had just been emptied.

Separately, `gpt-5.6-luna` was mapped as text-only. Kiro serves vision for it, but only `claude-*` IDs were given image input, so the host dropped attachments before a request was even built.

## Change

- Retain the newest image-bearing turn when its payload fits 512KB of base64; keep stripping older ones.
- If the newest set is itself too large, drop it too rather than falling back to an older image — substituting a different picture answers the question wrongly instead of admitting the image is gone.
- Retention is conditional on the model accepting images, so text-only models still get a stripped history.
- List models with end-to-end verified vision explicitly, and correct stale cache entries on read without rewriting the user's cache file.

## Test

Three stream tests (newest-bounded retention, text-only stripping, only-the-newest) plus history/models unit tests. The previous `strips images from history entries` test is rewritten, since its assertion was the behavior being fixed. Full suite green.
