### PR TITLE
fix(oauth): refresh from the credential's own auth family

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/chsong/.pi/agent/vendor/pi-provider-kiro/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,22 @@
         "@smithy/types": "^4.17.2",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": ">=0.80.10",
+        "@earendil-works/pi-coding-agent": ">=0.80.10",
+        "@earendil-works/pi-tui": ">=0.80.10"
+      },
+      "peerDependenciesMeta": {
+        "@earendil-works/pi-ai": {
+          "optional": true
+        },
+        "@earendil-works/pi-coding-agent": {
+          "optional": true
+        },
+        "@earendil-works/pi-tui": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1365,6 +1381,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,6 +1401,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,6 +1421,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,6 +1441,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1433,6 +1461,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -270,8 +270,26 @@ export async function refreshKiroToken(credentials: OAuthCredentials): Promise<O
 }
 
 async function refreshKiroTokenInternal(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-  const { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, saveKiroCliCredentials, getKiroCliSocialToken } =
-    await import("./kiro-cli.js");
+  const {
+    getKiroCliCredentials,
+    getKiroCliCredentialsAllowExpired,
+    saveKiroCliCredentials,
+    getKiroCliSocialToken,
+    getKiroCliSocialTokenAllowExpired,
+  } = await import("./kiro-cli.js");
+  const credentialAuthMethod =
+    (credentials as KiroCredentials).authMethod ??
+    (credentials.refresh.split("|").at(-1) === "desktop" ? "desktop" : "idc");
+  const getValidCliCredentials = (): KiroCredentials | undefined => {
+    if (credentialAuthMethod === "desktop") return getKiroCliSocialToken();
+    const cliCreds = getKiroCliCredentials();
+    return cliCreds?.authMethod === "idc" ? cliCreds : undefined;
+  };
+  const getExpiredCliCredentials = (): KiroCredentials | undefined => {
+    if (credentialAuthMethod === "desktop") return getKiroCliSocialTokenAllowExpired();
+    const cliCreds = getKiroCliCredentialsAllowExpired();
+    return cliCreds?.authMethod === "idc" ? cliCreds : undefined;
+  };
 
   // API key credentials are long-lived bearer tokens — there is nothing to
   // refresh. Return them unchanged so the same key keeps being used.
@@ -279,38 +297,33 @@ async function refreshKiroTokenInternal(credentials: OAuthCredentials): Promise<
     return credentials;
   }
 
-  // Layer 0: Kiro IDE token — freshest source, covers IAM Identity Center
-  const ideCreds = getKiroIdeCredentials();
-  if (ideCreds) return ideCreds;
+  // Kiro IDE credentials are IDC credentials. Only consult them for IDC
+  // credential refresh — never replace a stored social/desktop session with
+  // the IDE's potentially unrelated account (auth-family guard, #142).
+  if (credentialAuthMethod === "idc") {
+    const ideCreds = getKiroIdeCredentials();
+    if (ideCreds) return ideCreds;
+  }
 
