### PR TITLE
feat: store Kiro catalog cache under ~/.pi/agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Write the catalog cache to ~/.pi/agent/kiro-management-models-cache.json, still reading the legacy ~/.kiro-management-models-cache.json path.
+
 ## [0.10.2] - 2026-08-31
 
 ### Added

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,9 +1,9 @@
 // Feature 2: Model Definitions
 
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { Model, ThinkingLevelMap } from "@earendil-works/pi-ai";
 import { getKiroEffortConfig, type KiroEffortConfig } from "./effort.js";
 import { getKiroEndpoints } from "./endpoints.js";
@@ -13,7 +13,8 @@ export { resolveApiRegion } from "./endpoints.js";
 
 export const KIRO_MANAGEMENT_CACHE_VERSION = 2;
 export const KIRO_MANAGEMENT_CACHE_SOURCE = "kiro-management";
-export const KIRO_MANAGEMENT_CACHE_PATH = join(homedir(), ".kiro-management-models-cache.json");
+export const KIRO_MANAGEMENT_CACHE_PATH = join(homedir(), ".pi", "agent", "kiro-management-models-cache.json");
+export const LEGACY_HOME_CACHE_PATH = join(homedir(), ".kiro-management-models-cache.json");
 
 const CACHE_MAX_AGE_MS = 3600_000;
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -401,15 +402,21 @@ function parseManagementCache(raw: string): ManagementModelsCache | undefined {
 }
 
 function readManagementCache(): ManagementModelsCache | undefined {
-  if (!existsSync(KIRO_MANAGEMENT_CACHE_PATH)) return undefined;
+  const cachePath = existsSync(KIRO_MANAGEMENT_CACHE_PATH)
+    ? KIRO_MANAGEMENT_CACHE_PATH
+    : existsSync(LEGACY_HOME_CACHE_PATH)
+      ? LEGACY_HOME_CACHE_PATH
+      : undefined;
+  if (!cachePath) return undefined;
   try {
-    return parseManagementCache(readFileSync(KIRO_MANAGEMENT_CACHE_PATH, "utf-8"));
+    return parseManagementCache(readFileSync(cachePath, "utf-8"));
   } catch {
     return undefined;
   }
 }
 
 function writeManagementCache(cache: ManagementModelsCache): void {
+  mkdirSync(dirname(KIRO_MANAGEMENT_CACHE_PATH), { recursive: true });
   const temporaryPath = `${KIRO_MANAGEMENT_CACHE_PATH}.${process.pid}.${randomUUID()}.tmp`;
   try {
     writeFileSync(temporaryPath, JSON.stringify(cache, null, 2), "utf-8");

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { getSupportedThinkingLevels, type ModelThinkingLevel } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { deriveKiroEffort } from "../src/effort.js";
@@ -13,7 +13,9 @@ import {
   KIRO_MANAGEMENT_CACHE_SOURCE,
   KIRO_MANAGEMENT_CACHE_VERSION,
   KIRO_MODEL_IDS,
+  type KiroModel,
   kiroModels,
+  LEGACY_HOME_CACHE_PATH,
   mapKiroCatalogModels,
   resolveApiRegion,
   resolveKiroModel,
@@ -77,13 +79,16 @@ const catalogFixture: KiroCatalogModel[] = [
 ];
 
 beforeEach(() => {
+  mkdirSync(dirname(KIRO_MANAGEMENT_CACHE_PATH), { recursive: true });
   rmSync(KIRO_MANAGEMENT_CACHE_PATH, { force: true });
+  rmSync(LEGACY_HOME_CACHE_PATH, { force: true });
   rmSync(LEGACY_CACHE_PATH, { force: true });
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
   rmSync(KIRO_MANAGEMENT_CACHE_PATH, { force: true });
+  rmSync(LEGACY_HOME_CACHE_PATH, { force: true });
   rmSync(LEGACY_CACHE_PATH, { force: true });
 });
 
@@ -219,6 +224,12 @@ describe("Feature 2: Model Definitions", () => {
   });
 
   describe("management model cache", () => {
+    it("uses ~/.pi/agent as the primary version 2 cache location", () => {
+      expect(KIRO_MANAGEMENT_CACHE_PATH).toBe(join(homedir(), ".pi", "agent", "kiro-management-models-cache.json"));
+      expect(LEGACY_HOME_CACHE_PATH).toBe(join(homedir(), ".kiro-management-models-cache.json"));
+      expect(KIRO_MANAGEMENT_CACHE_VERSION).toBe(2);
+    });
+
     it("accepts the versioned cache and treats its regional catalog as authoritative", async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
@@ -270,6 +281,43 @@ describe("Feature 2: Model Definitions", () => {
 
       expect(getCachedModels(TEST_REGION)[0]?.input).toEqual(["text", "image"]);
       expect(readFileSync(KIRO_MANAGEMENT_CACHE_PATH, "utf-8")).toBe(serialized);
+    });
+
+
+    it("reads the version 2 legacy home cache when the primary cache is absent", () => {
+      const legacyModels = mapKiroCatalogModels([{ modelId: "legacy-only" }], TEST_REGION);
+      writeFileSync(
+        LEGACY_HOME_CACHE_PATH,
+        JSON.stringify({
+          version: KIRO_MANAGEMENT_CACHE_VERSION,
+          source: KIRO_MANAGEMENT_CACHE_SOURCE,
+          regions: {
+            [TEST_REGION]: { region: TEST_REGION, fetchedAt: Date.now(), models: legacyModels },
+          },
+        }),
+        "utf-8",
+      );
+
+      expect(getCachedModels(TEST_REGION).map((model) => model.id)).toEqual(["legacy-only"]);
+      expect(resolveKiroModel("legacy-only")).toBe("legacy-only");
+      expect(isCacheStale(TEST_REGION)).toBe(false);
+    });
+
+    it("prefers the primary cache when both cache paths are valid", () => {
+      const legacyModels = mapKiroCatalogModels([{ modelId: "legacy-only" }], TEST_REGION);
+      const primaryModels = mapKiroCatalogModels([{ modelId: "primary-only" }], TEST_REGION);
+      const cacheWith = (models: KiroModel[]) =>
+        JSON.stringify({
+          version: KIRO_MANAGEMENT_CACHE_VERSION,
+          source: KIRO_MANAGEMENT_CACHE_SOURCE,
+          regions: {
+            [TEST_REGION]: { region: TEST_REGION, fetchedAt: Date.now(), models },
+          },
+        });
+      writeFileSync(LEGACY_HOME_CACHE_PATH, cacheWith(legacyModels), "utf-8");
+      writeFileSync(KIRO_MANAGEMENT_CACHE_PATH, cacheWith(primaryModels), "utf-8");
+
+      expect(getCachedModels(TEST_REGION).map((model) => model.id)).toEqual(["primary-only"]);
     });
 
     it("ignores both the old Q cache path and an unversioned cache at the management path", () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -283,7 +283,6 @@ describe("Feature 2: Model Definitions", () => {
       expect(readFileSync(KIRO_MANAGEMENT_CACHE_PATH, "utf-8")).toBe(serialized);
     });
 
-
     it("reads the version 2 legacy home cache when the primary cache is absent", () => {
       const legacyModels = mapKiroCatalogModels([{ modelId: "legacy-only" }], TEST_REGION);
       writeFileSync(


### PR DESCRIPTION
Independent of #147/#148. Persist v2 cache at ~/.pi/agent/kiro-management-models-cache.json; still read the legacy ~/.kiro-management-models-cache.json when the new path is absent. Writes go only to the new path.