### PR TITLE
fix(models): keep version dots in generated catalog names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep version dots in generated display names for catalog models missing from the bootstrap list. The name was derived from the pi ID, where `toPiModelId` had already rewritten `5.1` as `5-1`, so `claude-fable-5.1` rendered as "Claude Fable 5 1"; it now reads "Claude Fable 5.1".
+
 - Resolve `ksk_` API key profiles through GetProfile instead of ListAvailableProfiles, which returns 403 Unsupported token type. Catalog queries then use that ARN in us-east-1. `KIRO_PROFILE_ARN` still wins.
 
 - Preserve canonical `developer` messages emitted by newer Pi-compatible hosts by lowering them to Kiro user input. Agent reminders and advisories previously degraded to the neutral `"Please proceed with the task."` placeholder when current, and disappeared from historical context entirely.

--- a/src/models.ts
+++ b/src/models.ts
@@ -533,7 +533,7 @@ export function mapKiroCatalogModels(catalogModels: KiroCatalogModel[], region: 
     return {
       id,
       kiroModelId,
-      name: catalogName ?? existing?.name ?? humanizeModelId(id),
+      name: catalogName ?? existing?.name ?? humanizeModelId(kiroModelId),
       api: "kiro-api",
       provider: "kiro",
       baseUrl: getKiroEndpoints(region).runtime,

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -71,6 +71,7 @@ const catalogFixture: KiroCatalogModel[] = [
     additionalModelRequestFieldsSchema: effortSchema("output_config", ["low", "medium", "high", "max"]),
   },
   { modelId: "qwen3-coder-next" },
+  { modelId: "claude-fable-5.1" },
   {
     modelId: "claude-fable-5",
     tokenLimits: { maxInputTokens: 1_000_000, maxOutputTokens: 128_000 },
@@ -180,6 +181,12 @@ describe("Feature 2: Model Definitions", () => {
       expect(mapped.find((model) => model.id === "gpt-5-6-luna")?.input).toEqual(["text", "image"]);
       expect(mapped.find((model) => model.id === "openai-gpt-5-6")?.input).toEqual(["text"]);
       expect(mapped.find((model) => model.id === "qwen3-coder-next")?.input).toEqual(["text"]);
+    });
+
+    it("keeps version dots when generating a name for a model outside the bootstrap list", () => {
+      const fable = mapped.find((model) => model.id === "claude-fable-5-1");
+      expect(fable?.kiroModelId).toBe("claude-fable-5.1");
+      expect(fable?.name).toBe("Claude Fable 5.1");
     });
 
     it("retains fresh schema and token metadata for a model also present in the bootstrap list", () => {


### PR DESCRIPTION
`mapKiroCatalogModels` humanized the pi ID, but `toPiModelId` has already rewritten `5.1` as `5-1` by then, so any catalog model outside the bootstrap list rendered as "Claude Fable 5 1" or "Gpt 5 6 Luna". 

Humanize the exact Kiro service ID instead, which still carries the dots.