-  // Layer 1: Pre-refresh check — prefer social token if available (user logged in that way)
-  // Otherwise check for any valid kiro-cli token
-  let preCheckCreds = getKiroCliSocialToken();
-  if (!preCheckCreds) {
-    preCheckCreds = getKiroCliCredentials();
-  }
-  if (preCheckCreds) {
-    return preCheckCreds;
-  }
+  // Prefer a fresh CLI token only when it belongs to the same auth family.
+  const preCheckCreds = getValidCliCredentials();
+  if (preCheckCreds) return preCheckCreds;
 
   try {
     const refreshed = await refreshKiroTokenDirect(credentials);
 
-    // Layer 2: Write refreshed tokens back to kiro-cli's SQLite DB so both stay in sync.
+    // Write refreshed tokens back to kiro-cli's SQLite DB so both stay in sync.
     saveKiroCliCredentials(refreshed as KiroCredentials);
 
     return refreshed;
   } catch (refreshError) {
-    // Layer 3: Refresh token may have been rotated by kiro-cli between our
-    // Layer 1 check and the network call. Re-read kiro-cli's DB.
-    const retryCreds = getKiroCliCredentials();
-    if (retryCreds) {
-      return retryCreds;
-    }
+    // The CLI may have rotated the refresh token between the pre-check and
+    // network call. Re-read only the matching auth family.
+    const retryCreds = getValidCliCredentials();
+    if (retryCreds) return retryCreds;
 
-    // Layer 4: kiro-cli may have a newer refresh token (expired access token).
-    // Try refreshing with those credentials instead of the stale ones from auth.json.
-    const expiredCliCreds = getKiroCliCredentialsAllowExpired();
+    // The CLI may have a newer refresh token with an expired access token.
+    const expiredCliCreds = getExpiredCliCredentials();
     if (expiredCliCreds && expiredCliCreds.refresh !== credentials.refresh) {
       try {
         const refreshedFromCli = await refreshKiroTokenDirect(expiredCliCreds);
@@ -321,8 +334,7 @@ async function refreshKiroTokenInternal(credentials: OAuthCredentials): Promise<
       }
     }
 
-    // Layer 5: Graceful degradation — our expires has a 5-min buffer, so the
-    // actual AWS token may still be valid. Return it to buy time.
+    // Our expires has a 5-min buffer, so the actual token may still be valid.
     const actualExpiry = credentials.expires + EXPIRES_BUFFER_MS;
     if (credentials.access && Date.now() < actualExpiry) {
       return { ...credentials, expires: actualExpiry };

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getKiroCliSocialToken } from "../src/kiro-cli.js";
+import { getKiroIdeCredentials } from "../src/kiro-ide.js";
 import type { KiroCredentials } from "../src/oauth.js";
 import { refreshKiroToken } from "../src/oauth.js";
 
@@ -10,6 +12,20 @@ vi.mock("../src/kiro-cli.js", () => ({
   getKiroCliSocialTokenAllowExpired: vi.fn(() => undefined),
   saveKiroCliCredentials: vi.fn(),
 }));
+
+// The IDE credential source is a real file read; stub it so a developer's live
+// Kiro IDE session cannot satisfy the refresh under test.
+vi.mock("../src/kiro-ide.js", () => ({
+  getKiroIdeCredentials: vi.fn(() => undefined),
+  getKiroIdeCredentialsAllowExpired: vi.fn(() => undefined),
+}));
+
+beforeEach(() => {
+  vi.mocked(getKiroCliSocialToken).mockReset();
+  vi.mocked(getKiroCliSocialToken).mockReturnValue(undefined);
+  vi.mocked(getKiroIdeCredentials).mockReset();
+  vi.mocked(getKiroIdeCredentials).mockReturnValue(undefined);
+});
 
 describe("Feature 3: OAuth — Token Refresh", () => {
   // Interactive login / device code flow tests live in test/login.test.ts (Feature 10)
@@ -266,5 +282,41 @@ describe("Feature 3: OAuth — Token Refresh", () => {
 
       vi.unstubAllGlobals();
     });
+  });
+
+  it("does not replace desktop credentials with an unrelated IDE IDC account", async () => {
+    vi.mocked(getKiroIdeCredentials).mockReturnValueOnce({
+      refresh: "ide_rt|ide_cid|ide_csec|idc",
+      access: "ide_at",
+      expires: Date.now() + 3_600_000,
+      clientId: "ide_cid",
+      clientSecret: "ide_csec",
+      region: "eu-central-1",
+      authMethod: "idc",
+    });
+    vi.mocked(getKiroCliSocialToken).mockReturnValueOnce({
+      refresh: "social_rt|desktop",
+      access: "social_at",
+      expires: Date.now() + 3_600_000,
+      clientId: "",
+      clientSecret: "",
+      region: "us-east-1",
+      authMethod: "desktop",
+      profileArn: "arn:aws:codewhisperer:us-east-1:123456789012:profile/social",
+    });
+
+    const creds = (await refreshKiroToken({
+      refresh: "stored_rt|desktop",
+      access: "stored_at",
+      expires: 0,
+      clientId: "",
+      clientSecret: "",
+      region: "us-east-1",
+      authMethod: "desktop",
+    } as KiroCredentials)) as KiroCredentials;
+
+    expect(creds.access).toBe("social_at");
+    expect(creds.authMethod).toBe("desktop");
+    expect(creds.region).toBe("us-east-1");
   });
 });


### PR DESCRIPTION
## Problem

The refresh cascade chose credential sources without regard for which auth method the credential being refreshed actually used. On a machine that has seen both kinds of login, two things go wrong:

- The pre-check preferred the kiro-cli **social** token unconditionally, so an IdC session was silently handed a social account's token — a different identity, with a different profile ARN.
- Layer 0 returned Kiro IDE credentials, which are always IdC, even when the stored session was a social one.

The result is a refresh that "succeeds" while swapping the user's account, which then surfaces later as profile/permission errors rather than as an auth failure.

## Change

Derive the credential's auth family once, from its `authMethod` or the suffix of the encoded refresh field, then filter every source lookup to match: social sources for desktop credentials, IdC-only kiro-cli entries otherwise. The IDE source is consulted only for IdC sessions.

Layer structure, write-back to kiro-cli's SQLite DB, and graceful degradation are unchanged — only source selection is.

## Test

`does not replace desktop credentials with an unrelated IDE IDC account`.

The test file also gains a stub for `src/kiro-ide.js`, which performs a real file read. Without it, a developer running the suite with a live Kiro IDE session cannot observe the behavior under test. Full suite green (494 tests).
