### PR TITLE
Track Kiro credits in usage dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add opt-in Kiro credit usage tracking for Pi cost dashboards. `usageTracking.enabled` converts the final successful attempt's exact credit count to an estimated USD-equivalent total, using the published `$0.04` add-on-credit rate by default or an optional `usdPerCredit` override. Tracking remains disabled by default; the estimate is not an invoice, and subscription-included credits may have no marginal cost.
+
 ### Fixed
 
 - Resolve `ksk_` API key profiles through GetProfile instead of ListAvailableProfiles, which returns 403 Unsupported token type. Catalog queries then use that ARN in us-east-1. `KIRO_PROFILE_ARN` still wins.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,35 @@ Or let Kiro pick automatically:
 
 Reasoning is automatically enabled for supported models. Use `/reasoning` to adjust the thinking budget.
 
+### Estimated usage cost
+
+Kiro reports an exact credit count for completed turns, but not a per-turn USD charge. In `~/.pi/agent/settings.json`, you can opt in to converting those credits into an estimated USD-equivalent value for Pi usage dashboards:
+
+```json
+{
+  "pi-provider-kiro": {
+    "usageTracking": {
+      "enabled": true
+    }
+  }
+}
+```
+
+When enabled, `usdPerCredit` defaults to Kiro's published add-on rate of `$0.04` per credit. Override it when a different equivalent rate is appropriate:
+
+```json
+{
+  "pi-provider-kiro": {
+    "usageTracking": {
+      "enabled": true,
+      "usdPerCredit": 0.025
+    }
+  }
+}
+```
+
+This value is an estimate, not an invoice or confirmed marginal charge. Credits included in a subscription may have no marginal cost. Tracking is disabled by default, and invalid settings fail closed to disabled. Pi's HTML session export currently recomputes component costs and may therefore show `$0`; cost dashboards and summaries that read `usage.cost.total` show the estimate.
+
 ## Retry Behavior
 
 Generic transient retries such as HTTP `429` and `5xx` are handled by `pi-coding-agent` at the session layer.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,9 @@ import { setExtensionContext } from "./login-ui.js";
 import { getCachedModels, isCacheStale, type KiroModel, kiroModels, updateKiroModelsCache } from "./models.js";
 import type { KiroCredentials } from "./oauth.js";
 import { loginKiro, refreshKiroToken } from "./oauth.js";
-import { streamKiro } from "./stream.js";
+import { createKiroStream } from "./stream.js";
 import { fetchKiroUsage } from "./usage.js";
+import { loadKiroUsageTracking } from "./usage-tracking.js";
 
 export { resolveApiRegion } from "./endpoints.js";
 export type { KiroProviderAttempts } from "./errors.js";
@@ -157,6 +158,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   const credential = resolveLocalCredential();
+  const streamSimple = createKiroStream(loadKiroUsageTracking());
   pi.registerProvider("kiro", {
     baseUrl: getKiroEndpoints("us-east-1").runtime,
     api: "kiro-api",
@@ -187,7 +189,7 @@ export default function (pi: ExtensionAPI) {
       fetchUsage: fetchKiroUsage,
       // biome-ignore lint/suspicious/noExplicitAny: ProviderConfig.oauth doesn't include getCliCredentials but OAuthProviderInterface does
     } as any,
-    streamSimple: streamKiro,
+    streamSimple,
   });
 
   startupCatalogRefresh = refreshCatalog(credential, { allowNetwork: true })

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -86,6 +86,7 @@ import {
   truncate,
 } from "./transform.js";
 import { TRUNCATION_NOTICE, wasPreviousResponseTruncated } from "./truncation.js";
+import { estimateKiroCreditCost, type KiroUsageTracking } from "./usage-tracking.js";
 
 const CAPACITY_LOG_DIR = join(homedir(), ".pi", "logs");
 const CAPACITY_LOG_FILE = join(CAPACITY_LOG_DIR, "capacity-retries.log");
