### PR TITLE
fix: GetProfile for ksk_ keys and scan local credentials at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve `ksk_` API key profiles through GetProfile instead of ListAvailableProfiles, which returns 403 Unsupported token type. Catalog queries then use that ARN in us-east-1. `KIRO_PROFILE_ARN` still wins.
+
 ## [0.10.2] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolve `ksk_` API key profiles through GetProfile instead of ListAvailableProfiles, which returns 403 Unsupported token type. Catalog queries then use that ARN in us-east-1. `KIRO_PROFILE_ARN` still wins.
 
+### Changed
+
+- At startup (and when the host refreshModels hook has no credential), scan KIRO_API_KEY then kiro-cli then Kiro IDE and refresh the catalog without blocking registration.
+
 ## [0.10.2] - 2026-08-31
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import type { Api, Model, OAuthCredentials, RefreshModelsContext } from "@earend
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatSafeError } from "./debug.js";
 import { getKiroEndpoints, resolveApiRegion } from "./endpoints.js";
-import { getKiroCliCredentials } from "./kiro-cli.js";
+import { getKiroCliCredentials, getKiroCliSocialToken } from "./kiro-cli.js";
+import { getKiroIdeCredentials } from "./kiro-ide.js";
 import { setExtensionContext } from "./login-ui.js";
 import { getCachedModels, isCacheStale, type KiroModel, kiroModels, updateKiroModelsCache } from "./models.js";
 import type { KiroCredentials } from "./oauth.js";
@@ -56,22 +57,51 @@ export {
   type KiroUserInputMessage,
 } from "./transform.js";
 
+type KiroRefreshModelsContext = Omit<RefreshModelsContext, "credential" | "store"> & {
+  credential?: RefreshModelsContext["credential"] | KiroCredentials;
+  store?: RefreshModelsContext["store"];
+};
+
+type KiroRefreshCredential = KiroRefreshModelsContext["credential"];
+
 /**
- * Host-driven catalog refresh. `oauth.modifyModels` only projects whatever the
- * cache already holds, so this is the path that actually fetches when the host
- * asks for a refresh or the cache has gone stale. The composer re-applies
- * `modifyModels` on top of the returned list, so region/profileArn projection
- * still happens here.
- *
- * Persistence uses the existing Kiro management file cache
- * (`updateKiroModelsCache` / `~/.kiro-management-models-cache.json`) rather than
- * `context.store`, so oauth/stream and host refresh share one catalog source.
+ * Local credential discovery. Every source is a file or environment read, so this
+ * stays callable from the synchronous registration path.
  */
