### PR TITLE
fix: cancel body read when caller abort signal fires mid-stream

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -772,6 +772,16 @@ export function streamKiro(
         stream.push({ type: "start", partial: output });
         if (!response.body) throw new Error("No response body");
         const bodyReader = (response.body as unknown as ReadableStream<Uint8Array>).getReader();
+        // Cancel the body read as soon as the caller aborts (e.g. user presses
+        // Esc mid-stream). Without this, the read loop below keeps consuming
+        // the event stream until the server finishes the response, which makes
+        // an interrupt appear to hang for the remainder of the generation.
+        const callerSignal = options?.signal;
+        const onCallerStreamAbort = () => {
+          void bodyReader.cancel().catch(() => {});
+        };
+        if (callerSignal?.aborted) onCallerStreamAbort();
+        else callerSignal?.addEventListener("abort", onCallerStreamAbort, { once: true });
         let totalContent = "";
         let lastContentData = "";
         let usageEvent: { inputTokens?: number; outputTokens?: number } | null = null;
@@ -851,6 +861,7 @@ export function streamKiro(
         const iterator = eventStream[Symbol.asyncIterator]() as AsyncIterator<Record<string, unknown>>;
 
         while (true) {
+          if (callerSignal?.aborted) break;
           let iterResult: IteratorResult<Record<string, unknown>>;
           try {
             if (!gotFirstToken) {
@@ -970,6 +981,13 @@ export function streamKiro(
           if (streamError) break;
         }
         if (idleTimer) clearTimeout(idleTimer);
+        callerSignal?.removeEventListener("abort", onCallerStreamAbort);
+        if (callerSignal?.aborted) {
+          // Surface the abort instead of treating the cancelled read as a
+          // retryable stream error; the outer catch maps this to
+          // stopReason "aborted".
+          throw callerSignal.reason ?? new Error("Request aborted");
+        }
         if (firstTokenTimedOut || idleCancelled || streamError) {
           // Timed out or received error mid-stream: retry with backoff
           if (retryCount < maxRetries) {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -187,7 +187,10 @@ function mockFetchChunked(chunks: string[]) {
   readMock.mockResolvedValueOnce({ done: true, value: undefined });
   return vi.fn().mockResolvedValueOnce({
     ok: true,
-    body: { getReader: () => ({ read: readMock, releaseLock: () => {} }), cancel: async () => {} },
+    body: {
+      getReader: () => ({ read: readMock, releaseLock: () => {}, cancel: async () => {} }),
+      cancel: async () => {},
+    },
   });
 }
 
@@ -1078,7 +1081,10 @@ describe("Feature 9: Streaming Integration", () => {
     });
     const mockFetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      body: { getReader: () => ({ read: readMock, releaseLock: () => {} }), cancel: async () => {} },
+      body: {
+        getReader: () => ({ read: readMock, releaseLock: () => {}, cancel: async () => {} }),
+        cancel: async () => {},
+      },
     });
     vi.stubGlobal("fetch", mockFetch);
 
@@ -1090,6 +1096,50 @@ describe("Feature 9: Streaming Integration", () => {
     expect(error?.type === "error" && error.error.stopReason).toBe("aborted");
     // Should have partial content from first chunk
     expect(error?.type === "error" && error.error.content.length).toBeGreaterThanOrEqual(0);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("cancels a pending body read when the signal fires (no hang until server finishes)", async () => {
+    const ac = new AbortController();
+    let pendingReject: ((e: unknown) => void) | undefined;
+    let cancelled = false;
+    const readMock = vi
+      .fn()
+      .mockImplementationOnce(async () => ({ done: false, value: encodeBody('{"content":"chunk1"}') }))
+      // Second read never resolves on its own — simulates a slow generation.
+      // It only rejects when cancel() is invoked, like a real reader.
+      .mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            pendingReject = reject;
+          }),
+      );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: readMock,
+          releaseLock: () => {},
+          cancel: async () => {
+            cancelled = true;
+            pendingReject?.(new DOMException("The operation was aborted", "AbortError"));
+          },
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stream = streamKiro(makeModel({ reasoning: false }), makeContext(), { apiKey: "tok", signal: ac.signal });
+    // Abort once the stream is mid-read.
+    setTimeout(() => ac.abort(), 20);
+    const events = await collect(stream);
+
+    expect(cancelled).toBe(true);
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeDefined();
+    expect(error?.type === "error" && error.error.stopReason).toBe("aborted");
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Summary

Pressing Esc in pi to interrupt a streaming response lags noticeably with the kiro provider — the abort only takes effect once the server finishes generating.

Root cause: after response headers arrive, the streaming read loop in `src/stream.ts` never observes `options.signal`. The signal is only wired to:
- the response-header deadline (`createResponseHeaderDeadline`), and
- `abortableDelay` between retries.

So a mid-stream abort leaves `await iterator.next()` blocked, consuming the event stream until the server completes the response. Other pi providers (Anthropic, Bedrock) pass the signal into their SDK fetch, which kills the network read immediately — this makes the lag kiro-specific.

## Fix

- Register an abort listener on `options.signal` that cancels the body reader immediately, so the pending read rejects at once.
- Break out of the read loop if the signal is already aborted.
- After the loop, re-throw the abort reason instead of classifying the cancelled read as a retryable stream error; the existing outer catch already maps this to `stopReason: "aborted"`.

## Tests

- New regression test: aborts while a read is pending and asserts the reader is cancelled and the stream ends with `stopReason: "aborted"`. Without the fix this test hangs (verified against unpatched `src/stream.ts`).
- Added the missing `cancel()` method to two reader mocks — the production code already calls `bodyReader.cancel()` in the first-token/idle timeout paths, so mocks without it throw an unhandled `TypeError` once the abort listener fires.
- `npx tsc --noEmit`, `npx tsc --noEmit -p tsconfig.test.json`, `npx biome check`, and the full `vitest` suite (523 tests) all pass.