@@ -389,6 +390,21 @@ function emitToolCall(
 }
 
 export function streamKiro(
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+  return streamKiroWithUsageTracking({ enabled: false }, model, context, options);
+}
+
+export function createKiroStream(
+  usageTracking: KiroUsageTracking,
+): (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream {
+  return (model, context, options) => streamKiroWithUsageTracking(usageTracking, model, context, options);
+}
+
+function streamKiroWithUsageTracking(
+  usageTracking: KiroUsageTracking,
   model: Model<Api>,
   context: Context,
   options?: SimpleStreamOptions,
@@ -1023,6 +1039,7 @@ export function streamKiro(
         let totalContent = "";
         let lastContentData = "";
         let usageEvent: KiroUsageData | null = null;
+        let meteringEvent: { credits?: number; unit?: string } | null = null;
         let receivedContextUsage = false;
         const thinkingParser = thinkingEnabled ? new ThinkingTagParser(output, stream) : null;
         let nativeThinkingBlockIndex: number | null = null;
@@ -1278,8 +1295,7 @@ export function streamKiro(
               break;
             }
             case "metering": {
-              // MeteringEvent.usage counts credits, not tokens. Recorded for
-              // observability only; never folded into token accounting.
+              meteringEvent = event.data;
               if (debugEnabled()) debugLog("stream.metering", [event.data]);
               break;
             }
@@ -1581,6 +1597,10 @@ export function streamKiro(
           // requires `!sawAnyToolCalls`. Kept so that loosening either predicate
           // appends rather than silently overwriting an exhaustion diagnostic.
           output.errorMessage = output.errorMessage ? `${output.errorMessage}. ${dropDiagnostic}` : dropDiagnostic;
+        }
+        if (!output.errorMessage) {
+          const estimatedCost = estimateKiroCreditCost(usageTracking, meteringEvent);
+          if (estimatedCost !== undefined) output.usage.cost.total = estimatedCost;
         }
         stream.push({ type: "done", reason: output.stopReason as "stop" | "toolUse", message: output });
         debugLog("response.done", {

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -1,0 +1,93 @@
+// ABOUTME: Opt-in usage tracking config — reads pi settings for Kiro credit accounting.
+// ABOUTME: Converts MeteringEvent credits into an estimated USD-equivalent cost.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Kiro's published add-on credit rate (https://kiro.dev/pricing/). Used as the
+ * conversion default so an enabled config needs no rate at all.
+ */
+export const DEFAULT_USD_PER_CREDIT = 0.04;
+
+/** Resolved conversion policy. `enabled: false` reproduces the historical zero-cost behaviour. */
+export type KiroUsageTracking = { enabled: false } | { enabled: true; usdPerCredit: number };
+
+const DISABLED: KiroUsageTracking = Object.freeze({ enabled: false });
+
+/** `MeteringEvent.unit` values that denote credits. The service has emitted both. */
+const CREDIT_UNITS = new Set(["credit", "credits"]);
+
+/**
+ * Load the conversion policy from pi's settings file.
+ *
+ * Fails closed on every unreadable, malformed, or out-of-range input: usage
+ * accounting is opt-in, so an unparseable setting must leave cost reporting
+ * exactly as it was rather than guess a rate. Settings contents are never
+ * logged — the file holds credentials for other providers.
+ */
+export function loadKiroUsageTracking(agentDir = getPiAgentDir()): KiroUsageTracking {
+  const raw = readSettings(join(agentDir, "settings.json"));
+  const tracking = asRecord(asRecord(raw)?.["pi-provider-kiro"])?.usageTracking;
+  const section = asRecord(tracking);
+  if (!section || section.enabled !== true) return DISABLED;
+
+  const usdPerCredit = resolveRate(section.usdPerCredit);
+  if (usdPerCredit === undefined) {
+    console.warn(
+      "[pi-provider-kiro] Ignoring usageTracking: usdPerCredit must be a finite number >= 0. Usage tracking stays disabled.",
+    );
+    return DISABLED;
+  }
+  return { enabled: true, usdPerCredit };
+}
+
+/**
+ * Estimated USD-equivalent value of one turn's credits, or `undefined` when the
+ * record cannot be trusted.
+ *
+ * This is a conversion of Kiro's own credit count, NOT a billed amount: credits
+ * included in a subscription may carry no marginal charge at all.
+ */
+export function estimateKiroCreditCost(
+  tracking: KiroUsageTracking,
+  metering: { credits?: number; unit?: string } | null | undefined,
+): number | undefined {
+  if (!tracking.enabled || !metering) return undefined;
+  if (typeof metering.unit !== "string" || !CREDIT_UNITS.has(metering.unit.toLowerCase())) return undefined;
+  const { credits } = metering;
+  if (typeof credits !== "number" || !Number.isFinite(credits) || credits < 0) return undefined;
+  return credits * tracking.usdPerCredit;
+}
+
+/** pi's agent directory, honoring the same override pi itself reads. */
+export function getPiAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+function readSettings(path: string): unknown {
+  let contents: string;
+  try {
+    contents = readFileSync(path, "utf-8");
+  } catch {
+    return undefined; // No settings file is the common case, not an error.
+  }
+  try {
+    return JSON.parse(contents);
+  } catch {
+    console.warn(`[pi-provider-kiro] Could not parse ${path}; Kiro usage tracking stays disabled.`);
+    return undefined;
+  }
+}
+
+/** An omitted rate takes the published default; a present one must be usable. */
+function resolveRate(value: unknown): number | undefined {
+  if (value === undefined) return DEFAULT_USD_PER_CREDIT;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+  return value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -13,8 +13,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { findJsonEnd } from "../src/bracket-tool-parser.js";
 import { validateKiroConversation, validateKiroToolStructure } from "../src/history-validator.js";
 import { capacityRetryConfig, retryConfig } from "../src/retry.js";
-import { resetProfileArnCache, streamKiro } from "../src/stream.js";
+import { createKiroStream, resetProfileArnCache, streamKiro } from "../src/stream.js";
 import { EMPTY_CONTENT_PLACEHOLDER, type KiroHistoryEntry } from "../src/transform.js";
+import type { KiroUsageTracking } from "../src/usage-tracking.js";
 import {
   concatMessages,
   encodeEventMessage,
@@ -223,6 +224,9 @@ function mockFetchChunked(chunks: string[]) {
 }
 
 describe("Feature 9: Streaming Integration", () => {
+  const trackedStream = (usdPerCredit = 0.04) =>
+    createKiroStream({ enabled: true, usdPerCredit } satisfies KiroUsageTracking);
+
   beforeEach(() => {
     // Mark profileArn as already resolved so tests don't see an extra fetch
     resetProfileArnCache(true);
@@ -3806,6 +3810,149 @@ describe("Feature 9: Streaming Integration", () => {
     expect(msg.usage.totalTokens).toBe(50250);
 
     vi.unstubAllGlobals();
+  });
+
+  it("converts valid metering credits to estimated USD-equivalent cost when enabled", async () => {
+    const frames = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage({ usage: 3, unit: "credit", unitPlural: "credits" }, "meteringEvent"),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(trackedStream()(makeModel(), makeContext(), { apiKey: "tok" }));
+    const done = events.find((event) => event.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+
+    expect(msg?.usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.12 });
+  });
+
+  it("uses a custom USD-per-credit rate", async () => {
+    const frames = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage({ usage: 2, unit: "credits" }, "meteringEvent"),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(trackedStream(0.025)(makeModel(), makeContext(), { apiKey: "tok" }));
+    const done = events.find((event) => event.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+
+    expect(msg?.usage.cost.total).toBe(0.05);
+  });
+
+  it.each([
+    ["missing unit", { usage: 3 }],
+    ["wrong unit", { usage: 3, unit: "token" }],
+    ["negative credits", { usage: -1, unit: "credit" }],
+    ["non-finite credits", { usage: null, unit: "credit" }],
+  ])("does not convert %s", async (_label, metering) => {
+    const frames = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage(metering, "meteringEvent"),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(trackedStream()(makeModel(), makeContext(), { apiKey: "tok" }));
+    const done = events.find((event) => event.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+
+    expect(msg?.usage.cost.total).toBe(0);
+  });
+
+  it("converts zero credits to zero cost", async () => {
+    const frames = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage({ usage: 0, unit: "CREDIT" }, "meteringEvent"),
+    );
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(trackedStream()(makeModel(), makeContext(), { apiKey: "tok" }));
+    const done = events.find((event) => event.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+
+    expect(msg?.usage.cost.total).toBe(0);
+  });
+
+  it("does not carry metering from a discarded retry attempt", async () => {
+    const first = concatMessages(encodeEventMessage({ usage: 9, unit: "credit" }, "meteringEvent"));
+    const second = concatMessages(
+      encodeEventMessage({ content: "Hello" }),
+      encodeEventMessage({ usage: 2, unit: "credit" }, "meteringEvent"),
+    );
+    const response = (frames: Uint8Array) => ({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: frames })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: () => {},
+        }),
+        cancel: async () => {},
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValueOnce(response(first)).mockResolvedValueOnce(response(second));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const events = await collect(trackedStream()(makeModel(), makeContext(), { apiKey: "tok" }));
+    const done = events.find((event) => event.type === "done");
+    const msg = done?.type === "done" ? done.message : undefined;
+
+    expect(msg?.usage.cost.total).toBe(0.08);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("keeps metadataEvent token counts when a meteringEvent credit frame follows", async () => {

--- a/test/usage-tracking.test.ts
+++ b/test/usage-tracking.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_USD_PER_CREDIT,
+  estimateKiroCreditCost,
+  getPiAgentDir,
+  type KiroUsageTracking,
+  loadKiroUsageTracking,
+} from "../src/usage-tracking.js";
+
+describe("Kiro usage tracking config", () => {
+  let agentDir: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "kiro-usage-tracking-"));
+  });
+
+  afterEach(() => {
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    delete process.env.PI_CODING_AGENT_DIR;
+  });
+
+  function writeSettings(settings: unknown): void {
+    writeFileSync(join(agentDir, "settings.json"), JSON.stringify(settings));
+  }
+
+  describe("loadKiroUsageTracking", () => {
+    it("is disabled when no settings file exists", () => {
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: false });
+    });
+
+    it("is disabled when the provider section is absent", () => {
+      writeSettings({ packages: ["npm:pi-provider-kiro"] });
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: false });
+    });
+
+    it("is disabled when enabled is false", () => {
+      writeSettings({ "pi-provider-kiro": { usageTracking: { enabled: false, usdPerCredit: 1 } } });
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: false });
+    });
+
+    it("defaults to Kiro's published add-on rate when only enabled is set", () => {
+      writeSettings({ "pi-provider-kiro": { usageTracking: { enabled: true } } });
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: true, usdPerCredit: DEFAULT_USD_PER_CREDIT });
+    });
+
+    it("honors a custom rate", () => {
+      writeSettings({ "pi-provider-kiro": { usageTracking: { enabled: true, usdPerCredit: 0.025 } } });
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: true, usdPerCredit: 0.025 });
+    });
+
+    it("accepts a zero rate so credits can be tracked without implying spend", () => {
+      writeSettings({ "pi-provider-kiro": { usageTracking: { enabled: true, usdPerCredit: 0 } } });
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: true, usdPerCredit: 0 });
+    });
+
+    it.each([
+      ["a negative rate", -0.04],
+      ["a non-numeric rate", "0.04"],
+      ["a NaN rate", Number.NaN],
+      ["an infinite rate", Number.POSITIVE_INFINITY],
+    ])("fails closed on %s", (_label, usdPerCredit) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      writeSettings({ "pi-provider-kiro": { usageTracking: { enabled: true, usdPerCredit } } });
+
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: false });
+      expect(warn).toHaveBeenCalledOnce();
+    });
+
+    it("fails closed on unparseable settings without leaking the file contents", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      writeFileSync(join(agentDir, "settings.json"), '{"pi-provider-kiro": {');
+
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: false });
+      const warning = warn.mock.calls[0]?.[0] as string;
+      expect(warning).toContain("stays disabled");
+      expect(warning).not.toContain('pi-provider-kiro":');
+    });
+
+    it.each([
+      ["a non-object section", { "pi-provider-kiro": { usageTracking: true } }],
+      ["an array section", { "pi-provider-kiro": { usageTracking: [] } }],
+      ["a non-object provider entry", { "pi-provider-kiro": "enabled" }],
+      ["a truthy non-boolean enabled", { "pi-provider-kiro": { usageTracking: { enabled: "yes" } } }],
+    ])("is disabled for %s", (_label, settings) => {
+      writeSettings(settings);
+      expect(loadKiroUsageTracking(agentDir)).toEqual({ enabled: false });
+    });
+
+    it("reads the directory named by PI_CODING_AGENT_DIR", () => {
+      writeSettings({ "pi-provider-kiro": { usageTracking: { enabled: true } } });
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+
+      expect(getPiAgentDir()).toBe(agentDir);
+      expect(loadKiroUsageTracking()).toEqual({ enabled: true, usdPerCredit: DEFAULT_USD_PER_CREDIT });
+    });
+  });
+
+  describe("estimateKiroCreditCost", () => {
+    const enabled: KiroUsageTracking = { enabled: true, usdPerCredit: DEFAULT_USD_PER_CREDIT };
+
+    it("converts credits at the configured rate", () => {
+      expect(estimateKiroCreditCost(enabled, { credits: 3, unit: "credit" })).toBeCloseTo(0.12, 10);
+    });
+
+    it("accepts the plural and mixed-case unit the service also emits", () => {
+      expect(estimateKiroCreditCost(enabled, { credits: 2, unit: "Credits" })).toBeCloseTo(0.08, 10);
+    });
+
+    it("rejects a metering record that omits its unit", () => {
+      expect(estimateKiroCreditCost(enabled, { credits: 1 })).toBeUndefined();
+    });
+
+    it("converts zero credits to zero cost", () => {
+      expect(estimateKiroCreditCost(enabled, { credits: 0, unit: "credit" })).toBe(0);
+    });
+
+    it("returns undefined when tracking is disabled", () => {
+      expect(estimateKiroCreditCost({ enabled: false }, { credits: 3, unit: "credit" })).toBeUndefined();
+    });
+
+    it.each([
+      ["a token unit", { credits: 3, unit: "token" }],
+      ["a missing credit count", { unit: "credit" }],
+      ["a negative count", { credits: -1, unit: "credit" }],
+      ["a NaN count", { credits: Number.NaN, unit: "credit" }],
+      ["an infinite count", { credits: Number.POSITIVE_INFINITY, unit: "credit" }],
+    ])("returns undefined for %s", (_label, metering) => {
+      expect(estimateKiroCreditCost(enabled, metering)).toBeUndefined();
+    });
+
+    it("returns undefined when no metering event was seen", () => {
+      expect(estimateKiroCreditCost(enabled, null)).toBeUndefined();
+      expect(estimateKiroCreditCost(enabled, undefined)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add opt-in conversion of Kiro's exact per-turn credit metering to an estimated USD-equivalent usage total
- default to Kiro's published `$0.04` add-on-credit rate when tracking is enabled, with an optional override
- isolate metering by retry attempt so discarded responses do not contribute usage
- document that the value is an estimate, not an invoice or confirmed marginal charge

## Configuration

```json
{
  "pi-provider-kiro": {
    "usageTracking": {
      "enabled": true
    }
  }
}
```

`usdPerCredit` is optional and defaults to `0.04` while enabled. Tracking remains disabled by default.

## Validation

- `npm test` — 669 tests passed
- `npm run check` — passed
- `npm run build` — passed
- Biome 2.4.2 check — passed in Node 22 Alpine; the host's older glibc cannot execute the packaged native binary
- `git diff --check` — passed
- independent review — no blockers
