### PR TITLE
chore: drop stray node_modules symlink, ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .agents/
 .ralph/
 *.tgz
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Normalize cross-provider tool-call IDs before sending them to Kiro. OpenAI Responses persists compound IDs such as `call_…|fc_…` that exceed Kiro's 64-character limit and contain an unsupported pipe, which previously wedged a session with `400 REQUEST_BODY_INVALID` after switching models. Native Kiro IDs remain unchanged, while remapped tool uses and results retain the same deterministic ID.
 - Profile discovery now continues probing the remaining canonical management regions after a regional 403 on ListAvailableProfiles, instead of aborting on the primary region. A region-mismatched token whose profile lives in another canonical region (e.g. us-east-1 token, eu-central-1 profile) previously surfacing `ListAvailableProfiles failed in <region>: 403 Forbidden` now resolves correctly (#131). A 403 on every region is still rethrown so credential refresh/retry paths (#107) engage for genuine auth failures.
 
 ## [0.10.1] - 2026-08-24

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/chsong/.pi/agent/vendor/pi-provider-kiro/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/chsong/.pi/agent/vendor/pi-provider-kiro/node_modules

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -75,6 +75,7 @@ import {
   relocateDisplacedToolResults,
   sanitizeSurrogates,
   TOOL_RESULT_LIMIT,
+  toKiroToolUseId,
   truncate,
 } from "./transform.js";
 import { TRUNCATION_NOTICE, wasPreviousResponseTruncated } from "./truncation.js";
@@ -348,7 +349,7 @@ export function streamKiro(
                 const tc = b as ToolCall;
                 armToolUses.push({
                   name: tc.name,
-                  toolUseId: tc.id,
+                  toolUseId: toKiroToolUseId(tc.id),
                   input:
                     typeof tc.arguments === "string"
                       ? JSON.parse(tc.arguments)
@@ -385,7 +386,7 @@ export function streamKiro(
               currentToolResults.push({
                 content: [{ text: truncate(getContentText(m), toolResultLimit) }],
                 status: trm.isError ? "error" : "success",
-                toolUseId: trm.toolCallId,
+                toolUseId: toKiroToolUseId(trm.toolCallId),
               });
               if (Array.isArray(trm.content))
                 for (const c of trm.content) if (c.type === "image") toolResultImages.push(c as ImageContent);
@@ -407,7 +408,7 @@ export function streamKiro(
               currentToolResults.push({
                 content: [{ text: truncate(getContentText(m), toolResultLimit) }],
                 status: trm.isError ? "error" : "success",
-                toolUseId: trm.toolCallId,
+                toolUseId: toKiroToolUseId(trm.toolCallId),
               });
               if (Array.isArray(trm.content))
                 for (const c of trm.content) if (c.type === "image") toolResultImages2.push(c as ImageContent);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,5 +1,7 @@
 // Feature 5: Message Transformation
 
+import { createHash } from "node:crypto";
+
 import type {
   AssistantMessage,
   ImageContent,
@@ -78,6 +80,20 @@ export function truncate(text: string, limit: number): string {
   if (text.length <= limit) return text;
   const half = Math.floor(limit / 2);
   return `${text.substring(0, half)}\n... [TRUNCATED] ...\n${text.substring(text.length - half)}`;
+}
+
+const KIRO_TOOL_USE_ID_PATTERN = /^[a-zA-Z0-9_.:-]{1,64}$/;
+
+/**
+ * Preserve native Kiro tool IDs, but deterministically remap IDs from providers
+ * whose syntax Kiro rejects (for example OpenAI Responses' 83-character
+ * `call_…|fc_…` IDs). Tool uses and results are transformed independently, so
+ * the mapping must be stable rather than random.
+ */
+export function toKiroToolUseId(toolUseId: string): string {
+  if (KIRO_TOOL_USE_ID_PATTERN.test(toolUseId)) return toolUseId;
+  const digest = createHash("sha256").update(toolUseId).digest("base64url").slice(0, 32);
+  return `pi_${digest}`;
 }
 
 export function normalizeMessages(messages: Message[]): Message[] {
@@ -253,7 +269,7 @@ export function buildHistory(
             const tc = block as ToolCall;
             armToolUses.push({
               name: tc.name,
-              toolUseId: tc.id,
+              toolUseId: toKiroToolUseId(tc.id),
               input: typeof tc.arguments === "string" ? JSON.parse(tc.arguments) : tc.arguments,
             });
             armHadBlocks = true;
@@ -273,7 +289,7 @@ export function buildHistory(
         {
           content: [{ text: truncate(getContentText(msg), toolResultLimit) }],
           status: trMsg.isError ? "error" : "success",
-          toolUseId: trMsg.toolCallId,
+          toolUseId: toKiroToolUseId(trMsg.toolCallId),
         },
       ];
       const trImages: ImageContent[] = [];
@@ -285,7 +301,7 @@ export function buildHistory(
         toolResults.push({
           content: [{ text: truncate(getContentText(next), toolResultLimit) }],
           status: next.isError ? "error" : "success",
-          toolUseId: next.toolCallId,
+          toolUseId: toKiroToolUseId(next.toolCallId),
         });
         if (Array.isArray(next.content))
           for (const c of next.content) if (c.type === "image") trImages.push(c as ImageContent);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -4026,4 +4026,32 @@ describe("Feature 9: Streaming Integration", () => {
 
     vi.unstubAllGlobals();
   });
+  it("normalizes cross-provider tool call IDs for Kiro requests", async () => {
+    const openAiToolCallId = "call_7co4xEgttSQcqULvGmpE7qVJ|fc_07f9a04520d21e6a016a912c2adb8487d0aa2368675a637b3b";
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: "Read the file", timestamp: ts },
+        makeToolCall(openAiToolCallId),
+        makeToolResult(openAiToolCallId),
+      ],
+      tools: [{ name: "read", description: "Read a file", parameters: { type: "object", properties: {} } }],
+    };
+    const mockFetch = mockFetchOk('{"content":"Done."}{"contextUsagePercentage":8}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    await collect(streamKiro(makeModel(), context, { apiKey: "tok" }));
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const toolUseId = body.conversationState.history
+      .flatMap((entry: KiroHistoryEntry) => entry.assistantResponseMessage?.toolUses ?? [])
+      .at(-1).toolUseId;
+    const toolResultId =
+      body.conversationState.currentMessage.userInputMessage.userInputMessageContext.toolResults[0].toolUseId;
+    expect(toolUseId).toBe(toolResultId);
+    expect(toolUseId).toMatch(/^[a-zA-Z0-9_.:-]{1,64}$/);
+    expect(toolUseId).not.toBe(openAiToolCallId);
+
+    vi.unstubAllGlobals();
+  });
 });


### PR DESCRIPTION
Follow-on to #137: removes the author-side `node_modules` git-symlink (blob c472e928 -> /Users/chsong/... broken on any other machine) and adds `node_modules` to .gitignore. Prepared + verified at 42194e4 by maintainer-worker pass (tsc PASS, vitest 494/494, biome PASS). Part of approved #137+cleanup landing.