-async function refreshKiroModels(context: RefreshModelsContext): Promise<KiroModel[]> {
-  const credential = context.credential;
-  const oauthCredential = credential?.type === "oauth" ? (credential as unknown as KiroCredentials) : undefined;
-  const accessToken = oauthCredential?.access ?? (credential?.type === "api_key" ? credential.key : undefined);
-  const region = resolveApiRegion(oauthCredential?.region);
+function resolveLocalCredential(): KiroRefreshCredential {
+  const apiKey = process.env.KIRO_API_KEY;
+  if (apiKey) return { type: "api_key", key: apiKey };
+  try {
+    return getKiroCliSocialToken() ?? getKiroCliCredentials() ?? getKiroIdeCredentials() ?? undefined;
+  } catch (error) {
+    console.warn(`[pi-provider-kiro] Failed to read local Kiro credentials: ${formatSafeError(error)}`);
+    return undefined;
+  }
+}
+
+function credentialRegion(credential: KiroRefreshCredential): string {
+  const oauthCredential = credential && "access" in credential ? (credential as KiroCredentials) : undefined;
+  return resolveApiRegion(oauthCredential?.region);
+}
+
+async function refreshCatalog(
+  credential: KiroRefreshCredential,
+  context: Pick<KiroRefreshModelsContext, "allowNetwork" | "force" | "signal">,
+): Promise<KiroModel[]> {
+  const oauthCredential = credential && "access" in credential ? (credential as KiroCredentials) : undefined;
+  const apiKey =
+    credential &&
+    "type" in credential &&
+    credential.type === "api_key" &&
+    "key" in credential &&
+    typeof credential.key === "string"
+      ? credential.key
+      : undefined;
+  const accessToken =
+    typeof oauthCredential?.access === "string" && oauthCredential.access ? oauthCredential.access : apiKey;
+  const region = credentialRegion(credential);
+
+  if (context.signal?.aborted) return [];
 
   if (accessToken && context.allowNetwork && (context.force || isCacheStale(region))) {
     try {
@@ -85,11 +115,46 @@ async function refreshKiroModels(context: RefreshModelsContext): Promise<KiroMod
   return getCachedModels(region);
 }
 
+/**
+ * Host-driven catalog refresh. `oauth.modifyModels` only projects whatever the
+ * cache already holds, so this is the path that actually fetches when the host
+ * asks for a refresh or the cache has gone stale. The composer re-applies
+ * `modifyModels` on top of the returned list, so region/profileArn projection
+ * still happens here.
+ *
+ * Persistence uses the existing Kiro management file cache
+ * (`updateKiroModelsCache` / `~/.kiro-management-models-cache.json`) rather than
+ * `context.store`, so oauth/stream and host refresh share one catalog source.
+ */
+function refreshKiroModels(context: KiroRefreshModelsContext): Promise<KiroModel[]> {
+  return refreshCatalog(context.credential ?? resolveLocalCredential(), context);
+}
+
+let startupCatalogRefresh: Promise<void> = Promise.resolve();
+
+/**
+ * The post-registration startup work the factory deliberately does not await.
+ * Exposed so tests can observe discovery without racing it.
+ */
+export function whenStartupCatalogSettled(): Promise<void> {
+  return startupCatalogRefresh;
+}
+
+/**
+ * Synchronous by contract. A host resolves `api: "kiro-api"` the moment a chat
+ * starts, and not every host awaits an async extension factory before then, so
+ * awaiting catalog discovery here left `kiro-api` unregistered while cached
+ * models were still offered in the picker — the first user message then crashed
+ * with `No API provider registered for api: kiro-api`. Discovery is kicked off
+ * afterwards and the host's `refreshModels` hook fills in the rest.
+ */
 export default function (pi: ExtensionAPI) {
   // Capture ctx for the custom TUI login component
   pi.on("session_start", async (_event, ctx) => {
     setExtensionContext(ctx);
   });
+
+  const credential = resolveLocalCredential();
   pi.registerProvider("kiro", {
     baseUrl: getKiroEndpoints("us-east-1").runtime,
     api: "kiro-api",
@@ -122,4 +187,10 @@ export default function (pi: ExtensionAPI) {
     } as any,
     streamSimple: streamKiro,
   });
+
+  startupCatalogRefresh = refreshCatalog(credential, { allowNetwork: true })
+    .then(() => {})
+    .catch((error) => {
+      console.warn(`[pi-provider-kiro] Kiro startup catalog discovery failed: ${formatSafeError(error)}`);
+    });
 }

--- a/src/management.ts
+++ b/src/management.ts
@@ -4,11 +4,19 @@
 import { createHash } from "node:crypto";
 import { debugLog, redactSensitiveText } from "./debug.js";
 import { getKiroEndpoints } from "./endpoints.js";
-import { kiroAuthHeaders } from "./oauth.js";
+import { isApiKey, kiroAuthHeaders, kiroUserAgent } from "./oauth.js";
 import { kiroTokenTypeHeaders } from "./token-type.js";
 
 const LIST_PROFILES_PATH = "List-Available-Profiles";
 const LIST_MODELS_PATH = "List-Available-Models";
+const GET_PROFILE_TARGET = "AmazonCodeWhispererService.GetProfile";
+
+/**
+ * Region Kiro issues API keys against. `ListAvailableProfiles` answers 403
+ * "Unsupported token type" for a `ksk_` key in every region, so an API key's
+ * profile — and therefore its model catalog — is only reachable here.
+ */
+const API_KEY_REGION = "us-east-1";
 
 export interface KiroManagementAuth {
   accessToken: string;
@@ -40,6 +48,10 @@ export interface KiroGetUsageLimitsRequest {
 
 interface KiroListAvailableProfilesResponse {
   profiles?: Array<{ arn?: string; [key: string]: unknown }>;
+}
+
+interface KiroGetProfileResponse {
+  profile?: { arn?: string; [key: string]: unknown };
 }
 
 const profileArnCache = new Map<string, string>();
@@ -131,6 +143,37 @@ function profileCacheKey(auth: KiroManagementAuth): string {
   return `${auth.region}:${tokenHash}`;
 }
 
+/**
+ * Resolve an API key's own profile through GetProfile, the same RPC the API-key
+ * login flow uses. This is the only profile-discovery call a `ksk_` key can
+ * make: the REST-style ListAvailableProfiles path rejects the key outright.
+ */
+async function getApiKeyProfileArn(accessToken: string): Promise<string> {
+  const operation = "GetProfile";
+  let response: Response;
+  try {
+    response = await fetch(getKiroEndpoints(API_KEY_REGION).management, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-amz-json-1.0",
+        "X-Amz-Target": GET_PROFILE_TARGET,
+        ...kiroAuthHeaders(accessToken),
+        ...kiroUserAgent("codewhispererruntime", "F,C"),
+      },
+      body: "{}",
+    });
+  } catch (error) {
+    throw new Error(`Kiro management ${operation} request failed in ${API_KEY_REGION}`, { cause: error });
+  }
+
+  const parsed = await parseManagementResponse<KiroGetProfileResponse>(response, operation, API_KEY_REGION);
+  const arn = parsed.profile?.arn;
+  if (!arn) {
+    throw new Error(`Kiro management ${operation} returned no profile in ${API_KEY_REGION}`);
+  }
+  return arn;
+}
+
 async function parseManagementResponse<TResponse>(
   response: Response,
   operation: string,
@@ -185,6 +228,16 @@ export async function resolveKiroProfileArn(auth: KiroManagementAuth, providedAr
   if (pending) return pending;
 
   const request = (async () => {
+    // A `ksk_` API key cannot use ListAvailableProfiles at all, so route it to
+    // GetProfile and pin the profile region to where API keys are issued.
+    if (isApiKey(auth.accessToken)) {
+      const arn = await getApiKeyProfileArn(auth.accessToken);
+      profileArnCache.set(key, arn);
+      profileRegionCache.set(key, API_KEY_REGION);
+      debugLog("profile.resolve", { source: "api-key", region: API_KEY_REGION, arn });
+      return arn;
+    }
+
     // ListAvailableProfiles is regional to where the profile actually lives, not
     // to the SSO-derived API region. Probe the primary region first, then the
     // remaining canonical management regions, so a region-mismatched token still
@@ -272,8 +325,12 @@ export async function fetchKiroModelCatalog(
   const profileArn = await resolveKiroProfileArn(auth, providedProfileArn);
   // Route the models query to the region where the profile actually lives — it
   // may differ from the SSO-derived region (#104), and ListAvailableModels is
-  // regional to the profile too, not to the login region.
-  const region = profileRegionCache.get(profileCacheKey(auth)) ?? auth.region;
+  // regional to the profile too, not to the login region. An API key's profile
+  // always lives in the key-issuing region, even when a pinned KIRO_PROFILE_ARN
+  // skipped discovery and left no cached region behind.
+  const region = isApiKey(auth.accessToken)
+    ? API_KEY_REGION
+    : (profileRegionCache.get(profileCacheKey(auth)) ?? auth.region);
   if (region !== auth.region) {
     return listAvailableModels({ ...auth, region }, profileArn);
   }

--- a/test/management.test.ts
+++ b/test/management.test.ts
@@ -8,6 +8,9 @@ import {
 
 const auth = { accessToken: "test-access-token", region: "us-east-1" };
 const profileArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/test";
+// Structurally valid but fake: `ksk_` only selects the GetProfile path.
+const apiKeyAuth = { accessToken: "ksk_not-a-real-key", region: "us-east-1" };
+const apiKeyProfileArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/api-key";
 
 afterEach(() => {
   resetKiroProfileArnCache();
@@ -32,6 +35,103 @@ describe("Kiro management control plane", () => {
     expect(request.headers["Content-Type"]).toBe("application/json");
     expect(request.headers["X-Amz-Target"]).toBeUndefined();
     expect(JSON.parse(request.body)).toEqual({});
+  });
+
+  // Live-probed 2026-08-31 with a real `ksk_` key: ListAvailableProfiles answers
+  // 403 "Unsupported token type" in both canonical regions, while GetProfile
+  // returns the key's own profile. Probing first would leave the catalog empty.
+  it("resolves an API key profile through GetProfile instead of probing ListAvailableProfiles", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ profile: { arn: apiKeyProfileArn } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveKiroProfileArn(apiKeyAuth)).resolves.toBe(apiKeyProfileArn);
+    await expect(resolveKiroProfileArn(apiKeyAuth)).resolves.toBe(apiKeyProfileArn);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, request] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://management.us-east-1.kiro.dev/");
+    expect(request.method).toBe("POST");
+    expect(request.headers["X-Amz-Target"]).toBe("AmazonCodeWhispererService.GetProfile");
+    expect(request.headers["Content-Type"]).toBe("application/x-amz-json-1.0");
+    expect(request.headers.tokentype).toBe("API_KEY");
+    expect(request.body).toBe("{}");
+  });
+
+  it("routes an API key catalog query to the GetProfile ARN in the key-issuing region", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profile: { arn: apiKeyProfileArn } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ models: [{ modelId: "claude-sonnet-4-5" }] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const catalog = await fetchKiroModelCatalog({ accessToken: apiKeyAuth.accessToken, region: "eu-central-1" });
+
+    expect(catalog.models.map((model) => model.modelId)).toEqual(["claude-sonnet-4-5"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const modelsUrl = new URL(fetchMock.mock.calls[1][0]);
+    expect(`${modelsUrl.origin}${modelsUrl.pathname}`).toBe(
+      "https://management.us-east-1.kiro.dev/List-Available-Models",
+    );
+    expect(Object.fromEntries(modelsUrl.searchParams)).toEqual({
+      origin: "KIRO_CLI",
+      profileArn: apiKeyProfileArn,
+    });
+  });
+
+  it("surfaces a rejected API key from GetProfile", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveKiroProfileArn(apiKeyAuth)).rejects.toThrow(
+      "Kiro management GetProfile failed in us-east-1: 403 Forbidden",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the KIRO_PROFILE_ARN override ahead of GetProfile for API keys (#110)", async () => {
+    const envArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/pinned";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [{ modelId: "claude-sonnet-4-5" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const previous = process.env.KIRO_PROFILE_ARN;
+    process.env.KIRO_PROFILE_ARN = envArn;
+    try {
+      await expect(resolveKiroProfileArn(apiKeyAuth)).resolves.toBe(envArn);
+      await fetchKiroModelCatalog(apiKeyAuth);
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(String(fetchMock.mock.calls[0][0])).toContain("List-Available-Models");
+      expect(Object.fromEntries(new URL(fetchMock.mock.calls[0][0]).searchParams).profileArn).toBe(envArn);
+    } finally {
+      if (previous === undefined) delete process.env.KIRO_PROFILE_ARN;
+      else process.env.KIRO_PROFILE_ARN = previous;
+    }
+  });
+
+  it("still probes ListAvailableProfiles for non-API-key tokens", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ profiles: [{ arn: profileArn }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveKiroProfileArn(auth)).resolves.toBe(profileArn);
+
+    const [url, request] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(request.headers["X-Amz-Target"]).toBeUndefined();
+    expect(request.headers.tokentype).toBeUndefined();
   });
 
   it("sends tokentype: EXTERNAL_IDP for external IdP tokens and omits it otherwise", async () => {

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -3,7 +3,27 @@ import type { ProviderModelsStore } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getKiroCliCredentials } from "../src/kiro-cli.js";
-import { KIRO_MANAGEMENT_CACHE_PATH, kiroModels } from "../src/models.js";
+import { getCachedModels, KIRO_MANAGEMENT_CACHE_PATH, type KiroModel, kiroModels } from "../src/models.js";
+
+const credentialMocks = vi.hoisted(() => ({
+  cli: vi.fn(),
+  social: vi.fn(),
+  ide: vi.fn(),
+}));
+
+vi.mock("../src/kiro-cli.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/kiro-cli.js")>("../src/kiro-cli.js");
+  return {
+    ...actual,
+    getKiroCliCredentials: credentialMocks.cli,
+    getKiroCliSocialToken: credentialMocks.social,
+  };
+});
+
+vi.mock("../src/kiro-ide.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/kiro-ide.js")>("../src/kiro-ide.js");
+  return { ...actual, getKiroIdeCredentials: credentialMocks.ide };
+});
 
 const mockPi = () => {
   const registerProvider = vi.fn();
@@ -17,7 +37,32 @@ const mockProviderModelsStore = (): ProviderModelsStore => ({
   delete: vi.fn(async () => {}),
 });
 
+const cliOauthCredential = {
+  access: "cli-access",
+  refresh: "cli-refresh|idc",
+  expires: Date.now() + 60_000,
+  region: "us-east-1",
+  authMethod: "idc" as const,
+  profileArn: "arn:cli",
+  clientId: "",
+  clientSecret: "",
+};
+
 describe("Feature 1: Extension Registration", () => {
+  beforeEach(() => {
+    delete process.env.KIRO_API_KEY;
+    credentialMocks.cli.mockReset();
+    credentialMocks.social.mockReset();
+    credentialMocks.ide.mockReset();
+    rmSync(KIRO_MANAGEMENT_CACHE_PATH, { force: true });
+  });
+
+  afterEach(() => {
+    delete process.env.KIRO_API_KEY;
+    vi.unstubAllGlobals();
+    rmSync(KIRO_MANAGEMENT_CACHE_PATH, { force: true });
+  });
+
   it("exports a default function", async () => {
     const mod = await import("../src/index.js");
     expect(typeof mod.default).toBe("function");
@@ -57,7 +102,7 @@ describe("Feature 1: Extension Registration", () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
 
-    mod.default(pi);
+    await mod.default(pi);
 
     expect(registerProvider).toHaveBeenCalledOnce();
     expect(registerProvider.mock.calls[0][0]).toBe("kiro");
@@ -72,10 +117,121 @@ describe("Feature 1: Extension Registration", () => {
     expect(config.models).toHaveLength(15);
   });
 
-  it("preserves the existing OAuth and kiro-cli credential contract", async () => {
+  // Regression: the factory used to await catalog discovery before registering,
+  // so a host that does not await an async extension factory started a chat with
+  // `kiro-api` unregistered and crashed on the first message with
+  // "No API provider registered for api: kiro-api".
+  it("registers synchronously while catalog discovery is still in flight", async () => {
+    credentialMocks.cli.mockReturnValue(cliOauthCredential);
+    let failFetch: (error: Error) => void = () => {};
+    const pendingFetch = new Promise<never>((_, reject) => {
+      failFetch = reject;
+    });
+    const fetchMock = vi.fn(() => pendingFetch);
+    vi.stubGlobal("fetch", fetchMock);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const mod = await import("../src/index.js");
+    const { pi, registerProvider } = mockPi();
+
+    const returned = mod.default(pi);
+
+    expect(mod.default.constructor.name).toBe("Function");
+    expect(returned).toBeUndefined();
+    expect(registerProvider).toHaveBeenCalledOnce();
+
+    // Discovery was started, not awaited: the registration above already landed
+    // while this request is still outstanding.
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    failFetch(new Error("network down"));
+    await mod.whenStartupCatalogSettled();
+    warn.mockRestore();
+  });
+
+  // A `ksk_` key must reach the catalog through GetProfile: ListAvailableProfiles
+  // answers 403 "Unsupported token type" for API keys, which would otherwise
+  // skip startup discovery even though the bootstrap catalog is already present.
+  it("runs startup discovery after registering and gives KIRO_API_KEY precedence over local credentials", async () => {
+    process.env.KIRO_API_KEY = "ksk_not-a-real-key";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profile: { arn: "arn:startup" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ models: [{ modelId: "claude-sonnet-4.6" }] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
     mod.default(pi);
+    expect(registerProvider).toHaveBeenCalledOnce();
+    await mod.whenStartupCatalogSettled();
+
+    expect(credentialMocks.social).not.toHaveBeenCalled();
+    expect(credentialMocks.cli).not.toHaveBeenCalled();
+    expect(credentialMocks.ide).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][1].headers["X-Amz-Target"]).toBe("AmazonCodeWhispererService.GetProfile");
+    expect(getCachedModels("us-east-1").map((model: KiroModel) => model.id)).toEqual(["claude-sonnet-4-6"]);
+  });
+
+  it("checks kiro-cli social credentials before the general kiro-cli credential scan", async () => {
+    credentialMocks.cli.mockReturnValue(cliOauthCredential);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ models: [{ modelId: "deepseek-3.2" }] }),
+      }),
+    );
+
+    const mod = await import("../src/index.js");
+    const { pi } = mockPi();
+    mod.default(pi);
+    await mod.whenStartupCatalogSettled();
+
+    expect(credentialMocks.social).toHaveBeenCalledOnce();
+    expect(credentialMocks.cli).toHaveBeenCalledOnce();
+    expect(credentialMocks.ide).not.toHaveBeenCalled();
+  });
+
+  it("uses Kiro IDE credentials only after both kiro-cli scans miss", async () => {
+    credentialMocks.ide.mockReturnValue({
+      access: "ide-access",
+      refresh: "ide-refresh|||idc",
+      expires: Date.now() + 60_000,
+      region: "us-east-1",
+      authMethod: "idc",
+      profileArn: "arn:ide",
+      clientId: "",
+      clientSecret: "",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ models: [{ modelId: "glm-5" }] }),
+      }),
+    );
+
+    const mod = await import("../src/index.js");
+    const { pi } = mockPi();
+    mod.default(pi);
+    await mod.whenStartupCatalogSettled();
+
+    expect(credentialMocks.social).toHaveBeenCalledOnce();
+    expect(credentialMocks.cli).toHaveBeenCalledOnce();
+    expect(credentialMocks.ide).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the existing OAuth and kiro-cli credential contract", async () => {
+    const mod = await import("../src/index.js");
+    const { pi, registerProvider } = mockPi();
+    await mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
     expect(config.oauth.name).toBe("Kiro (Builder ID / Google / GitHub)");
@@ -89,7 +245,7 @@ describe("Feature 1: Extension Registration", () => {
   it("registers a streamSimple handler", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
-    mod.default(pi);
+    await mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
     expect(typeof config.streamSimple).toBe("function");
@@ -98,7 +254,7 @@ describe("Feature 1: Extension Registration", () => {
   it("uses kiro-api as the api type", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
-    mod.default(pi);
+    await mod.default(pi);
 
     expect(registerProvider.mock.calls[0][1].api).toBe("kiro-api");
   });
@@ -116,7 +272,7 @@ describe("Feature 1: Extension Registration", () => {
     const refreshModels = async () => {
       const mod = await import("../src/index.js");
       const { pi, registerProvider } = mockPi();
-      mod.default(pi);
+      await mod.default(pi);
       return registerProvider.mock.calls[0][1].refreshModels;
     };
 
@@ -189,7 +345,7 @@ describe("Feature 1: Extension Registration", () => {
   }) => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
-    mod.default(pi);
+    await mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
     const models = kiroModels.map((m) => ({ ...m, provider: "kiro", api: "kiro-api", baseUrl: "old" }));
@@ -201,11 +357,10 @@ describe("Feature 1: Extension Registration", () => {
   it("modifyModels carries the OAuth profile ARN on Kiro models only", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
-    mod.default(pi);
+    await mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
     const profileArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/social";
-    const models = kiroModels.map((model) => ({ ...model, baseUrl: "old" }));
     const creds = {
       access: "social-access",
       refresh: "social-refresh|desktop",
@@ -217,6 +372,7 @@ describe("Feature 1: Extension Registration", () => {
       profileArn,
     };
 
+    const models = kiroModels.map((model) => ({ ...model, baseUrl: "old" }));
     const modified = config.oauth.modifyModels(models, creds);
 
     expect(modified).toHaveLength(models.length);
@@ -226,7 +382,7 @@ describe("Feature 1: Extension Registration", () => {
   it("modifyModels does not apply a hardcoded regional allowlist", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
-    mod.default(pi);
+    await mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
     const models = kiroModels.map((m) => ({ ...m, provider: "kiro", api: "kiro-api", baseUrl: "old" }));
@@ -241,7 +397,7 @@ describe("Feature 1: Extension Registration", () => {
   it("modifyModels preserves non-kiro provider models", async () => {
     const mod = await import("../src/index.js");
     const { pi, registerProvider } = mockPi();
-    mod.default(pi);
+    await mod.default(pi);
 
     const config = registerProvider.mock.calls[0][1];
     const kiro = kiroModels.map((m) => ({ ...m, provider: "kiro", api: "kiro-api", baseUrl: "old" }));


### PR DESCRIPTION
ListAvailableProfiles returns 403 Unsupported token type for `ksk_` keys in every canonical region, so catalog discovery never finds a profile.

This uses the same GetProfile RPC as the API-key login path, pins the catalog query to us-east-1 (where API keys are issued), and keeps `KIRO_PROFILE_ARN` as the override. OAuth/SSO tokens still use the regional ListAvailableProfiles probe.

Also scans local credentials at startup (and when the host `refreshModels` hook has no credential) so catalog discovery runs even when the host did not pass credentials:

1. `KIRO_API_KEY`
2. kiro-cli social
3. kiro-cli
4. Kiro IDE

The factory stays synchronous; discovery is fire-and-forget after `registerProvider`. This does **not** empty the bootstrap catalog and does **not** change the cache path.

Live-probed: GetProfile 200, ListAvailableModels 200, ListAvailableProfiles 403 on us-east-1 and eu-central-1.