### PR TITLE
fix(stream): honour recoverTextToolCalls before recovering tool calls from text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Honour `recoverTextToolCalls` before rescuing tool calls from assistant prose. `src/models.ts` sets the flag to `false` on every Claude model, and `test/models.test.ts` asserts it, but `src/stream.ts` never read it — so the text-dialect fallback ran for every model. For a model that emits native tool-use events the pass has nothing to rescue and one way to do harm: prose that merely *quotes* the syntax, such as a model explaining how a tool is called, was lifted into a real call the model never made, and the turn ended `stopReason:"toolUse"` so the agent loop went on to execute it. Verified against `claude-sonnet-4-5`: the sentence `You would write [Called read with args: {"path":"/tmp/a"}] to do that.` produced a live `read` call. An absent flag still means recover, so a model the catalog leaves unmarked keeps the fallback and nothing outside the Claude family changes. The existing quoted-XML case passed only because it sits inside a code fence; the inline bracket form did not.
+
 ## [0.10.2] - 2026-08-31
 
 ### Added

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -262,6 +262,7 @@ export function streamKiro(
         kiroRegion?: string;
         kiroProfileArn?: string;
         additionalModelRequestFieldsSchema?: Record<string, unknown>;
+        recoverTextToolCalls?: boolean;
       };
       const region = modelMetadata.kiroRegion ?? getKiroRegionFromEndpoint(model.baseUrl) ?? "us-east-1";
       const endpoint = new URL("generateAssistantResponse", getKiroEndpoints(region).runtime).toString();
@@ -999,7 +1000,15 @@ export function streamKiro(
         // Without this, the turn ends `stopReason:"stop"` with zero tool calls —
         // the agent loop sees a finished answer and an unattended session stalls
         // indefinitely with no error recorded anywhere.
-        if (!sawAnyToolCalls && textBlockIndex !== null) {
+        //
+        // Models that emit native tool-use events opt out via
+        // `recoverTextToolCalls: false`, which `src/models.ts` already sets for
+        // every Claude model. For them this pass has nothing to rescue and one
+        // way to do harm: prose that merely *quotes* the syntax — a model
+        // explaining how a tool is called — is lifted into a real call the model
+        // never made. Absent still means recover, so a model the catalog says
+        // nothing about keeps the fallback.
+        if (modelMetadata.recoverTextToolCalls !== false && !sawAnyToolCalls && textBlockIndex !== null) {
           const textBlock = output.content[textBlockIndex] as TextContent;
           const recovered: Array<{ toolUseId: string; name: string; arguments: Record<string, unknown> }> = [];
           const bracketResult = parseBracketToolCalls(textBlock.text);

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -33,6 +33,7 @@ type TestKiroModel = Model<Api> & {
   kiroRegion?: string;
   kiroProfileArn?: string;
   additionalModelRequestFieldsSchema?: Record<string, unknown>;
+  recoverTextToolCalls?: boolean;
 };
 
 function makeModel(overrides?: Partial<TestKiroModel>): TestKiroModel {
@@ -3862,6 +3863,66 @@ describe("Feature 9: Streaming Integration", () => {
     expect(msg?.content.filter((b) => b.type === "toolCall")).toHaveLength(0);
     const textBlock = msg?.content.find((b) => b.type === "text");
     expect(textBlock?.type === "text" && textBlock.text).toBe(prose);
+    expect(done?.type === "done" && done.reason).toBe("stop");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("recovers bracket-dialect prose for a model the catalog leaves unmarked", async () => {
+    // The fallback's reason to exist. A model with no `recoverTextToolCalls`
+    // entry keeps it, so gating on the flag must not disturb this path.
+    const text = 'You would write [Called read with args: {"path":"/tmp/a"}] to do that.';
+    const mockFetch = mockFetchOk(`${JSON.stringify({ content: text })}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok" });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg?.content.filter((b) => b.type === "toolCall")).toHaveLength(1);
+    expect(done?.type === "done" && done.reason).toBe("toolUse");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not recover bracket-dialect prose a native-tool-call model merely quoted", async () => {
+    // `src/models.ts` sets `recoverTextToolCalls: false` on every Claude model,
+    // but the fallback never read it. A model explaining how a tool is called
+    // had that sentence lifted into a real call it never made — and the turn
+    // ended `toolUse`, so the agent loop went on to execute it.
+    const text = 'You would write [Called read with args: {"path":"/tmp/a"}] to do that.';
+    const mockFetch = mockFetchOk(`${JSON.stringify({ content: text })}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false, recoverTextToolCalls: false }), makeContext(), {
+      apiKey: "tok",
+    });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg?.content.filter((b) => b.type === "toolCall")).toHaveLength(0);
+    const textBlock = msg?.content.find((b) => b.type === "text");
+    expect(textBlock?.type === "text" && textBlock.text).toBe(text);
+    expect(done?.type === "done" && done.reason).toBe("stop");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not recover the XML dialect for a native-tool-call model", async () => {
+    // Same gate, the dialect that carries a shell command.
+    const mockFetch = mockFetchOk(`${JSON.stringify({ content: RECORD_279_TEXT })}{"contextUsagePercentage":10}`);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false, recoverTextToolCalls: false }), makeContext(), {
+      apiKey: "tok",
+    });
+    const events = await collect(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+    expect(msg?.content.filter((b) => b.type === "toolCall")).toHaveLength(0);
     expect(done?.type === "done" && done.reason).toBe("stop");
 
     vi.unstubAllGlobals();


### PR DESCRIPTION
## The gap

`src/models.ts` sets `recoverTextToolCalls: false` on every Claude model, and `test/models.test.ts` asserts it — but `src/stream.ts` never reads the flag. The text-dialect recovery pass runs for every model.

## Why it matters

For a model that emits native tool-use events the pass has nothing to rescue, and one clear way to do harm: prose that merely *quotes* the syntax — a model explaining how a tool is called — gets lifted into a real call the model never made. The turn then ends `stopReason:"toolUse"`, so the agent loop goes on to execute it.

Reproduced on `main` before touching anything. A `claude-sonnet-4-5` response reading

```
You would write [Called read with args: {"path":"/tmp/a"}] to do that.
```

emitted a live `read` toolCall with `arguments: {"path":"/tmp/a"}` and flipped the stop reason to `toolUse`.

The existing `leaves prose that merely quotes the dialect alone` test passes today only because its payload sits inside a code fence. The inline bracket form was never covered.

## The change

One condition at the recovery seam, plus `recoverTextToolCalls` added to the `modelMetadata` cast:

```ts
if (modelMetadata.recoverTextToolCalls !== false && !sawAnyToolCalls && textBlockIndex !== null) {
```

Absent still means recover, so a model the catalog leaves unmarked keeps the fallback and nothing outside the Claude family changes.

## Tests

Three added to `test/stream.test.ts`:

- an unmarked model still recovers bracket-dialect prose — pins the fallback's reason to exist
- a model with `recoverTextToolCalls: false` does not recover the bracket dialect
- the same for the XML dialect, using the `RECORD_279` fixture, which is the one carrying a shell command

Verified by mutation, not by a green run: reverting the one-line gate fails exactly the latter two and leaves the first passing.

`npm test` 525 passing, `npm run check` clean, `npm run lint` reports the same 3 pre-existing warnings as `main` (`src/oauth.ts`, `test/oauth.test.ts`) and exits 0.

## Note

Found while writing stream coverage for a downstream port of this protocol layer. Happy to adjust the shape of the gate or the test placement if you would rather it read differently.