### PR TITLE
fix(transform): preserve developer messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve canonical `developer` messages emitted by newer Pi-compatible hosts by lowering them to Kiro user input. Agent reminders and advisories previously degraded to the neutral `"Please proceed with the task."` placeholder when current, and disappeared from historical context entirely.
+
 ## [0.10.2] - 2026-08-31
 
 ### Added

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -11,6 +11,7 @@ import type {
   Tool,
   ToolCall,
   ToolResultMessage,
+  UserMessage,
 } from "@earendil-works/pi-ai";
 
 export interface KiroImage {
@@ -45,6 +46,13 @@ export interface KiroHistoryEntry {
   userInputMessage?: KiroUserInputMessage;
   assistantResponseMessage?: KiroAssistantResponseMessage;
 }
+
+/** Canonical message shape emitted by newer Pi-compatible hosts after their
+ * application-level custom messages have passed through `convertToLlm`.
+ * Kiro has no developer wire role, so these are lowered to user messages at
+ * the transport boundary. Raw application roles remain the host's concern. */
+type DeveloperMessage = Omit<UserMessage, "role"> & { role: "developer" };
+type KiroInputMessage = Message | DeveloperMessage;
 
 export const TOOL_RESULT_LIMIT = 250000;
 
@@ -96,12 +104,14 @@ export function toKiroToolUseId(toolUseId: string): string {
   return `pi_${digest}`;
 }
 
-export function normalizeMessages(messages: Message[]): Message[] {
-  return messages.filter((msg) => {
-    if (msg.role !== "assistant") return true;
-    const am = msg as AssistantMessage;
-    return am.stopReason !== "error" && am.stopReason !== "aborted";
-  });
+export function normalizeMessages(messages: KiroInputMessage[]): Message[] {
+  return messages
+    .filter((msg) => {
+      if (msg.role !== "assistant") return true;
+      const am = msg as AssistantMessage;
+      return am.stopReason !== "error" && am.stopReason !== "aborted";
+    })
+    .map((msg) => (msg.role === "developer" ? { ...msg, role: "user" as const } : msg));
 }
 
 /**

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2132,13 +2132,11 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
-  // The observed failure: a host appended a reminder message carrying a role
-  // outside pi-ai's `Message` union ("developer") after a settled assistant
-  // turn. None of the current-message branches matched it, so `content` went
-  // out empty and Kiro answered 400 REQUEST_BODY_INVALID — which the provider
-  // then relabeled `context_length_exceeded`, sending the caller into a
-  // compaction loop against a request that was structurally invalid, not large.
-  it("sends placeholder content when the turn ends on an unrecognized role", async () => {
+  // Newer Pi-compatible hosts convert application-specific messages to the
+  // canonical `developer` role before provider dispatch. Kiro has no distinct
+  // developer wire role, so those messages must retain their content as user
+  // input rather than degrade to EMPTY_CONTENT_PLACEHOLDER.
+  it("preserves a current developer message as Kiro user input", async () => {
     const settledAssistant: AssistantMessage = {
       role: "assistant",
       content: [{ type: "text", text: "Done." }],
@@ -2170,9 +2168,48 @@ describe("Feature 9: Streaming Integration", () => {
     const events = await collect(streamKiro(makeModel(), context, { apiKey: "tok" }));
 
     const currentMsg = JSON.parse(mockFetch.mock.calls[0][1].body).conversationState.currentMessage.userInputMessage;
-    expect(currentMsg.content).not.toBe("");
+    expect(currentMsg.content).toBe("<system-reminder>2 incomplete todos</system-reminder>");
     expect(events.some((event) => event.type === "done")).toBe(true);
     expect(events.some((event) => event.type === "error")).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves a historical developer message in Kiro history", async () => {
+    const advisory = {
+      role: "developer",
+      content: [{ type: "text", text: '<advisory severity="concern">STOP_AND_REPORT</advisory>' }],
+      attribution: "agent",
+      timestamp: ts,
+    };
+    const context: Context = {
+      systemPrompt: "You are helpful",
+      messages: [
+        { role: "user", content: "Investigate", timestamp: ts },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Working." }],
+          api: "kiro-api",
+          provider: "kiro",
+          model: "claude-sonnet-4-5",
+          usage: zeroUsage,
+          stopReason: "stop",
+          timestamp: ts,
+        },
+        advisory as unknown as Context["messages"][number],
+        { role: "user", content: "Continue", timestamp: ts + 1 },
+      ],
+      tools: [],
+    };
+    const mockFetch = mockFetchOk('{"content":"Continuing."}{"contextUsagePercentage":4}');
+    vi.stubGlobal("fetch", mockFetch);
+
+    await collect(streamKiro(makeModel(), context, { apiKey: "tok" }));
+
+    const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const historicalAdvisory = sent.conversationState.history.at(-1).userInputMessage;
+    expect(historicalAdvisory.content).toBe('<advisory severity="concern">STOP_AND_REPORT</advisory>');
+    expect(sent.conversationState.currentMessage.userInputMessage.content).toBe("Continue");
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Problem

Newer Pi-compatible hosts can pass canonical `developer` messages to provider transports after application-specific messages have already gone through `convertToLlm`. Kiro has no developer wire role, and this provider only handled `user`, `assistant`, and `toolResult`.

A current developer message therefore became the neutral `Please proceed with the task.` fallback. The same message disappeared entirely once it moved into history. In omp this affects agent-origin context such as advisor notes and system reminders: the UI shows the note, but the Kiro request does not contain it.

This is narrower than #123's original raw-role report. Raw `custom`, `hookMessage`, and summary roles still belong to the host conversion layer. This change handles only `developer`, which is already a canonical provider-facing role in newer hosts.

## Change

Normalize `developer` to `user` before Kiro splits history from the current turn. That single boundary preserves text and images through both paths without teaching the Kiro serializer about application-only message roles.

Existing `user`, `assistant`, and `toolResult` handling is unchanged.

## Tests

Added wire-level regressions for both failure modes:

- a current developer message reaches `currentMessage.userInputMessage.content` byte-for-byte instead of the placeholder;
- a historical developer message remains in `conversationState.history` while the following user message stays current.

Verification:

- `npx vitest run test/stream.test.ts -t 'preserves a .*developer message'`
- `npm test` — 523 passed
- `npm run check`
- `npm run lint` — exits successfully with the existing warnings in untouched OAuth files
- `npm run build`

Written with AI assistance. I reproduced the failure against the installed provider, chose the transport-boundary normalization, and verified the request payload before and after the change.