### PR TITLE
feat: re-export KiroManagementHttpError from the entry module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The entry module now re-exports `KiroManagementHttpError`. The class already shipped in 0.10.0 and is thrown by every management-plane request that returns a non-OK status (profile discovery, model catalog, usage limits) and already caught in `stream.ts`, where a 403 drives the credential-refresh retry — but it was not re-exported from `src/index.ts`, and there is no per-module file to deep-import instead: the build bundles the whole graph into one `dist/index.js`. No behaviour change: the class, its `status` field, and every throw and catch site are unchanged. Same entry-point caveat as the 0.10.0 re-exports — this is the extension entry the pi host loads, not a resolvable npm entry point.
+
 ### Fixed
 
 - Normalize cross-provider tool-call IDs before sending them to Kiro. OpenAI Responses persists compound IDs such as `call_…|fc_…` that exceed Kiro's 64-character limit and contain an unsupported pipe, which previously wedged a session with `400 REQUEST_BODY_INVALID` after switching models. Native Kiro IDs remain unchanged, while remapped tool uses and results retain the same deterministic ID.

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {
   validateKiroConversation,
   validateKiroToolStructure,
 } from "./history-validator.js";
+export { KiroManagementHttpError } from "./management.js";
 export { KIRO_MODEL_IDS, kiroModels, resolveKiroModel } from "./models.js";
 // Kiro's own error vocabulary and the predicates this provider classifies it
 // with. Published so consumers can interpret a reason code without an error

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -297,4 +297,16 @@ describe("Feature 1: Extension Registration", () => {
     expect(mod.SYNTHETIC_FAILED_TOOL_RESULT_TEXT).toBe("Tool use was interrupted and did not produce a result.");
     expect(mod.EMPTY_CONTENT_PLACEHOLDER).toBe("Please proceed with the task.");
   });
+
+  // Same entry-module caveat as above: this pins that the symbol leaves this
+  // module, so a consumer can `instanceof` the error the provider already
+  // throws from every management-plane request that returns a non-OK status.
+  // There is no per-module alternative — the build bundles everything into one
+  // `dist/index.js`, so what this module re-exports is the whole reachable
+  // surface and the fallback was string-matching `error.name` or the message.
+  it("re-exports KiroManagementHttpError from the entry module", async () => {
+    const mod = await import("../src/index.js");
+    const { KiroManagementHttpError } = await import("../src/management.js");
+    expect(mod.KiroManagementHttpError).toBe(KiroManagementHttpError);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Same change as #129: re-export `KiroManagementHttpError` from `src/index.ts`, pin it in the entry-module surface test, and document it under **Unreleased → Added**.

## Why a new PR

#129 is still correct on the code, but its CHANGELOG hunk applies against the old Unreleased section that has since shipped as 0.10.1. Merging #129 as-is would put this addition under a released version. This PR is that export with the changelog in the right place.

## Why this, not #112

| | #129 / this PR | #112 |
|---|---|---|
| Scope | Re-export the existing class | Re-export **plus** plane discriminator, `refreshAttempted`, stream diagnostics |
| Behaviour | None | Changes `stream.ts` error flattening |
| Risk | Trivial | Design discussion (auth vs entitlement 403s) |

Land the re-export now. Keep #112 for the auth-plane API after a rebase.

## Verification

- `npm test -- test/registration.test.ts` — 21 passed
- `npm run check` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01ff1-2138-77d3-b30a-cd398194d50a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01ff1-2138-77d3-b30a-cd398194d50a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

