### PR TITLE
fix(stream): resolve region from kiro-cli session/profile discovery, not just model metadata

### DIFF
--- a/src/management.ts
+++ b/src/management.ts
@@ -163,6 +163,20 @@ export function invalidateKiroProfileArn(auth: KiroManagementAuth): void {
   pendingProfileRequests.delete(key);
 }
 
+/**
+ * Region where `resolveKiroProfileArn` actually found the profile, if it differs
+ * from the region the caller guessed. Callers that built a runtime endpoint from
+ * model metadata (see stream.ts) may have guessed wrong when that metadata was
+ * never stamped with the account's real region (e.g. sub-agent-spawned calls
+ * bypass the `modifyModels` hook that stamps `kiroRegion` on top-level model
+ * objects). Checking this cache after profile resolution lets the runtime
+ * endpoint self-correct instead of sending a region-mismatched profileArn to
+ * the wrong host, which the backend rejects with an unclassified 400.
+ */
+export function getResolvedProfileRegion(auth: KiroManagementAuth): string | undefined {
+  return profileRegionCache.get(profileCacheKey(auth));
+}
+
 export async function resolveKiroProfileArn(auth: KiroManagementAuth, providedArn?: string): Promise<string> {
   // Explicit user override (#110). Highest precedence: a user who pins
   // KIRO_PROFILE_ARN knows which profile they want, even if the token or the

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -40,6 +40,7 @@ import { isKiroToolStructureRule, kiroConversationEntries, repairKiroConversatio
 import { parseInvokeToolCalls } from "./invoke-tool-parser.js";
 import { getKiroCliCredentials, getKiroCliCredentialsAllowExpired, refreshViaKiroCli } from "./kiro-cli.js";
 import {
+  getResolvedProfileRegion,
   invalidateKiroProfileArn,
   type KiroManagementAuth,
   KiroManagementHttpError,
@@ -263,14 +264,26 @@ export function streamKiro(
         kiroProfileArn?: string;
         additionalModelRequestFieldsSchema?: Record<string, unknown>;
       };
-      const region = modelMetadata.kiroRegion ?? getKiroRegionFromEndpoint(model.baseUrl) ?? "us-east-1";
-      const endpoint = new URL("generateAssistantResponse", getKiroEndpoints(region).runtime).toString();
+      const cliCreds = getKiroCliCredentials() ?? getKiroCliCredentialsAllowExpired();
+      // Model metadata is stamped with the account's real region by the
+      // `modifyModels` hook (see index.ts), but that hook only runs for models
+      // resolved through the top-level session's credential/model list. A
+      // sub-agent-spawned call can receive a model object that never went
+      // through `modifyModels`, leaving `kiroRegion`/`baseUrl` at their
+      // provider-registration defaults ("us-east-1"). Falling back to the
+      // active kiro-cli session's own region before the hardcoded default
+      // avoids guessing wrong for any account outside us-east-1.
+      let region =
+        modelMetadata.kiroRegion ??
+        getKiroRegionFromEndpoint(model.baseUrl) ??
+        (cliCreds?.access === accessToken ? cliCreds.region : undefined) ??
+        "us-east-1";
+      let endpoint = new URL("generateAssistantResponse", getKiroEndpoints(region).runtime).toString();
       let managementAuth: KiroManagementAuth = { accessToken, region };
 
       const optionProfileArn =
         (options as unknown as { credentials?: { profileArn?: string }; profileArn?: string })?.credentials
           ?.profileArn || (options as unknown as { profileArn?: string })?.profileArn;
-      const cliCreds = getKiroCliCredentials() ?? getKiroCliCredentialsAllowExpired();
       const cliProfileArn = cliCreds?.access === accessToken ? cliCreds.profileArn : undefined;
       const initialProfileArn = modelMetadata.kiroProfileArn || optionProfileArn || cliProfileArn;
       let profileArn: string;
@@ -295,6 +308,18 @@ export function streamKiro(
         profileArn =
           freshCreds.profileArn ||
           (skipProfileResolutionForTests ? TEST_PROFILE_ARN : await resolveKiroProfileArn(managementAuth));
+      }
+
+      // `resolveKiroProfileArn` probes multiple canonical regions and may have
+      // found the profile somewhere other than our initial guess (#104, #131).
+      // Self-correct the runtime endpoint and management region here instead of
+      // sending a region-mismatched profileArn to the wrong host — that
+      // mismatch is what produces Kiro's generic, unclassified 400 response.
+      const resolvedProfileRegion = getResolvedProfileRegion(managementAuth);
+      if (resolvedProfileRegion && resolvedProfileRegion !== region) {
+        region = resolvedProfileRegion;
+        endpoint = new URL("generateAssistantResponse", getKiroEndpoints(region).runtime).toString();
+        managementAuth = { ...managementAuth, region };
       }
 
       // Trigger dynamic models cache update in the background if empty or stale

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -711,6 +711,116 @@ describe("Feature 9: Streaming Integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("falls back to the kiro-cli session's region when model metadata carries no region hint", async () => {
+    // A sub-agent-spawned call can receive a model object that never went
+    // through the `modifyModels` hook that stamps `kiroRegion`/`baseUrl` with
+    // the account's real region, so both are absent/unresolvable here. The
+    // active kiro-cli session's own region should be preferred over the
+    // "us-east-1" default, saving the extra probe round-trip resolveKiroProfileArn
+    // would otherwise need to find the profile.
+    resetProfileArnCache(false);
+    const testArn = "arn:aws:codewhisperer:eu-central-1:123:profile/TEST";
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profiles: [{ arn: testArn }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"Hi"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
+          }),
+        },
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const kiroCliModule = await import("../src/kiro-cli.js");
+    const getCredsSpy = vi.spyOn(kiroCliModule, "getKiroCliCredentials").mockReturnValue({
+      refresh: "refresh|client|secret|idc",
+      access: "tok",
+      expires: Date.now() + 3_600_000,
+      clientId: "client",
+      clientSecret: "secret",
+      region: "eu-central-1",
+      authMethod: "idc" as const,
+    });
+
+    const events = await collect(
+      streamKiro(makeModel({ kiroRegion: undefined, baseUrl: "https://example.com/" }), makeContext(), {
+        apiKey: "tok",
+      }),
+    );
+
+    // No wasted us-east-1 probe: the cli session's region is tried first.
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.eu-central-1.kiro.dev/List-Available-Profiles");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://runtime.eu-central-1.kiro.dev/generateAssistantResponse");
+    expect(events.find((event) => event.type === "done")).toBeDefined();
+
+    getCredsSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("self-corrects the runtime endpoint when the resolved profile lives in a different region than the model's guess", async () => {
+    // Reproduces the sub-agent 400 bug: model metadata claims us-east-1 (the
+    // provider-registration default, exactly what an un-stamped model object
+    // carries), but the account's profile actually lives in eu-central-1.
+    // resolveKiroProfileArn's canonical-region probe (#104, #131) finds it
+    // there; the runtime endpoint must follow, or the profileArn gets sent to
+    // the wrong regional host and Kiro rejects it with an unclassified 400.
+    resetProfileArnCache(false);
+    const testArn = "arn:aws:codewhisperer:eu-central-1:123:profile/TEST";
+    const mockFetch = vi
+      .fn()
+      // Primary guess (us-east-1): no profile here, but not a 403 — the probe
+      // continues to the next canonical region without raising.
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profiles: [] }),
+      })
+      // Fallback (eu-central-1): profile found.
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ profiles: [{ arn: testArn }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: vi
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: encodeBody('{"content":"Hi"}{"contextUsagePercentage":5}'),
+              })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+            releaseLock: () => {},
+          }),
+        },
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(streamKiro(makeModel(), makeContext(), { apiKey: "tok" }));
+
+    expect(mockFetch.mock.calls[0][0]).toBe("https://management.us-east-1.kiro.dev/List-Available-Profiles");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://management.eu-central-1.kiro.dev/List-Available-Profiles");
+    // The runtime call must follow the region the profile actually resolved
+    // in, not the model's original us-east-1 guess.
+    expect(mockFetch.mock.calls[2][0]).toBe("https://runtime.eu-central-1.kiro.dev/generateAssistantResponse");
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body).profileArn).toBe(testArn);
+    expect(events.find((event) => event.type === "done")).toBeDefined();
+
+    vi.unstubAllGlobals();
+  });
+
   it("sets stopReason to toolUse when tool calls are present", async () => {
     const toolPayload = '{"name":"bash","toolUseId":"tc1","input":"{\\"cmd\\":\\"ls\\"}","stop":true}';
     const mockFetch = mockFetchOk(`${toolPayload}{"contextUsagePercentage":20}`);


### PR DESCRIPTION
## Bug

Any pi sub-agent (spawned via pi's `Agent` tool) fails its **first** API call with a generic, unclassified 400:

```
Kiro API error: 400 Bad Request {"message":"Improperly formed request.","reason":null}
```

Reproduced consistently across sub-agent types with wildly different tool counts (5 tools vs 30+ tools) and prompt sizes, ruling out payload shape/size as the cause. Top-level (non-sub-agent) calls on the same session, same account, succeed without issue. Direct `kiro-cli chat` also succeeds, confirming the account/credentials are healthy.

## Root cause

Captured both a successful top-level request and a failing sub-agent request with `KIRO_DEBUG=1` and diffed them structurally — identical tool schemas, identical JSON shape, smaller total payload on the failing one. The actual divergence was in the `profile.resolve` debug line vs. the request's target host:

- Successful call: profile resolved for `eu-central-1` → sent to `runtime.eu-central-1.kiro.dev` ✅
- Failing sub-agent call: profile resolved for `eu-central-1` → sent to `runtime.us-east-1.kiro.dev` ❌

In `src/stream.ts`, `streamKiro` computes the runtime endpoint's region purely from model metadata:

```ts
const region = modelMetadata.kiroRegion ?? getKiroRegionFromEndpoint(model.baseUrl) ?? "us-east-1";
```

`kiroRegion`/`baseUrl` are normally stamped onto every model object by the `modifyModels` hook in `index.ts`, which derives them from the OAuth credential's real region. A model object that never went through that hook — which appears to be what a pi sub-agent spawn receives — falls through to the hardcoded `"us-east-1"` default. For any account whose profile actually lives in a different region (e.g. `eu-central-1`), this sends that region's `profileArn` to the wrong runtime host, and Kiro's backend rejects it with the generic, unclassified 400 above (not one of the size/capacity-related reason codes already handled elsewhere in this codebase).

Notably, `resolveKiroProfileArn` in `src/management.ts` already has a workaround for a closely related problem (#104, #131) — it probes both canonical management regions and caches whichever one actually has the profile. That correct region was being discovered and cached, but never read back to fix the runtime endpoint.

## Fix

1. Prefer the active `kiro-cli` session's own region (when its access token matches the one in use) over the `"us-east-1"` default, ahead of `resolveKiroProfileArn`'s network round-trip.
2. Export `getResolvedProfileRegion()` from `management.ts` (a thin accessor over the existing `profileRegionCache`) and use it in `streamKiro` to rebuild the runtime endpoint + management auth after profile resolution, if the resolved profile's region disagrees with the initial guess.

## Testing

- Added two regression tests to `test/stream.test.ts`:
  - `"falls back to the kiro-cli session's region when model metadata carries no region hint"`
  - `"self-corrects the runtime endpoint when the resolved profile lives in a different region than the model's guess"`
- Full suite: `npm test` → 524 passed (522 existing + 2 new), 0 failed.
- `npm run check` (tsc, both configs) → clean.
- `npx biome check src/stream.ts src/management.ts test/stream.test.ts` → clean (pre-existing lint warnings in unrelated `oauth.ts`/`oauth.test.ts` untouched).

## Notes

Not a fix to the sub-agent spawning code path itself (which is outside this repo) — this makes the provider's region resolution resilient regardless of what the caller's model object carries, which is the right fix either way since the underlying region-guessing logic was fragile for any caller, not just sub-agents.
